### PR TITLE
Add realtime invalidation for web views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -343,8 +344,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -772,6 +775,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
@@ -3099,6 +3108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3314,6 +3335,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3433,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 
 [dependencies]
 # HTTP
-axum = { version = "0.8", features = ["json", "multipart"] }
+axum = { version = "0.8", features = ["json", "multipart", "ws"] }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors", "compression-gzip", "compression-br"] }
 # HTTP client — used by `lific doctor` to probe a running server (reachability,

--- a/src/api/activity.rs
+++ b/src/api/activity.rs
@@ -32,9 +32,9 @@ async fn require_scope_viewer(
         ActivityScope::Page(id) => {
             with_read(db, |conn| crate::db::queries::get_page(conn, id))?.project_id
         }
-        ActivityScope::Plan(id) => Some(
-            with_read(db, |conn| crate::db::queries::plans::get_plan(conn, id))?.project_id,
-        ),
+        ActivityScope::Plan(id) => {
+            Some(with_read(db, |conn| crate::db::queries::plans::get_plan(conn, id))?.project_id)
+        }
         ActivityScope::Project(id) => Some(id),
     };
     match project_id {

--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -620,6 +620,7 @@ mod api_tests {
         use axum::Extension;
         use std::sync::Arc;
         let app = crate::api::router(db, &[])
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
             .layer(Extension(crate::storage::AttachmentStore::new(
                 std::env::temp_dir().join(format!("lific_sz_{}", std::process::id())),
             )))
@@ -662,6 +663,7 @@ mod api_tests {
 
         // Lead creates an issue and uploads an attachment linked to it.
         let lead_app = with_attachment_layers(crate::api::router(db.clone(), &[]))
+            .layer(axum::Extension(crate::realtime::RealtimeHub::new()))
             .layer(axum::Extension(crate::config::AuthConfig {
                 allow_signup: true,
                 required: true,
@@ -816,6 +818,7 @@ mod api_tests {
             conn.last_insert_rowid()
         };
         let app = with_attachment_layers_store(crate::api::router(db.clone(), &[]), store.clone())
+            .layer(axum::Extension(crate::realtime::RealtimeHub::new()))
             .layer(axum::Extension(crate::config::AuthConfig {
                 allow_signup: true,
                 required: true,

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -236,9 +236,8 @@ pub(super) async fn auth_auto_login(
         ));
     }
 
-    let admin = crate::db::queries::users::first_admin(&conn)?.ok_or_else(|| {
-        LificError::BadRequest("no admin account exists to sign in as".into())
-    })?;
+    let admin = crate::db::queries::users::first_admin(&conn)?
+        .ok_or_else(|| LificError::BadRequest("no admin account exists to sign in as".into()))?;
 
     let session = crate::db::queries::users::create_session(
         &conn,
@@ -384,7 +383,9 @@ pub(super) async fn instance_settings_patch(
         web_auto_login: input.web_auto_login,
         authz_enforced: input.authz_enforced,
     };
-    let s = with_write(&db, move |conn| crate::db::queries::settings::update(conn, patch))?;
+    let s = with_write(&db, move |conn| {
+        crate::db::queries::settings::update(conn, patch)
+    })?;
     Ok(Json(settings_json(&s)))
 }
 
@@ -468,7 +469,9 @@ pub(super) async fn change_password(
             &full.password_hash,
         )?;
         if !ok {
-            return Err(LificError::BadRequest("current password is incorrect".into()));
+            return Err(LificError::BadRequest(
+                "current password is incorrect".into(),
+            ));
         }
         crate::db::queries::users::update_password(conn, user.id, &input.new_password)?;
         // Kill every existing session (including any an attacker holds), then
@@ -730,7 +733,10 @@ mod tests {
         assert!(secure.contains("SameSite=Lax"));
 
         let insecure = super::session_cookie("lific_sess_x", "2099-01-01T00:00:00Z", false);
-        assert!(!insecure.contains("Secure"), "http deploy must omit Secure: {insecure}");
+        assert!(
+            !insecure.contains("Secure"),
+            "http deploy must omit Secure: {insecure}"
+        );
         assert!(insecure.contains("HttpOnly"));
         assert!(insecure.contains("SameSite=Lax"));
     }
@@ -917,7 +923,11 @@ mod tests {
         let data = parse_json(json_get(&app, "/api/instance/settings").await).await;
         assert_eq!(data["authz_enforced"], false, "off by default");
 
-        let patch = json_patch(&app, "/api/instance/settings", serde_json::json!({ "authz_enforced": true }))
+        let patch = json_patch(
+            &app,
+            "/api/instance/settings",
+            serde_json::json!({ "authz_enforced": true }),
+        )
             .await;
         assert_eq!(patch.status(), StatusCode::OK);
         assert_eq!(parse_json(patch).await["authz_enforced"], true);
@@ -950,7 +960,11 @@ mod tests {
             StatusCode::FORBIDDEN
         );
         assert_eq!(
-            json_patch(&app, "/api/instance/settings", serde_json::json!({ "allow_signup": true }))
+            json_patch(
+                &app,
+                "/api/instance/settings",
+                serde_json::json!({ "allow_signup": true })
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN
@@ -1152,20 +1166,21 @@ mod tests {
         };
         let app = crate::api::test_helpers::app_as_user(db, &user);
 
-        let wrong =
-            serde_json::json!({ "current_password": "totally-wrong", "new_password": "newpassword123" });
+        let wrong = serde_json::json!({ "current_password": "totally-wrong", "new_password": "newpassword123" });
         let resp = json_post(&app, "/api/auth/me/password", wrong).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
-        let right =
-            serde_json::json!({ "current_password": "originalpass123", "new_password": "newpassword123" });
+        let right = serde_json::json!({ "current_password": "originalpass123", "new_password": "newpassword123" });
         let resp = json_post(&app, "/api/auth/me/password", right).await;
         assert_eq!(resp.status(), StatusCode::OK);
         // LIF-205: a successful change returns a fresh session token so the
         // current browser stays logged in after the old sessions are killed.
         let data = parse_json(resp).await;
         assert!(
-            data["token"].as_str().unwrap_or("").starts_with("lific_sess_"),
+            data["token"]
+                .as_str()
+                .unwrap_or("")
+                .starts_with("lific_sess_"),
             "password change should mint a new session token: {data}"
         );
         assert!(data["expires_at"].as_str().is_some());
@@ -1364,10 +1379,16 @@ mod tests {
         }
         // Attacker IP is now capped.
         let (_, attacker) = login_attempt(&app, "a-extra", "198.51.100.1").await;
-        assert!(is_rate_limited(&attacker), "attacker IP should be capped: {attacker}");
+        assert!(
+            is_rate_limited(&attacker),
+            "attacker IP should be capped: {attacker}"
+        );
         // A different IP is unaffected.
         let (_, other) = login_attempt(&app, "someone", "198.51.100.2").await;
-        assert!(!is_rate_limited(&other), "distinct IP should not be limited: {other}");
+        assert!(
+            !is_rate_limited(&other),
+            "distinct IP should not be limited: {other}"
+        );
     }
 
     // ── LIF-138: signup rate limiting must also key on source IP ──
@@ -1417,7 +1438,10 @@ mod tests {
         for i in 0..5 {
             let (status, body) = signup_attempt(&app, i, "203.0.113.9").await;
             assert_eq!(status, StatusCode::OK, "signup {i} should succeed: {body}");
-            assert!(!is_signup_rate_limited(&body), "signup {i} not yet limited: {body}");
+            assert!(
+                !is_signup_rate_limited(&body),
+                "signup {i} not yet limited: {body}"
+            );
         }
         // 6th: same IP, brand-new email → blocked by the IP bucket.
         let (status, body) = signup_attempt(&app, 99, "203.0.113.9").await;
@@ -1439,9 +1463,16 @@ mod tests {
         }
         // Capping IP is now blocked.
         let (_, capped) = signup_attempt(&app, 50, "198.51.100.7").await;
-        assert!(is_signup_rate_limited(&capped), "capped IP should be blocked: {capped}");
+        assert!(
+            is_signup_rate_limited(&capped),
+            "capped IP should be blocked: {capped}"
+        );
         // A different IP is unaffected.
         let (status, other) = signup_attempt(&app, 60, "198.51.100.8").await;
-        assert_eq!(status, StatusCode::OK, "distinct IP should not be limited: {other}");
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "distinct IP should not be limited: {other}"
+        );
     }
 }

--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -7,6 +7,7 @@ use crate::authz;
 use crate::db::queries::comments::{self, CommentParent};
 use crate::db::{DbPool, models::*};
 use crate::error::LificError;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 use super::{with_read, with_write};
 
@@ -28,7 +29,12 @@ fn create_comment_with_mentions(
         let comment = comments::create_comment(conn, parent, user_id, content)?;
         comments::sync_mentions(conn, comment.id, &comment.content, &candidates)?;
         // LIF-262: link attachments referenced in the comment body.
-        super::attachments::sync_links(conn, AttachmentEntity::Comment, comment.id, &comment.content)?;
+        super::attachments::sync_links(
+            conn,
+            AttachmentEntity::Comment,
+            comment.id,
+            &comment.content,
+        )?;
         Ok(comment)
     })
 }
@@ -53,36 +59,43 @@ pub(super) async fn list_comments(
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(issue_id): Path<i64>,
 ) -> Result<Json<Vec<Comment>>, LificError> {
-    let project_id = with_read(&db, |conn| crate::db::queries::get_issue(conn, issue_id))?
-        .project_id;
+    let project_id =
+        with_read(&db, |conn| crate::db::queries::get_issue(conn, issue_id))?.project_id;
     require_comment_viewer(&db, &auth_user, Some(project_id))?;
     with_read(&db, |conn| {
-        crate::db::queries::comments::list_comments(conn, CommentParent::Issue(issue_id), None, None)
+        crate::db::queries::comments::list_comments(
+            conn,
+            CommentParent::Issue(issue_id),
+            None,
+            None,
+        )
     })
     .map(Json)
 }
 
 pub(super) async fn create_comment(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(issue_id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<CreateComment>,
 ) -> Result<Json<Comment>, LificError> {
-    let project_id = with_read(&db, |conn| crate::db::queries::get_issue(conn, issue_id))?
-        .project_id;
+    let project_id =
+        with_read(&db, |conn| crate::db::queries::get_issue(conn, issue_id))?.project_id;
     require_comment_viewer(&db, &auth_user, Some(project_id))?;
 
     let user = auth_user
         .ok_or_else(|| LificError::BadRequest("authentication required to comment".into()))?;
 
-    create_comment_with_mentions(
+    let comment = create_comment_with_mentions(
         &db,
         CommentParent::Issue(issue_id),
         Some(project_id),
         user.id,
         &input.content,
-    )
-    .map(Json)
+    )?;
+    realtime.send(issue_updated_event(project_id, issue_id));
+    Ok(Json(comment))
 }
 
 pub(super) async fn list_page_comments(
@@ -90,8 +103,7 @@ pub(super) async fn list_page_comments(
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(page_id): Path<i64>,
 ) -> Result<Json<Vec<Comment>>, LificError> {
-    let project_id = with_read(&db, |conn| crate::db::queries::get_page(conn, page_id))?
-        .project_id;
+    let project_id = with_read(&db, |conn| crate::db::queries::get_page(conn, page_id))?.project_id;
     require_comment_viewer(&db, &auth_user, project_id)?;
     with_read(&db, |conn| {
         crate::db::queries::comments::list_comments(conn, CommentParent::Page(page_id), None, None)
@@ -101,25 +113,28 @@ pub(super) async fn list_page_comments(
 
 pub(super) async fn create_page_comment(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(page_id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<CreateComment>,
 ) -> Result<Json<Comment>, LificError> {
-    let project_id = with_read(&db, |conn| crate::db::queries::get_page(conn, page_id))?
-        .project_id;
+    let project_id = with_read(&db, |conn| crate::db::queries::get_page(conn, page_id))?.project_id;
     require_comment_viewer(&db, &auth_user, project_id)?;
 
     let user = auth_user
         .ok_or_else(|| LificError::BadRequest("authentication required to comment".into()))?;
 
-    create_comment_with_mentions(
+    let comment = create_comment_with_mentions(
         &db,
         CommentParent::Page(page_id),
         project_id,
         user.id,
         &input.content,
-    )
-    .map(Json)
+    )?;
+    if let Some(project_id) = project_id {
+        realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    }
+    Ok(Json(comment))
 }
 
 /// GET /api/projects/{id}/mention-candidates — the users who may be
@@ -142,6 +157,7 @@ pub(super) async fn mention_candidates(
 
 pub(super) async fn update_comment_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<UpdateComment>,
@@ -165,15 +181,29 @@ pub(super) async fn update_comment_handler(
     let project_id = with_read(&db, |conn| resolve_comment_project(conn, &existing))?;
     let member_scoped = authz::authz_enforced(&db)?;
 
-    with_write(&db, |conn| {
+    let comment = with_write(&db, |conn| {
         let candidates = comments::mention_candidates(conn, project_id, member_scoped)?;
         let comment = comments::update_comment(conn, id, &input.content)?;
         comments::sync_mentions(conn, comment.id, &comment.content, &candidates)?;
         // LIF-262: re-scan the edited comment and reconcile links.
-        super::attachments::sync_links(conn, AttachmentEntity::Comment, comment.id, &comment.content)?;
+        super::attachments::sync_links(
+            conn,
+            AttachmentEntity::Comment,
+            comment.id,
+            &comment.content,
+        )?;
         Ok(comment)
-    })
-    .map(Json)
+    })?;
+    match (comment.issue_id, project_id) {
+        (Some(issue_id), Some(project_id)) => {
+            realtime.send(issue_updated_event(project_id, issue_id));
+        }
+        (None, Some(project_id)) if comment.page_id.is_some() => {
+            realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+        }
+        _ => {}
+    }
+    Ok(Json(comment))
 }
 
 /// Resolve the project a comment belongs to, via its issue or page parent.
@@ -182,7 +212,9 @@ fn resolve_comment_project(
     comment: &Comment,
 ) -> Result<Option<i64>, LificError> {
     if let Some(issue_id) = comment.issue_id {
-        Ok(Some(crate::db::queries::get_issue(conn, issue_id)?.project_id))
+        Ok(Some(
+            crate::db::queries::get_issue(conn, issue_id)?.project_id,
+        ))
     } else if let Some(page_id) = comment.page_id {
         Ok(crate::db::queries::get_page(conn, page_id)?.project_id)
     } else {
@@ -192,6 +224,7 @@ fn resolve_comment_project(
 
 pub(super) async fn delete_comment_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
 ) -> Result<Json<serde_json::Value>, LificError> {
@@ -207,10 +240,27 @@ pub(super) async fn delete_comment_handler(
         ));
     }
 
+    let project_id = with_read(&db, |conn| resolve_comment_project(conn, &existing))?;
     with_write(&db, |conn| {
         crate::db::queries::comments::delete_comment(conn, id)
     })?;
+    match (existing.issue_id, project_id) {
+        (Some(issue_id), Some(project_id)) => {
+            realtime.send(issue_updated_event(project_id, issue_id));
+        }
+        (None, Some(project_id)) if existing.page_id.is_some() => {
+            realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+        }
+        _ => {}
+    }
     Ok(Json(serde_json::json!({"deleted": true})))
+}
+
+fn issue_updated_event(project_id: i64, issue_id: i64) -> RealtimeEvent {
+    RealtimeEvent::IssueUpdated {
+        project_id,
+        issue_id,
+    }
 }
 
 #[cfg(test)]
@@ -272,7 +322,12 @@ mod tests {
         drop(conn);
 
         let app = crate::api::router(db, &[])
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: user.id,
                 username: user.username.clone(),
@@ -440,7 +495,12 @@ mod tests {
 
         // Build app as "other" (non-owner, non-admin)
         let app = crate::api::router(db, &[])
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: other.id,
                 username: other.username,
@@ -550,7 +610,12 @@ mod tests {
 
         // Build app as admin
         let app = crate::api::router(db, &[])
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: admin.id,
                 username: admin.username,
@@ -625,7 +690,12 @@ mod tests {
         };
 
         let app = crate::api::router(db, &[])
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: user.id,
                 username: user.username.clone(),
@@ -776,7 +846,12 @@ mod tests {
         };
 
         let app = crate::api::router(db, &[])
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: other.id,
                 username: other.username,
@@ -865,7 +940,12 @@ mod tests {
         };
 
         let app = crate::api::router(db, &[])
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: admin.id,
                 username: admin.username,
@@ -975,12 +1055,18 @@ mod tests {
 
         // The project activity feed carries a "mention" row for ada.
         let feed = parse_json(
-            json_get(&app, &format!("/api/projects/{project_id}/activity?limit=100")).await,
+            json_get(
+                &app,
+                &format!("/api/projects/{project_id}/activity?limit=100"),
+            )
+            .await,
         )
         .await;
         let items = feed["items"].as_array().unwrap();
         assert!(
-            items.iter().any(|a| a["action"] == "mention" && a["new_value"] == "ada"),
+            items
+                .iter()
+                .any(|a| a["action"] == "mention" && a["new_value"] == "ada"),
             "expected a mention activity row: {items:#?}"
         );
     }
@@ -1132,7 +1218,11 @@ mod tests {
 
         // Candidates: the non_member (not a project member) must be absent;
         // the viewer/maintainer/lead members present.
-        let resp = json_get(&lead_app, &format!("/api/projects/{project_id}/mention-candidates")).await;
+        let resp = json_get(
+            &lead_app,
+            &format!("/api/projects/{project_id}/mention-candidates"),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let cands = parse_json(resp).await;
         let arr = cands.as_array().unwrap();
@@ -1155,11 +1245,16 @@ mod tests {
         let comment_id = parse_json(resp).await["id"].as_i64().unwrap();
 
         let resolved = mention_ids(&db, comment_id);
-        assert!(!resolved.contains(&non_member.id), "non-member must not resolve");
+        assert!(
+            !resolved.contains(&non_member.id),
+            "non-member must not resolve"
+        );
         // viewer resolves.
         let viewer_id = {
             let conn = db.read().unwrap();
-            crate::db::queries::users::get_user_by_username(&conn, "viewer").unwrap().id
+            crate::db::queries::users::get_user_by_username(&conn, "viewer")
+                .unwrap()
+                .id
         };
         assert_eq!(resolved, vec![viewer_id]);
     }
@@ -1227,7 +1322,12 @@ mod tests {
         };
 
         let app = crate::api::router(db, &[])
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: user.id,
                 username: user.username,

--- a/src/api/export.rs
+++ b/src/api/export.rs
@@ -1,11 +1,11 @@
+use axum::Extension;
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::IntoResponse;
-use axum::Extension;
 
 use crate::authz;
-use crate::db::models::{AuthUser, Role};
 use crate::db::DbPool;
+use crate::db::models::{AuthUser, Role};
 use crate::error::LificError;
 
 use super::with_read;
@@ -36,10 +36,18 @@ pub(super) async fn export_issue(
         .into_iter()
         .next()
         .ok_or_else(|| LificError::Internal("issue export produced no files".into()))?;
-    let filename = file.path.rsplit('/').next().unwrap_or("issue.md").to_string();
+    let filename = file
+        .path
+        .rsplit('/')
+        .next()
+        .unwrap_or("issue.md")
+        .to_string();
 
     let mut headers = HeaderMap::new();
-    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("text/markdown; charset=utf-8"));
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/markdown; charset=utf-8"),
+    );
     headers.insert(header::CONTENT_DISPOSITION, content_disposition(&filename)?);
     Ok((headers, file.content))
 }
@@ -63,10 +71,18 @@ pub(super) async fn export_page(
         .into_iter()
         .next()
         .ok_or_else(|| LificError::Internal("page export produced no files".into()))?;
-    let filename = file.path.rsplit('/').next().unwrap_or("page.md").to_string();
+    let filename = file
+        .path
+        .rsplit('/')
+        .next()
+        .unwrap_or("page.md")
+        .to_string();
 
     let mut headers = HeaderMap::new();
-    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("text/markdown; charset=utf-8"));
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/markdown; charset=utf-8"),
+    );
     headers.insert(header::CONTENT_DISPOSITION, content_disposition(&filename)?);
     Ok((headers, file.content))
 }
@@ -77,8 +93,9 @@ pub(super) async fn export_project(
     Path(identifier): Path<String>,
     Query(q): Query<ProjectExportQuery>,
 ) -> Result<impl IntoResponse, LificError> {
-    let project_id =
-        with_read(&db, |conn| crate::db::queries::resolve_project_identifier(conn, &identifier))?;
+    let project_id = with_read(&db, |conn| {
+        crate::db::queries::resolve_project_identifier(conn, &identifier)
+    })?;
     authz::require_role(&db, &auth_user, project_id, Role::Viewer)?;
     let format = q.format.as_deref().unwrap_or("zip");
     let bundle = with_read(&db, |conn| crate::export::export_project(conn, &identifier))?;
@@ -89,7 +106,10 @@ pub(super) async fn export_project(
             let filename = format!("{}-export.zip", bundle.root.to_ascii_lowercase());
             let bytes = crate::export::bundle_to_zip(&bundle)?;
             let mut headers = HeaderMap::new();
-            headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/zip"));
+            headers.insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/zip"),
+            );
             headers.insert(header::CONTENT_DISPOSITION, content_disposition(&filename)?);
             Ok((headers, bytes).into_response())
         }
@@ -129,7 +149,10 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/export/issues/{}", created["identifier"].as_str().unwrap()))
+                    .uri(format!(
+                        "/api/export/issues/{}",
+                        created["identifier"].as_str().unwrap()
+                    ))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
@@ -164,13 +187,19 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/export/projects/{}", project["identifier"].as_str().unwrap()))
+                    .uri(format!(
+                        "/api/export/projects/{}",
+                        project["identifier"].as_str().unwrap()
+                    ))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(resp.headers()[axum::http::header::CONTENT_TYPE], "application/zip");
+        assert_eq!(
+            resp.headers()[axum::http::header::CONTENT_TYPE],
+            "application/zip"
+        );
     }
 }

--- a/src/api/insights.rs
+++ b/src/api/insights.rs
@@ -10,7 +10,10 @@ use axum::{
 
 use crate::authz;
 use crate::db::queries::insights::{clamp_weeks, get_insights};
-use crate::db::{DbPool, models::{AuthUser, InsightsPayload, Role}};
+use crate::db::{
+    DbPool,
+    models::{AuthUser, InsightsPayload, Role},
+};
 use crate::error::LificError;
 
 use super::with_read;
@@ -67,7 +70,11 @@ mod tests {
         )
         .await;
 
-        let resp = json_get(&app, &format!("/api/projects/{project_id}/insights?weeks=6")).await;
+        let resp = json_get(
+            &app,
+            &format!("/api/projects/{project_id}/insights?weeks=6"),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = parse_json(resp).await;
 
@@ -98,7 +105,11 @@ mod tests {
         assert_eq!(body["weeks"], 12);
         assert_eq!(body["created_per_week"].as_array().unwrap().len(), 12);
 
-        let resp = json_get(&app, &format!("/api/projects/{project_id}/insights?weeks=999")).await;
+        let resp = json_get(
+            &app,
+            &format!("/api/projects/{project_id}/insights?weeks=999"),
+        )
+        .await;
         let body = parse_json(resp).await;
         assert_eq!(body["weeks"], 52);
     }
@@ -126,7 +137,12 @@ mod authz_gating_tests {
 
         let non_member_app = app_as_user(db.clone(), &non_member);
         assert_eq!(
-            json_get(&non_member_app, &format!("/api/projects/{project_id}/insights")).await.status(),
+            json_get(
+                &non_member_app,
+                &format!("/api/projects/{project_id}/insights")
+            )
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -6,6 +6,7 @@ use axum::{
 use crate::authz;
 use crate::db::{DbPool, models::*};
 use crate::error::LificError;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 use super::{filter_visible, with_read, with_write};
 
@@ -21,7 +22,9 @@ pub(super) async fn list_issues(
     // Cross-project list: filter instead of denying (LIF-197 scope item 2).
     let visible = authz::visible_project_ids(&db, &auth_user)?;
     let issues = with_read(&db, |conn| crate::db::queries::list_issues(conn, &q))?;
-    Ok(Json(filter_visible(issues, &visible, |i| Some(i.project_id))))
+    Ok(Json(filter_visible(issues, &visible, |i| {
+        Some(i.project_id)
+    })))
 }
 
 pub(super) async fn get_issue(
@@ -49,6 +52,7 @@ pub(super) async fn resolve_issue(
 
 pub(super) async fn create_issue(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<CreateIssue>,
 ) -> Result<Json<Issue>, LificError> {
@@ -64,11 +68,16 @@ pub(super) async fn create_issue(
         )?;
         Ok(issue)
     })?;
+    realtime.send(RealtimeEvent::IssueCreated {
+        project_id: issue.project_id,
+        issue_id: issue.id,
+    });
     Ok(Json(issue))
 }
 
 pub(super) async fn update_issue(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(id): Path<i64>,
     Json(input): Json<UpdateIssue>,
@@ -86,17 +95,30 @@ pub(super) async fn update_issue(
         )?;
         Ok(issue)
     })?;
+    realtime.send(RealtimeEvent::IssueUpdated {
+        project_id: issue.project_id,
+        issue_id: issue.id,
+    });
     Ok(Json(issue))
 }
 
 pub(super) async fn delete_issue_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(id): Path<i64>,
 ) -> Result<Json<serde_json::Value>, LificError> {
     let project_id = with_read(&db, |conn| crate::db::queries::get_issue(conn, id))?.project_id;
     authz::require_role(&db, &auth_user, project_id, Role::Maintainer)?;
-    with_write(&db, |conn| crate::db::queries::delete_issue(conn, id))?;
+    let issue = with_write(&db, |conn| {
+        let issue = crate::db::queries::get_issue(conn, id)?;
+        crate::db::queries::delete_issue(conn, id)?;
+        Ok(issue)
+    })?;
+    realtime.send(RealtimeEvent::IssueDeleted {
+        project_id: issue.project_id,
+        issue_id: issue.id,
+    });
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
@@ -115,49 +137,65 @@ pub(super) struct UnlinkRequest {
 
 pub(super) async fn link_issues(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<LinkRequest>,
 ) -> Result<Json<serde_json::Value>, LificError> {
-    let (source_id, target_id) = with_read(&db, |conn| {
+    let (source, target) = with_read(&db, |conn| {
         let source_id = crate::db::queries::resolve_identifier(conn, &input.source)?;
         let target_id = crate::db::queries::resolve_identifier(conn, &input.target)?;
-        Ok((source_id, target_id))
+        Ok((
+            crate::db::queries::get_issue(conn, source_id)?,
+            crate::db::queries::get_issue(conn, target_id)?,
+        ))
     })?;
     // Cross-project relation: the caller must be a Maintainer on BOTH sides
     // (LIF-197 scope item 3), even when source and target share a project.
-    let source_project = with_read(&db, |conn| crate::db::queries::get_issue(conn, source_id))?
-        .project_id;
-    let target_project = with_read(&db, |conn| crate::db::queries::get_issue(conn, target_id))?
-        .project_id;
-    authz::require_role(&db, &auth_user, source_project, Role::Maintainer)?;
-    authz::require_role(&db, &auth_user, target_project, Role::Maintainer)?;
+    authz::require_role(&db, &auth_user, source.project_id, Role::Maintainer)?;
+    authz::require_role(&db, &auth_user, target.project_id, Role::Maintainer)?;
 
     with_write(&db, |conn| {
-        crate::db::queries::link_issues(conn, source_id, target_id, &input.relation_type)
+        crate::db::queries::link_issues(conn, source.id, target.id, &input.relation_type)
     })?;
+    realtime.send(RealtimeEvent::IssueLinked {
+        project_id: source.project_id,
+        issue_id: source.id,
+    });
+    realtime.send(RealtimeEvent::IssueLinked {
+        project_id: target.project_id,
+        issue_id: target.id,
+    });
     Ok(Json(serde_json::json!({"linked": true})))
 }
 
 pub(super) async fn unlink_issues(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<UnlinkRequest>,
 ) -> Result<Json<serde_json::Value>, LificError> {
-    let (source_id, target_id) = with_read(&db, |conn| {
+    let (source, target) = with_read(&db, |conn| {
         let source_id = crate::db::queries::resolve_identifier(conn, &input.source)?;
         let target_id = crate::db::queries::resolve_identifier(conn, &input.target)?;
-        Ok((source_id, target_id))
+        Ok((
+            crate::db::queries::get_issue(conn, source_id)?,
+            crate::db::queries::get_issue(conn, target_id)?,
+        ))
     })?;
-    let source_project = with_read(&db, |conn| crate::db::queries::get_issue(conn, source_id))?
-        .project_id;
-    let target_project = with_read(&db, |conn| crate::db::queries::get_issue(conn, target_id))?
-        .project_id;
-    authz::require_role(&db, &auth_user, source_project, Role::Maintainer)?;
-    authz::require_role(&db, &auth_user, target_project, Role::Maintainer)?;
+    authz::require_role(&db, &auth_user, source.project_id, Role::Maintainer)?;
+    authz::require_role(&db, &auth_user, target.project_id, Role::Maintainer)?;
 
     with_write(&db, |conn| {
-        crate::db::queries::unlink_issues(conn, source_id, target_id)
+        crate::db::queries::unlink_issues(conn, source.id, target.id)
     })?;
+    realtime.send(RealtimeEvent::IssueUnlinked {
+        project_id: source.project_id,
+        issue_id: source.id,
+    });
+    realtime.send(RealtimeEvent::IssueUnlinked {
+        project_id: target.project_id,
+        issue_id: target.id,
+    });
     Ok(Json(serde_json::json!({"unlinked": true})))
 }
 
@@ -167,6 +205,31 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn issue_create_emits_realtime_event() {
+        let test = test_app_with_realtime();
+        let (project_id, _) = seed_project(&test.app).await;
+        let mut events = test.realtime.subscribe();
+        let body = serde_json::json!({
+            "project_id": project_id,
+            "title": "Fresh event",
+        });
+
+        let resp = json_post(&test.app, "/api/issues", body).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let axum::extract::ws::Message::Text(text) = event.message else {
+            panic!("expected text realtime event");
+        };
+        let event: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(event["type"], "issue.created");
+        assert_eq!(event["project_id"], project_id);
+    }
 
     #[tokio::test]
     async fn issue_crud_lifecycle() {

--- a/src/api/members.rs
+++ b/src/api/members.rs
@@ -30,6 +30,7 @@ use crate::authz;
 use crate::db::queries::members;
 use crate::db::{DbPool, models::*};
 use crate::error::LificError;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 use super::{with_read, with_write};
 
@@ -41,7 +42,10 @@ pub(super) async fn list_project_members(
     Path(project_id): Path<i64>,
 ) -> Result<Json<Vec<MemberWithUser>>, LificError> {
     authz::require_role(&db, &auth_user, project_id, Role::Viewer)?;
-    with_read(&db, |conn| members::list_members_with_users(conn, project_id)).map(Json)
+    with_read(&db, |conn| {
+        members::list_members_with_users(conn, project_id)
+    })
+    .map(Json)
 }
 
 /// GET /api/projects/{id}/my-role — the caller's own effective role on this
@@ -94,16 +98,18 @@ pub(super) async fn my_project_role(
 /// if `user_id` doesn't resolve to a real user.
 pub(super) async fn add_project_member(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(project_id): Path<i64>,
     Json(input): Json<AddMember>,
 ) -> Result<Json<ProjectMember>, LificError> {
     authz::require_role(&db, &auth_user, project_id, Role::Lead)?;
     let role = input.role.as_deref().unwrap_or("viewer").to_string();
-    with_write(&db, |conn| {
+    let member = with_write(&db, |conn| {
         members::add_member(conn, project_id, input.user_id, &role)
-    })
-    .map(Json)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    Ok(Json(member))
 }
 
 /// PATCH /api/projects/{id}/members/{user_id} — change an existing
@@ -111,21 +117,24 @@ pub(super) async fn add_project_member(
 /// the project's sole `lead`.
 pub(super) async fn update_project_member(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path((project_id, user_id)): Path<(i64, i64)>,
     Json(input): Json<ChangeMemberRole>,
 ) -> Result<Json<ProjectMember>, LificError> {
     authz::require_role(&db, &auth_user, project_id, Role::Lead)?;
-    with_write(&db, |conn| {
+    let member = with_write(&db, |conn| {
         members::change_role(conn, project_id, user_id, &input.role)
-    })
-    .map(Json)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    Ok(Json(member))
 }
 
 /// DELETE /api/projects/{id}/members/{user_id} — remove a member. 404 if
 /// they aren't a member; 409 if they're the project's sole `lead`.
 pub(super) async fn remove_project_member(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path((project_id, user_id)): Path<(i64, i64)>,
 ) -> Result<Json<serde_json::Value>, LificError> {
@@ -133,6 +142,7 @@ pub(super) async fn remove_project_member(
     with_write(&db, |conn| {
         members::remove_member_guarded(conn, project_id, user_id)
     })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
@@ -181,7 +191,9 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
 
         // Confirm gone: listing no longer includes them.
-        let list = parse_json(json_get(&lead_app, &format!("/api/projects/{project_id}/members")).await).await;
+        let list =
+            parse_json(json_get(&lead_app, &format!("/api/projects/{project_id}/members")).await)
+                .await;
         assert!(
             list.as_array()
                 .unwrap()
@@ -296,7 +308,12 @@ mod tests {
 
         let non_member_app = app_as_user(db, &non_member);
         assert_eq!(
-            json_get(&non_member_app, &format!("/api/projects/{project_id}/members")).await.status(),
+            json_get(
+                &non_member_app,
+                &format!("/api/projects/{project_id}/members")
+            )
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
     }
@@ -318,7 +335,11 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::CONFLICT);
 
-        let resp = json_delete(&lead_app, &format!("/api/projects/{project_id}/members/{}", lead.id)).await;
+        let resp = json_delete(
+            &lead_app,
+            &format!("/api/projects/{project_id}/members/{}", lead.id),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::CONFLICT);
 
         // Promote a second lead, then the original can be demoted/removed.
@@ -336,7 +357,11 @@ mod tests {
             serde_json::json!({ "role": "maintainer" }),
         )
         .await;
-        assert_eq!(resp.status(), StatusCode::OK, "demotion allowed once a second lead exists");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "demotion allowed once a second lead exists"
+        );
     }
 
     // ── POST duplicate / unknown user / bad role ──────────────────
@@ -464,7 +489,11 @@ mod tests {
         .await;
 
         let feed = parse_json(
-            json_get(&lead_app, &format!("/api/projects/{project_id}/activity?limit=100")).await,
+            json_get(
+                &lead_app,
+                &format!("/api/projects/{project_id}/activity?limit=100"),
+            )
+            .await,
         )
         .await;
         let items = feed["items"].as_array().unwrap();
@@ -478,7 +507,9 @@ mod tests {
             .collect();
 
         assert!(
-            member_rows.iter().any(|a| a["action"] == "create" && a["new_value"] == "viewer"),
+            member_rows
+                .iter()
+                .any(|a| a["action"] == "create" && a["new_value"] == "viewer"),
             "expected a member create row: {member_rows:#?}"
         );
         assert!(
@@ -489,7 +520,9 @@ mod tests {
             "expected a member role-change row: {member_rows:#?}"
         );
         assert!(
-            member_rows.iter().any(|a| a["action"] == "delete" && a["old_value"] == "maintainer"),
+            member_rows
+                .iter()
+                .any(|a| a["action"] == "delete" && a["old_value"] == "maintainer"),
             "expected a member delete row: {member_rows:#?}"
         );
         assert!(
@@ -505,7 +538,11 @@ mod tests {
         let (db, _admin, lead, maintainer, viewer, _non_member, project_id) =
             setup_membership_test();
 
-        for (user, expected) in [(&lead, "lead"), (&maintainer, "maintainer"), (&viewer, "viewer")] {
+        for (user, expected) in [
+            (&lead, "lead"),
+            (&maintainer, "maintainer"),
+            (&viewer, "viewer"),
+        ] {
             let app = app_as_user(db.clone(), user);
             let resp = json_get(&app, &format!("/api/projects/{project_id}/my-role")).await;
             assert_eq!(resp.status(), StatusCode::OK, "{} my-role", user.username);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -14,7 +14,9 @@ mod views;
 
 use axum::{
     Router,
-    extract::{DefaultBodyLimit, Json, Query, State},
+    extract::{DefaultBodyLimit, Extension, Json, Query, State, ws::WebSocketUpgrade},
+    http::{HeaderMap, header},
+    response::IntoResponse,
     routing::{delete, get, patch, post, put},
 };
 use tower_http::cors::{self, CorsLayer};
@@ -38,10 +40,8 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
     let cors = if cors_origins.is_empty() {
         CorsLayer::new().allow_origin(cors::Any)
     } else {
-        let origins: Vec<axum::http::HeaderValue> = cors_origins
-            .iter()
-            .filter_map(|o| o.parse().ok())
-            .collect();
+        let origins: Vec<axum::http::HeaderValue> =
+            cors_origins.iter().filter_map(|o| o.parse().ok()).collect();
         CorsLayer::new().allow_origin(origins)
     };
 
@@ -120,10 +120,7 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
             get(issues::resolve_issue),
         )
         // Activity (audit log read surface — LIF-156)
-        .route(
-            "/api/issues/{id}/activity",
-            get(activity::issue_activity),
-        )
+        .route("/api/issues/{id}/activity", get(activity::issue_activity))
         .route("/api/pages/{id}/activity", get(activity::page_activity))
         .route(
             "/api/projects/{id}/activity",
@@ -140,7 +137,10 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
         )
         .route("/api/export/issues/{identifier}", get(export::export_issue))
         .route("/api/export/pages/{identifier}", get(export::export_page))
-        .route("/api/export/projects/{identifier}", get(export::export_project))
+        .route(
+            "/api/export/projects/{identifier}",
+            get(export::export_project),
+        )
         // Issue relations
         .route("/api/issues/link", post(issues::link_issues))
         .route("/api/issues/unlink", post(issues::unlink_issues))
@@ -208,6 +208,7 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
         )
         // Users (for dropdowns)
         .route("/api/users", get(auth::list_users))
+        .route("/api/events/ws", get(events_ws))
         // Search
         .route("/api/search", get(search))
         // Board view
@@ -225,10 +226,7 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
         // The caller's own effective role on a project (LIF-234) — Viewer-gated,
         // so any member can learn their role to drive role-aware UI affordances
         // without reading the full roster or the admin-only instance settings.
-        .route(
-            "/api/projects/{id}/my-role",
-            get(members::my_project_role),
-        )
+        .route("/api/projects/{id}/my-role", get(members::my_project_role))
         // @mention autocomplete candidates (LIF-263) — Viewer-gated,
         // member-scoped when authz enforcement is on.
         .route(
@@ -268,8 +266,7 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
         )
         .route(
             "/api/attachments/{id}",
-            get(attachments::download_attachment)
-                .delete(attachments::delete_attachment),
+            get(attachments::download_attachment).delete(attachments::delete_attachment),
         )
         // Health
         .route("/api/health", get(health))
@@ -277,6 +274,7 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
             cors.allow_methods([
                     axum::http::Method::GET,
                     axum::http::Method::POST,
+                axum::http::Method::PATCH,
                     axum::http::Method::PUT,
                     axum::http::Method::DELETE,
                 ])
@@ -286,6 +284,135 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
                 ]),
         )
         .with_state(db)
+        .layer(Extension(cors_origins.to_vec()))
+}
+
+async fn events_ws(
+    State(db): State<DbPool>,
+    Extension(realtime): Extension<crate::realtime::RealtimeHub>,
+    Extension(allowed_origins): Extension<Vec<String>>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Result<impl IntoResponse, LificError> {
+    let session_token = validate_websocket_request(&db, &headers, &allowed_origins)?;
+    Ok(ws.on_upgrade(move |socket| {
+        crate::realtime::serve_socket(socket, realtime, db, session_token)
+    }))
+}
+
+fn validate_websocket_request(
+    db: &DbPool,
+    headers: &HeaderMap,
+    allowed_origins: &[String],
+) -> Result<String, LificError> {
+    match (
+        websocket_origin_allowed(headers, allowed_origins),
+        websocket_session_token(headers),
+    ) {
+        (false, _) => Err(LificError::Forbidden("websocket origin not allowed".into())),
+        (true, None) => Err(LificError::Forbidden("authentication required".into())),
+        (true, Some(token)) => with_read(db, |conn| {
+            match crate::db::queries::users::validate_session(conn, token) {
+                Ok(_) => Ok(token.to_string()),
+                Err(LificError::BadRequest(message))
+                    if message == crate::db::queries::users::INVALID_SESSION_MESSAGE =>
+                {
+                    Err(LificError::Forbidden(
+                        crate::db::queries::users::INVALID_SESSION_MESSAGE.into(),
+                    ))
+                }
+                Err(error) => Err(error),
+            }
+        }),
+    }
+}
+
+fn websocket_origin_allowed(headers: &HeaderMap, allowed_origins: &[String]) -> bool {
+    match headers.get(header::ORIGIN).map(|value| value.to_str()) {
+        None => true,
+        Some(Ok(origin)) => {
+            allowed_origins.iter().any(|allowed| allowed == origin)
+                || headers
+                .get(header::HOST)
+                    .and_then(|value| value.to_str().ok())
+                    .is_some_and(|host| {
+                        websocket_same_origin(origin, host, websocket_request_scheme(headers))
+                    })
+        }
+        Some(Err(_)) => false,
+    }
+}
+
+fn websocket_request_scheme(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(',').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            headers
+                .get("forwarded")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| {
+                    value.split(';').find_map(|part| {
+                        part.trim()
+                            .strip_prefix("proto=")
+                            .map(str::trim)
+                            .filter(|proto| !proto.is_empty())
+                    })
+                })
+        })
+}
+
+fn websocket_same_origin(origin: &str, host: &str, request_scheme: Option<&str>) -> bool {
+    let Some(request_scheme) = request_scheme else {
+        return false;
+    };
+    let origin = origin.parse::<axum::http::Uri>().ok();
+    let host = host.parse::<axum::http::uri::Authority>().ok();
+
+    match (
+        origin.as_ref().and_then(axum::http::Uri::scheme_str),
+        origin.as_ref().and_then(axum::http::Uri::authority),
+        host.as_ref(),
+    ) {
+        (Some(scheme), Some(origin_authority), Some(host_authority))
+            if scheme.eq_ignore_ascii_case(request_scheme) =>
+        {
+            websocket_default_port(scheme).is_some_and(|default_port| {
+                let origin_port = origin_authority.port_u16().unwrap_or(default_port);
+                let host_port = host_authority.port_u16().unwrap_or(default_port);
+                origin_authority
+                    .host()
+                    .eq_ignore_ascii_case(host_authority.host())
+                    && origin_port == host_port
+            })
+        }
+        _ => false,
+    }
+}
+
+fn websocket_default_port(scheme: &str) -> Option<u16> {
+    match scheme {
+        "http" => Some(80),
+        "https" => Some(443),
+        _ => None,
+    }
+}
+
+fn websocket_session_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(header::COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|cookie| {
+            cookie.split(';').find_map(|part| {
+                part.trim()
+                    .strip_prefix("lific_token=")
+                    .map(str::trim)
+                    .filter(|token| token.starts_with("lific_sess_"))
+            })
+        })
 }
 
 // ── Shared helpers ───────────────────────────────────────────
@@ -429,6 +556,11 @@ pub(crate) mod test_helpers {
     use crate::db::DbPool;
     use crate::db::models::*;
 
+    pub struct RealtimeTestApp {
+        pub app: Router,
+        pub realtime: crate::realtime::RealtimeHub,
+    }
+
     /// A unique tempdir-backed attachment store for a test app, plus the
     /// config + rate-limiter extensions the attachment routes need. Layered
     /// onto every test app so the attachment endpoints work in tests without a
@@ -463,6 +595,10 @@ pub(crate) mod test_helpers {
     }
 
     pub fn test_app() -> Router {
+        test_app_with_realtime().app
+    }
+
+    pub fn test_app_with_realtime() -> RealtimeTestApp {
         let db = crate::db::open_memory().expect("test db");
         // Insert a real admin row so FK constraints (e.g. projects.lead_user_id
         // now defaults to the creator — see LIF-102) pass. Direct SQL skips
@@ -477,14 +613,21 @@ pub(crate) mod test_helpers {
             .expect("seed test admin");
             conn.last_insert_rowid()
         };
-        with_attachment_layers(super::router(db, &[]))
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+        let realtime = crate::realtime::RealtimeHub::new();
+        let app = with_attachment_layers(super::router(db, &[]))
+            .layer(Extension(realtime.clone()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: admin_id,
                 username: "test-admin".into(),
                 display_name: "Test Admin".into(),
                 is_admin: true,
-            })))
+            })));
+        RealtimeTestApp { app, realtime }
     }
 
     /// Seed a project and return its id.
@@ -600,7 +743,12 @@ pub(crate) mod test_helpers {
     /// Build a test app authenticated as a specific user.
     pub fn app_as_user(db: DbPool, user: &User) -> Router {
         with_attachment_layers(super::router(db, &[]))
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: user.id,
                 username: user.username.clone(),
@@ -720,7 +868,12 @@ pub(crate) mod test_helpers {
         )
         .unwrap();
 
-        crate::db::queries::members::upsert_member(&conn, project.id, maintainer.id, Role::Maintainer)
+        crate::db::queries::members::upsert_member(
+            &conn,
+            project.id,
+            maintainer.id,
+            Role::Maintainer,
+        )
             .unwrap();
         crate::db::queries::members::upsert_member(&conn, project.id, viewer.id, Role::Viewer)
             .unwrap();
@@ -821,13 +974,17 @@ mod authz_gating_tests {
 
         let non_member_app = app_as_user(db.clone(), &non_member);
         assert_eq!(
-            json_get(&non_member_app, &format!("/api/issues/{issue_id}")).await.status(),
+            json_get(&non_member_app, &format!("/api/issues/{issue_id}"))
+                .await
+                .status(),
             StatusCode::FORBIDDEN
         );
 
         let viewer_app = app_as_user(db, &viewer);
         assert_eq!(
-            json_get(&viewer_app, &format!("/api/issues/{issue_id}")).await.status(),
+            json_get(&viewer_app, &format!("/api/issues/{issue_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
     }
@@ -860,21 +1017,29 @@ mod authz_gating_tests {
 
         let non_member_app = app_as_user(db.clone(), &non_member);
         assert_eq!(
-            json_get(&non_member_app, &format!("/api/pages/{page_id}")).await.status(),
+            json_get(&non_member_app, &format!("/api/pages/{page_id}"))
+                .await
+                .status(),
             StatusCode::FORBIDDEN
         );
         assert_eq!(
-            json_get(&non_member_app, &format!("/api/plans/{plan_id}")).await.status(),
+            json_get(&non_member_app, &format!("/api/plans/{plan_id}"))
+                .await
+                .status(),
             StatusCode::FORBIDDEN
         );
 
         let viewer_app = app_as_user(db, &viewer);
         assert_eq!(
-            json_get(&viewer_app, &format!("/api/pages/{page_id}")).await.status(),
+            json_get(&viewer_app, &format!("/api/pages/{page_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
         assert_eq!(
-            json_get(&viewer_app, &format!("/api/plans/{plan_id}")).await.status(),
+            json_get(&viewer_app, &format!("/api/plans/{plan_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
     }
@@ -945,8 +1110,7 @@ mod authz_gating_tests {
 
     #[tokio::test]
     async fn issue_create_gated_by_maintainer_role() {
-        let (db, admin, lead, maintainer, viewer, non_member, project_id) =
-            setup_membership_test();
+        let (db, admin, lead, maintainer, viewer, non_member, project_id) = setup_membership_test();
 
         for (user, expect_ok) in [
             (&non_member, false),
@@ -962,8 +1126,17 @@ mod authz_gating_tests {
                 serde_json::json!({ "project_id": project_id, "title": format!("by {}", user.username) }),
             )
             .await;
-            let expected = if expect_ok { StatusCode::OK } else { StatusCode::FORBIDDEN };
-            assert_eq!(resp.status(), expected, "{} create expected {expected}", user.username);
+            let expected = if expect_ok {
+                StatusCode::OK
+            } else {
+                StatusCode::FORBIDDEN
+            };
+            assert_eq!(
+                resp.status(),
+                expected,
+                "{} create expected {expected}",
+                user.username
+            );
         }
     }
 
@@ -985,14 +1158,22 @@ mod authz_gating_tests {
 
         let viewer_app = app_as_user(db.clone(), &viewer);
         assert_eq!(
-            json_put(&viewer_app, &format!("/api/issues/{issue_id}"), serde_json::json!({"title": "hijack"}))
+            json_put(
+                &viewer_app,
+                &format!("/api/issues/{issue_id}"),
+                serde_json::json!({"title": "hijack"})
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN
         );
         let non_member_app = app_as_user(db.clone(), &non_member);
         assert_eq!(
-            json_put(&non_member_app, &format!("/api/issues/{issue_id}"), serde_json::json!({"title": "hijack"}))
+            json_put(
+                &non_member_app,
+                &format!("/api/issues/{issue_id}"),
+                serde_json::json!({"title": "hijack"})
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN
@@ -1000,18 +1181,26 @@ mod authz_gating_tests {
 
         let lead_app = app_as_user(db.clone(), &lead);
         assert_eq!(
-            json_put(&lead_app, &format!("/api/issues/{issue_id}"), serde_json::json!({"title": "renamed"}))
+            json_put(
+                &lead_app,
+                &format!("/api/issues/{issue_id}"),
+                serde_json::json!({"title": "renamed"})
+            )
                 .await
                 .status(),
             StatusCode::OK
         );
 
         assert_eq!(
-            json_delete(&viewer_app, &format!("/api/issues/{issue_id}")).await.status(),
+            json_delete(&viewer_app, &format!("/api/issues/{issue_id}"))
+                .await
+                .status(),
             StatusCode::FORBIDDEN
         );
         assert_eq!(
-            json_delete(&lead_app, &format!("/api/issues/{issue_id}")).await.status(),
+            json_delete(&lead_app, &format!("/api/issues/{issue_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
     }
@@ -1021,7 +1210,12 @@ mod authz_gating_tests {
         let (db, _admin, lead, maintainer, viewer, non_member, project_id) =
             setup_membership_test();
 
-        for (user, expect_ok) in [(&viewer, false), (&non_member, false), (&maintainer, true), (&lead, true)] {
+        for (user, expect_ok) in [
+            (&viewer, false),
+            (&non_member, false),
+            (&maintainer, true),
+            (&lead, true),
+        ] {
             let app = app_as_user(db.clone(), user);
             let resp = json_post(
                 &app,
@@ -1029,7 +1223,11 @@ mod authz_gating_tests {
                 serde_json::json!({ "project_id": project_id, "title": format!("page by {}", user.username) }),
             )
             .await;
-            let expected = if expect_ok { StatusCode::OK } else { StatusCode::FORBIDDEN };
+            let expected = if expect_ok {
+                StatusCode::OK
+            } else {
+                StatusCode::FORBIDDEN
+            };
             assert_eq!(resp.status(), expected, "page create by {}", user.username);
 
             let resp = json_post(
@@ -1067,7 +1265,11 @@ mod authz_gating_tests {
             serde_json::json!({ "content": "viewers can comment" }),
         )
         .await;
-        assert_eq!(resp.status(), StatusCode::OK, "viewer must be allowed to comment");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "viewer must be allowed to comment"
+        );
 
         let non_member_app = app_as_user(db, &non_member);
         let resp = json_post(
@@ -1088,14 +1290,22 @@ mod authz_gating_tests {
 
         let viewer_app = app_as_user(db.clone(), &viewer);
         assert_eq!(
-            json_post(&viewer_app, "/api/modules", serde_json::json!({"project_id": project_id, "name": "Nope"}))
+            json_post(
+                &viewer_app,
+                "/api/modules",
+                serde_json::json!({"project_id": project_id, "name": "Nope"})
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN
         );
         let non_member_app = app_as_user(db.clone(), &non_member);
         assert_eq!(
-            json_post(&non_member_app, "/api/labels", serde_json::json!({"project_id": project_id, "name": "nope"}))
+            json_post(
+                &non_member_app,
+                "/api/labels",
+                serde_json::json!({"project_id": project_id, "name": "nope"})
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN
@@ -1103,14 +1313,22 @@ mod authz_gating_tests {
 
         let maintainer_app = app_as_user(db.clone(), &maintainer);
         assert_eq!(
-            json_post(&maintainer_app, "/api/modules", serde_json::json!({"project_id": project_id, "name": "Backend"}))
+            json_post(
+                &maintainer_app,
+                "/api/modules",
+                serde_json::json!({"project_id": project_id, "name": "Backend"})
+            )
                 .await
                 .status(),
             StatusCode::OK,
             "maintainer should manage structure once enforcement loosens the gate"
         );
         assert_eq!(
-            json_post(&maintainer_app, "/api/folders", serde_json::json!({"project_id": project_id, "name": "Docs"}))
+            json_post(
+                &maintainer_app,
+                "/api/folders",
+                serde_json::json!({"project_id": project_id, "name": "Docs"})
+            )
                 .await
                 .status(),
             StatusCode::OK
@@ -1126,7 +1344,11 @@ mod authz_gating_tests {
 
         let maintainer_app = app_as_user(db.clone(), &maintainer);
         assert_eq!(
-            json_put(&maintainer_app, &format!("/api/projects/{project_id}"), serde_json::json!({"name": "Nope"}))
+            json_put(
+                &maintainer_app,
+                &format!("/api/projects/{project_id}"),
+                serde_json::json!({"name": "Nope"})
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN
@@ -1134,7 +1356,11 @@ mod authz_gating_tests {
 
         let lead_app = app_as_user(db, &lead);
         assert_eq!(
-            json_put(&lead_app, &format!("/api/projects/{project_id}"), serde_json::json!({"name": "Renamed"}))
+            json_put(
+                &lead_app,
+                &format!("/api/projects/{project_id}"),
+                serde_json::json!({"name": "Renamed"})
+            )
                 .await
                 .status(),
             StatusCode::OK
@@ -1149,13 +1375,17 @@ mod authz_gating_tests {
 
         let maintainer_app = app_as_user(db.clone(), &maintainer);
         assert_eq!(
-            json_delete(&maintainer_app, &format!("/api/projects/{project_id}")).await.status(),
+            json_delete(&maintainer_app, &format!("/api/projects/{project_id}"))
+                .await
+                .status(),
             StatusCode::FORBIDDEN
         );
 
         let lead_app = app_as_user(db, &lead);
         assert_eq!(
-            json_delete(&lead_app, &format!("/api/projects/{project_id}")).await.status(),
+            json_delete(&lead_app, &format!("/api/projects/{project_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
     }
@@ -1168,7 +1398,12 @@ mod authz_gating_tests {
             setup_membership_test();
         let lead_app = app_as_user(db.clone(), &lead);
         let issue_a = parse_json(
-            json_post(&lead_app, "/api/issues", serde_json::json!({"project_id": project_id, "title": "A"})).await,
+            json_post(
+                &lead_app,
+                "/api/issues",
+                serde_json::json!({"project_id": project_id, "title": "A"}),
+            )
+            .await,
         )
         .await;
 
@@ -1202,18 +1437,27 @@ mod authz_gating_tests {
             "source": issue_a["identifier"], "target": issue_b["identifier"], "relation_type": "relates_to"
         });
         assert_eq!(
-            json_post(&maintainer_app, "/api/issues/link", link_body.clone()).await.status(),
+            json_post(&maintainer_app, "/api/issues/link", link_body.clone())
+                .await
+                .status(),
             StatusCode::FORBIDDEN,
             "maintainer has no role on the target's project"
         );
 
         {
             let conn = db.write().unwrap();
-            crate::db::queries::members::upsert_member(&conn, other_project_id, maintainer.id, Role::Maintainer)
+            crate::db::queries::members::upsert_member(
+                &conn,
+                other_project_id,
+                maintainer.id,
+                Role::Maintainer,
+            )
                 .unwrap();
         }
         assert_eq!(
-            json_post(&maintainer_app, "/api/issues/link", link_body).await.status(),
+            json_post(&maintainer_app, "/api/issues/link", link_body)
+                .await
+                .status(),
             StatusCode::OK,
             "maintainer now has Maintainer on both sides"
         );
@@ -1228,7 +1472,11 @@ mod authz_gating_tests {
 
         let maintainer_app = app_as_user(db.clone(), &maintainer);
         assert_eq!(
-            json_post(&maintainer_app, "/api/pages", serde_json::json!({"title": "Workspace doc"}))
+            json_post(
+                &maintainer_app,
+                "/api/pages",
+                serde_json::json!({"title": "Workspace doc"})
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN
@@ -1236,7 +1484,13 @@ mod authz_gating_tests {
 
         let admin_app = app_as_user(db, &admin);
         assert_eq!(
-            json_post(&admin_app, "/api/pages", serde_json::json!({"title": "Workspace doc"})).await.status(),
+            json_post(
+                &admin_app,
+                "/api/pages",
+                serde_json::json!({"title": "Workspace doc"})
+            )
+            .await
+            .status(),
             StatusCode::OK
         );
     }
@@ -1267,24 +1521,36 @@ mod authz_gating_tests {
 
         // Read: project + issue, despite no membership row for admin.
         assert_eq!(
-            json_get(&admin_app, &format!("/api/projects/{project_id}")).await.status(),
+            json_get(&admin_app, &format!("/api/projects/{project_id}"))
+                .await
+                .status(),
             StatusCode::OK,
             "admin must read a project they're not a member of"
         );
         assert_eq!(
-            json_get(&admin_app, &format!("/api/issues/{issue_id}")).await.status(),
+            json_get(&admin_app, &format!("/api/issues/{issue_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
 
         // Write: create + update.
         assert_eq!(
-            json_post(&admin_app, "/api/issues", serde_json::json!({ "project_id": project_id, "title": "by admin" }))
+            json_post(
+                &admin_app,
+                "/api/issues",
+                serde_json::json!({ "project_id": project_id, "title": "by admin" })
+            )
                 .await
                 .status(),
             StatusCode::OK
         );
         assert_eq!(
-            json_put(&admin_app, &format!("/api/issues/{issue_id}"), serde_json::json!({"title": "renamed by admin"}))
+            json_put(
+                &admin_app,
+                &format!("/api/issues/{issue_id}"),
+                serde_json::json!({"title": "renamed by admin"})
+            )
                 .await
                 .status(),
             StatusCode::OK
@@ -1355,8 +1621,10 @@ mod authz_gating_tests {
 
         fn insert_oauth_token(db: &crate::db::DbPool, suffix: &str, user_id: i64) -> String {
             let token = format!("lific_at_test-{suffix}");
-            let hash: String =
-                Sha256::digest(token.as_bytes()).iter().map(|b| format!("{b:02x}")).collect();
+            let hash: String = Sha256::digest(token.as_bytes())
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
             let expires = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
             let client_id = format!("client-{suffix}");
             let conn = db.write().unwrap();
@@ -1385,8 +1653,16 @@ mod authz_gating_tests {
         // The real request path: api::router behind the real require_api_key
         // middleware — not the app_as_user() Extension-injection shortcut.
         let app = crate::api::router(db.clone(), &[])
-            .layer(axum::Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
-            .layer(axum::middleware::from_fn_with_state(auth_state, crate::auth::require_api_key));
+            .layer(axum::Extension(crate::realtime::RealtimeHub::new()))
+            .layer(axum::Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
+            .layer(axum::middleware::from_fn_with_state(
+                auth_state,
+                crate::auth::require_api_key,
+            ));
 
         async fn get_with_token(app: axum::Router, uri: String, token: &str) -> SC {
             app.oneshot(
@@ -1423,7 +1699,12 @@ mod authz_gating_tests {
 
         // Token-backed MEMBER succeeds on read + write.
         assert_eq!(
-            get_with_token(app.clone(), format!("/api/issues/{issue_id}"), &member_token).await,
+            get_with_token(
+                app.clone(),
+                format!("/api/issues/{issue_id}"),
+                &member_token
+            )
+            .await,
             SC::OK,
             "token-backed member must be able to read"
         );
@@ -1441,7 +1722,12 @@ mod authz_gating_tests {
 
         // Token-backed NON-MEMBER is denied on both.
         assert_eq!(
-            get_with_token(app.clone(), format!("/api/issues/{issue_id}"), &outsider_token).await,
+            get_with_token(
+                app.clone(),
+                format!("/api/issues/{issue_id}"),
+                &outsider_token
+            )
+            .await,
             SC::FORBIDDEN,
             "token-backed non-member must be denied on read"
         );
@@ -1469,7 +1755,9 @@ mod authz_gating_tests {
 
         // Reads + content mutation stay open to any authenticated user.
         assert_eq!(
-            json_get(&random_app, &format!("/api/projects/{project_id}")).await.status(),
+            json_get(&random_app, &format!("/api/projects/{project_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
         assert_eq!(
@@ -1486,14 +1774,22 @@ mod authz_gating_tests {
 
         // Structure endpoints stay lead-gated (not loosened to Maintainer).
         assert_eq!(
-            json_post(&random_app, "/api/modules", serde_json::json!({"project_id": project_id, "name": "Nope"}))
+            json_post(
+                &random_app,
+                "/api/modules",
+                serde_json::json!({"project_id": project_id, "name": "Nope"})
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN
         );
         let lead_app = app_as_user(db.clone(), &lead);
         assert_eq!(
-            json_post(&lead_app, "/api/modules", serde_json::json!({"project_id": project_id, "name": "Yes"}))
+            json_post(
+                &lead_app,
+                "/api/modules",
+                serde_json::json!({"project_id": project_id, "name": "Yes"})
+            )
                 .await
                 .status(),
             StatusCode::OK
@@ -1501,12 +1797,16 @@ mod authz_gating_tests {
 
         // Project delete stays admin-only (lead denied, matching pre-LIF-194).
         assert_eq!(
-            json_delete(&lead_app, &format!("/api/projects/{project_id}")).await.status(),
+            json_delete(&lead_app, &format!("/api/projects/{project_id}"))
+                .await
+                .status(),
             StatusCode::FORBIDDEN
         );
         let admin_app = app_as_user(db, &admin);
         assert_eq!(
-            json_delete(&admin_app, &format!("/api/projects/{project_id}")).await.status(),
+            json_delete(&admin_app, &format!("/api/projects/{project_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
     }
@@ -1521,11 +1821,17 @@ mod authz_gating_tests {
 
         // Flag off (default): a non-member can read the project freely.
         assert_eq!(
-            json_get(&regular_app, &format!("/api/projects/{project_id}")).await.status(),
+            json_get(&regular_app, &format!("/api/projects/{project_id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
 
-        let resp = json_patch(&admin_app, "/api/instance/settings", serde_json::json!({"authz_enforced": true}))
+        let resp = json_patch(
+            &admin_app,
+            "/api/instance/settings",
+            serde_json::json!({"authz_enforced": true}),
+        )
             .await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(parse_json(resp).await["authz_enforced"], true);
@@ -1533,8 +1839,219 @@ mod authz_gating_tests {
         // Same connection, next request: the non-member is now denied — no
         // restart required (authz::authz_enforced reads the row live).
         assert_eq!(
-            json_get(&regular_app, &format!("/api/projects/{project_id}")).await.status(),
+            json_get(&regular_app, &format!("/api/projects/{project_id}"))
+                .await
+                .status(),
             StatusCode::FORBIDDEN
         );
+    }
+
+    fn websocket_session() -> (crate::db::DbPool, String) {
+        let db = crate::db::open_memory().expect("test db");
+        let token = {
+            let conn = db.write().unwrap();
+            let user = crate::db::queries::users::create_user(
+                &conn,
+                &crate::db::models::CreateUser {
+                    username: "ws-user".into(),
+                    email: "ws@test.local".into(),
+                    password: "testpassword1".into(),
+                    display_name: None,
+                    is_admin: false,
+                    is_bot: false,
+                },
+            )
+            .unwrap();
+            crate::db::queries::users::create_session(&conn, user.id, None)
+                .unwrap()
+                .token
+        };
+        (db, token)
+    }
+
+    #[test]
+    fn websocket_session_token_reads_cookie_only() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            "Bearer lific_sess_bearer".parse().unwrap(),
+        );
+        headers.insert(
+            axum::http::header::COOKIE,
+            "theme=dark; lific_token=lific_sess_cookie; other=1"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(
+            super::websocket_session_token(&headers),
+            Some("lific_sess_cookie")
+        );
+    }
+
+    #[test]
+    fn websocket_session_token_rejects_empty_credentials() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::COOKIE, "lific_token=".parse().unwrap());
+        assert_eq!(super::websocket_session_token(&headers), None);
+
+        headers.insert(
+            axum::http::header::COOKIE,
+            "lific_token=   ".parse().unwrap(),
+        );
+        assert_eq!(super::websocket_session_token(&headers), None);
+    }
+
+    #[test]
+    fn websocket_session_token_rejects_non_session_credentials() {
+        for value in ["lific_sk_live_x", "lific_at_x", "garbage"] {
+            let mut headers = axum::http::HeaderMap::new();
+            headers.insert(
+                axum::http::header::COOKIE,
+                format!("lific_token={value}").parse().unwrap(),
+            );
+            assert_eq!(
+                super::websocket_session_token(&headers),
+                None,
+                "websocket cookie auth must only accept session tokens"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn websocket_rejects_missing_or_invalid_session_cookie() {
+        let (db, _) = websocket_session();
+
+        let missing = axum::http::HeaderMap::new();
+        assert!(matches!(
+            super::validate_websocket_request(&db, &missing, &[]),
+            Err(crate::error::LificError::Forbidden(_))
+        ));
+
+        let mut invalid = axum::http::HeaderMap::new();
+        invalid.insert(
+            axum::http::header::COOKIE,
+            "lific_token=lific_sess_fake".parse().unwrap(),
+        );
+        assert!(matches!(
+            super::validate_websocket_request(&db, &invalid, &[]),
+            Err(crate::error::LificError::Forbidden(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn websocket_accepts_valid_session_cookie_before_upgrade() {
+        let (db, token) = websocket_session();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::COOKIE,
+            format!("lific_token={token}").parse().unwrap(),
+        );
+
+        super::validate_websocket_request(&db, &headers, &[]).unwrap();
+    }
+
+    #[tokio::test]
+    async fn websocket_origin_policy_uses_configured_origins() {
+        let origins = vec!["https://app.example.test".to_string()];
+        let (db, token) = websocket_session();
+
+        let mut rejected = axum::http::HeaderMap::new();
+        rejected.insert(
+            axum::http::header::ORIGIN,
+            "https://evil.example.test".parse().unwrap(),
+        );
+        rejected.insert(
+            axum::http::header::COOKIE,
+            format!("lific_token={token}").parse().unwrap(),
+        );
+        assert!(matches!(
+            super::validate_websocket_request(&db, &rejected, &origins),
+            Err(crate::error::LificError::Forbidden(_))
+        ));
+
+        let mut accepted = axum::http::HeaderMap::new();
+        accepted.insert(
+            axum::http::header::ORIGIN,
+            "https://app.example.test".parse().unwrap(),
+        );
+        accepted.insert(
+            axum::http::header::COOKIE,
+            format!("lific_token={token}").parse().unwrap(),
+        );
+        super::validate_websocket_request(&db, &accepted, &origins).unwrap();
+    }
+
+    #[tokio::test]
+    async fn websocket_origin_policy_rejects_cross_site_by_default() {
+        let (db, token) = websocket_session();
+
+        let mut rejected = axum::http::HeaderMap::new();
+        rejected.insert(
+            axum::http::header::ORIGIN,
+            "https://evil.example.test".parse().unwrap(),
+        );
+        rejected.insert(
+            axum::http::header::HOST,
+            "app.example.test".parse().unwrap(),
+        );
+        rejected.insert(
+            axum::http::header::COOKIE,
+            format!("lific_token={token}").parse().unwrap(),
+        );
+        assert!(matches!(
+            super::validate_websocket_request(&db, &rejected, &[]),
+            Err(crate::error::LificError::Forbidden(_))
+        ));
+
+        let mut malformed = axum::http::HeaderMap::new();
+        malformed.insert(
+            axum::http::header::ORIGIN,
+            axum::http::HeaderValue::from_bytes(b"\xff").unwrap(),
+        );
+        malformed.insert(
+            axum::http::header::COOKIE,
+            format!("lific_token={token}").parse().unwrap(),
+        );
+        assert!(matches!(
+            super::validate_websocket_request(&db, &malformed, &[]),
+            Err(crate::error::LificError::Forbidden(_))
+        ));
+
+        let mut same_origin = axum::http::HeaderMap::new();
+        same_origin.insert(
+            axum::http::header::ORIGIN,
+            "https://app.example.test".parse().unwrap(),
+        );
+        same_origin.insert(
+            axum::http::header::HOST,
+            "app.example.test".parse().unwrap(),
+        );
+        same_origin.insert("x-forwarded-proto", "https".parse().unwrap());
+        same_origin.insert(
+            axum::http::header::COOKIE,
+            format!("lific_token={token}").parse().unwrap(),
+        );
+        super::validate_websocket_request(&db, &same_origin, &[]).unwrap();
+
+        same_origin.insert(
+            axum::http::header::ORIGIN,
+            "https://app.example.test".parse().unwrap(),
+        );
+        same_origin.insert(
+            axum::http::header::HOST,
+            "app.example.test:443".parse().unwrap(),
+        );
+        super::validate_websocket_request(&db, &same_origin, &[]).unwrap();
+
+        same_origin.insert(
+            axum::http::header::ORIGIN,
+            "http://app.example.test:80".parse().unwrap(),
+        );
+        same_origin.insert(
+            axum::http::header::HOST,
+            "app.example.test".parse().unwrap(),
+        );
+        same_origin.insert("x-forwarded-proto", "http".parse().unwrap());
+        super::validate_websocket_request(&db, &same_origin, &[]).unwrap();
     }
 }

--- a/src/api/pages.rs
+++ b/src/api/pages.rs
@@ -6,6 +6,7 @@ use axum::{
 use crate::authz;
 use crate::db::{DbPool, models::*};
 use crate::error::LificError;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 use super::{filter_visible, with_read, with_write};
 
@@ -97,6 +98,7 @@ pub(super) async fn get_page(
 
 pub(super) async fn create_page(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<CreatePage>,
 ) -> Result<Json<Page>, LificError> {
@@ -107,11 +109,15 @@ pub(super) async fn create_page(
         super::attachments::sync_links(conn, AttachmentEntity::Page, page.id, &page.content)?;
         Ok(page)
     })?;
+    if let Some(project_id) = page.project_id {
+        realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    }
     Ok(Json(page))
 }
 
 pub(super) async fn update_page(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(id): Path<i64>,
     Json(input): Json<UpdatePage>,
@@ -124,17 +130,24 @@ pub(super) async fn update_page(
         super::attachments::sync_links(conn, AttachmentEntity::Page, page.id, &page.content)?;
         Ok(page)
     })?;
+    if let Some(project_id) = page.project_id {
+        realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    }
     Ok(Json(page))
 }
 
 pub(super) async fn delete_page_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(id): Path<i64>,
 ) -> Result<Json<serde_json::Value>, LificError> {
     let project_id = with_read(&db, |conn| crate::db::queries::get_page(conn, id))?.project_id;
     require_page_role(&db, &auth_user, project_id, Role::Maintainer)?;
     with_write(&db, |conn| crate::db::queries::delete_page(conn, id))?;
+    if let Some(project_id) = project_id {
+        realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    }
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 

--- a/src/api/plans.rs
+++ b/src/api/plans.rs
@@ -5,8 +5,9 @@ use axum::{
 
 use crate::authz;
 use crate::db::queries::plans::{self, StepDoneEffect};
-use crate::db::{models::*, DbPool};
+use crate::db::{DbPool, models::*};
 use crate::error::LificError;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 use super::{filter_visible, with_read, with_write};
 
@@ -50,32 +51,40 @@ pub(super) async fn resolve_plan(
 
 pub(super) async fn create_plan(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<CreatePlan>,
 ) -> Result<Json<Plan>, LificError> {
     authz::require_role(&db, &auth_user, input.project_id, Role::Maintainer)?;
-    with_write(&db, |conn| plans::create_plan(conn, &input)).map(Json)
+    let plan = with_write(&db, |conn| plans::create_plan(conn, &input))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id: plan.project_id });
+    Ok(Json(plan))
 }
 
 pub(super) async fn update_plan(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(id): Path<i64>,
     Json(input): Json<UpdatePlan>,
 ) -> Result<Json<Plan>, LificError> {
     let project_id = with_read(&db, |conn| plans::get_plan(conn, id))?.project_id;
     authz::require_role(&db, &auth_user, project_id, Role::Maintainer)?;
-    with_write(&db, |conn| plans::update_plan(conn, id, &input)).map(Json)
+    let plan = with_write(&db, |conn| plans::update_plan(conn, id, &input))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    Ok(Json(plan))
 }
 
 pub(super) async fn delete_plan_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(id): Path<i64>,
 ) -> Result<Json<serde_json::Value>, LificError> {
     let project_id = with_read(&db, |conn| plans::get_plan(conn, id))?.project_id;
     authz::require_role(&db, &auth_user, project_id, Role::Maintainer)?;
     with_write(&db, |conn| plans::delete_plan(conn, id))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
@@ -90,13 +99,14 @@ pub(super) struct AddStepRequest {
 
 pub(super) async fn add_step(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(plan_id): Path<i64>,
     Json(input): Json<AddStepRequest>,
 ) -> Result<Json<Plan>, LificError> {
     let project_id = with_read(&db, |conn| plans::get_plan(conn, plan_id))?.project_id;
     authz::require_role(&db, &auth_user, project_id, Role::Maintainer)?;
-    with_write(&db, |conn| {
+    let plan = with_write(&db, |conn| {
         plans::add_step(
             conn,
             plan_id,
@@ -106,8 +116,9 @@ pub(super) async fn add_step(
             input.issue_id,
         )?;
         plans::get_plan(conn, plan_id)
-    })
-    .map(Json)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    Ok(Json(plan))
 }
 
 #[derive(serde::Deserialize)]
@@ -134,6 +145,7 @@ pub(super) struct StepUpdateResponse {
 
 pub(super) async fn update_step(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path((plan_id, step_id)): Path<(i64, i64)>,
     Json(input): Json<UpdateStepRequest>,
@@ -171,22 +183,25 @@ pub(super) async fn update_step(
         let plan = plans::get_plan(conn, plan_id)?;
         Ok(StepUpdateResponse { plan, effect })
     })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
     Ok(Json(resp))
 }
 
 pub(super) async fn delete_step_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path((plan_id, step_id)): Path<(i64, i64)>,
 ) -> Result<Json<Plan>, LificError> {
     let project_id = with_read(&db, |conn| plans::get_plan(conn, plan_id))?.project_id;
     authz::require_role(&db, &auth_user, project_id, Role::Maintainer)?;
-    with_write(&db, |conn| {
+    let plan = with_write(&db, |conn| {
         plans::assert_step_in_plan(conn, plan_id, step_id)?;
         plans::delete_step(conn, step_id)?;
         plans::get_plan(conn, plan_id)
-    })
-    .map(Json)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    Ok(Json(plan))
 }
 
 #[cfg(test)]
@@ -312,7 +327,8 @@ mod tests {
                     .uri(format!("/api/plans/{plan_id}/steps/{step_id}"))
                     .header("content-type", "application/json")
                     .body(axum::body::Body::from(
-                        serde_json::to_vec(&serde_json::json!({"description": "the body"})).unwrap(),
+                        serde_json::to_vec(&serde_json::json!({"description": "the body"}))
+                            .unwrap(),
                     ))
                     .unwrap(),
             )
@@ -334,9 +350,15 @@ mod tests {
             .unwrap();
         let feed = body_json(resp).await;
         let items = feed["items"].as_array().unwrap();
-        assert!(items.iter().any(|a| a["entity_type"] == "plan" && a["action"] == "create"));
         assert!(
-            items.iter().any(|a| a["entity_type"] == "plan_step" && a["field"] == "description"),
+            items
+                .iter()
+                .any(|a| a["entity_type"] == "plan" && a["action"] == "create")
+        );
+        assert!(
+            items
+                .iter()
+                .any(|a| a["entity_type"] == "plan_step" && a["field"] == "description"),
             "step description edit must show in plan activity: {feed}"
         );
     }

--- a/src/api/projects.rs
+++ b/src/api/projects.rs
@@ -6,10 +6,11 @@ use axum::{
 use crate::authz;
 use crate::db::{DbPool, models::*};
 use crate::error::LificError;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 use super::{
-    filter_visible, require_authenticated, require_project_delete, require_project_lead,
-    with_read, with_write,
+    filter_visible, require_authenticated, require_project_delete, require_project_lead, with_read,
+    with_write,
 };
 
 pub(super) async fn list_projects(
@@ -34,6 +35,7 @@ pub(super) async fn get_project(
 
 pub(super) async fn create_project(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(mut input): Json<CreateProject>,
 ) -> Result<Json<Project>, LificError> {
@@ -45,20 +47,28 @@ pub(super) async fn create_project(
     {
         input.lead_user_id = Some(user.id);
     }
-    with_write(&db, |conn| crate::db::queries::create_project(conn, &input)).map(Json)
+    let project = with_write(&db, |conn| crate::db::queries::create_project(conn, &input))?;
+    realtime.send(RealtimeEvent::ProjectCreated {
+        project_id: project.id,
+    });
+    Ok(Json(project))
 }
 
 pub(super) async fn update_project(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<UpdateProject>,
 ) -> Result<Json<Project>, LificError> {
     require_project_lead(&db, &auth_user, id)?;
-    with_write(&db, |conn| {
+    let project = with_write(&db, |conn| {
         crate::db::queries::update_project(conn, id, &input)
-    })
-    .map(Json)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated {
+        project_id: project.id,
+    });
+    Ok(Json(project))
 }
 
 /// PUT /api/projects/reorder — persist the sidebar order (LIF-233). Takes the
@@ -68,23 +78,35 @@ pub(super) async fn update_project(
 /// lead/admin-only.
 pub(super) async fn reorder_projects(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<ReorderProjects>,
 ) -> Result<Json<Vec<Project>>, LificError> {
     require_authenticated(&auth_user)?;
-    with_write(&db, |conn| {
+    let projects = with_write(&db, |conn| {
         crate::db::queries::reorder_projects(conn, &input.ids)
-    })
-    .map(Json)
+    })?;
+    realtime.send(RealtimeEvent::ProjectsReordered);
+    Ok(Json(projects))
 }
 
 pub(super) async fn delete_project_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
 ) -> Result<Json<serde_json::Value>, LificError> {
     require_project_delete(&db, &auth_user, id)?;
-    with_write(&db, |conn| crate::db::queries::delete_project(conn, id))?;
+    let (project, audience) = with_write(&db, |conn| {
+        crate::db::queries::delete_project_with_audience(conn, id)
+    })?;
+    let event = RealtimeEvent::ProjectDeleted {
+        project_id: project.id,
+    };
+    match audience {
+        Some(user_ids) => realtime.send_to_users(event, user_ids),
+        None => realtime.send(event),
+    }
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
@@ -213,6 +235,7 @@ fn default_map_closed() -> String {
 /// the fetcher as a parameter so tests can stub the network entirely.
 pub(super) async fn import_github(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Path(project_id): Path<i64>,
     Json(req): Json<GithubImportRequest>,
@@ -223,6 +246,7 @@ pub(super) async fn import_github(
     // owned by whoever ran the import), so audit provenance is correct. On a
     // dry run we skip bot creation entirely.
     let owner_id = auth_user.as_ref().map(|u| u.id);
+    let dry_run = req.dry_run;
 
     let db2 = db.clone();
     let summary = tokio::task::spawn_blocking(move || {
@@ -230,6 +254,10 @@ pub(super) async fn import_github(
     })
     .await
     .map_err(|e| LificError::Internal(format!("import task failed: {e}")))??;
+
+    if !dry_run {
+        realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    }
 
     Ok(Json(summary))
 }
@@ -243,10 +271,10 @@ fn run_github_import_blocking(
     owner_id: Option<i64>,
     req: &GithubImportRequest,
 ) -> Result<crate::import::ImportSummary, LificError> {
-    let (owner, name) = crate::import::github::parse_repo(&req.repo)
-        .map_err(LificError::BadRequest)?;
-    let state = crate::import::github::StateFilter::parse(&req.state)
-        .map_err(LificError::BadRequest)?;
+    let (owner, name) =
+        crate::import::github::parse_repo(&req.repo).map_err(LificError::BadRequest)?;
+    let state =
+        crate::import::github::StateFilter::parse(&req.state).map_err(LificError::BadRequest)?;
     let fetcher = crate::import::github::LiveGithub::new(&owner, &name, req.token.clone())
         .map_err(LificError::Internal)?;
     let slug = format!("{owner}/{name}");
@@ -278,9 +306,12 @@ pub(super) fn import_github_with(
         None
     } else {
         match owner_id {
-            Some(owner) => {
-                Some(crate::import::ensure_import_bot(db, owner, "github", "GitHub Import")?)
-            }
+            Some(owner) => Some(crate::import::ensure_import_bot(
+                db,
+                owner,
+                "github",
+                "GitHub Import",
+            )?),
             None => None,
         }
     };
@@ -442,12 +473,7 @@ mod tests {
         let app = test_app();
         let (project_id, _) = seed_project(&app).await;
 
-        for (title, status) in [
-            ("A", "todo"),
-            ("B", "active"),
-            ("C", "todo"),
-            ("D", "done"),
-        ] {
+        for (title, status) in [("A", "todo"), ("B", "active"), ("C", "todo"), ("D", "done")] {
             let body = serde_json::json!({
                 "project_id": project_id,
                 "title": title,
@@ -492,7 +518,12 @@ mod tests {
             conn.last_insert_rowid()
         };
         let app = crate::api::router(db.clone(), &[])
-            .layer(Extension(crate::config::AuthConfig { allow_signup: true, required: true, secure_cookies: false }))
+            .layer(Extension(crate::realtime::RealtimeHub::new()))
+            .layer(Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
             .layer(Extension(Some(AuthUser {
                 id: admin_id,
                 username: "test-admin".into(),
@@ -711,10 +742,7 @@ mod tests {
         let data = parse_json(resp).await;
         // Distinct message tells the user *why* they can't edit: no lead exists.
         assert!(
-            data["error"]
-                .as_str()
-                .unwrap_or("")
-                .contains("no lead"),
+            data["error"].as_str().unwrap_or("").contains("no lead"),
             "expected 'no lead' in error, got: {}",
             data["error"]
         );
@@ -788,7 +816,11 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let data = parse_json(resp).await;
-        assert!(data["emoji"].is_null(), "expected null emoji, got: {}", data["emoji"]);
+        assert!(
+            data["emoji"].is_null(),
+            "expected null emoji, got: {}",
+            data["emoji"]
+        );
     }
 
     #[tokio::test]
@@ -1036,7 +1068,9 @@ mod tests {
     // the same collect → apply pipeline the endpoint uses, with zero network.
 
     use crate::db::DbPool;
-    use crate::import::github::{GithubFetcher, GithubIssue, GithubComment, GithubUser, StateFilter};
+    use crate::import::github::{
+        GithubComment, GithubFetcher, GithubIssue, GithubUser, StateFilter,
+    };
 
     fn import_pool() -> (DbPool, i64, i64) {
         let db = crate::db::open_memory().unwrap();
@@ -1088,7 +1122,9 @@ mod tests {
         }
         fn fetch_comments(&self, _n: i64) -> Result<Vec<GithubComment>, String> {
             Ok(vec![GithubComment {
-                user: Some(GithubUser { login: "octocat".into() }),
+                user: Some(GithubUser {
+                    login: "octocat".into(),
+                }),
                 body: Some("nice".into()),
                 created_at: Some("2024-01-01T00:00:00Z".into()),
             }])
@@ -1110,7 +1146,13 @@ mod tests {
     fn import_github_dry_run_counts_and_writes_nothing() {
         let (db, pid, owner) = import_pool();
         let summary = import_github_with(
-            &db, pid, Some(owner), &FakeGithub, "octocat/hello", StateFilter::All, &req(true),
+            &db,
+            pid,
+            Some(owner),
+            &FakeGithub,
+            "octocat/hello",
+            StateFilter::All,
+            &req(true),
         )
         .unwrap();
         assert!(summary.dry_run);
@@ -1120,7 +1162,9 @@ mod tests {
         assert_eq!(summary.labels_planned, 1);
         // Nothing written.
         let conn = db.read().unwrap();
-        let n: i64 = conn.query_row("SELECT COUNT(*) FROM issues", [], |r| r.get(0)).unwrap();
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM issues", [], |r| r.get(0))
+            .unwrap();
         assert_eq!(n, 0);
     }
 
@@ -1128,7 +1172,13 @@ mod tests {
     fn import_github_real_run_writes_and_is_idempotent() {
         let (db, pid, owner) = import_pool();
         let s1 = import_github_with(
-            &db, pid, Some(owner), &FakeGithub, "octocat/hello", StateFilter::All, &req(false),
+            &db,
+            pid,
+            Some(owner),
+            &FakeGithub,
+            "octocat/hello",
+            StateFilter::All,
+            &req(false),
         )
         .unwrap();
         assert_eq!(s1.issues_created, 2);
@@ -1137,7 +1187,13 @@ mod tests {
 
         // Re-run: idempotent no-op.
         let s2 = import_github_with(
-            &db, pid, Some(owner), &FakeGithub, "octocat/hello", StateFilter::All, &req(false),
+            &db,
+            pid,
+            Some(owner),
+            &FakeGithub,
+            "octocat/hello",
+            StateFilter::All,
+            &req(false),
         )
         .unwrap();
         assert_eq!(s2.issues_created, 0);

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -6,6 +6,7 @@ use axum::{
 use crate::authz;
 use crate::db::{DbPool, models::*};
 use crate::error::LificError;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 use super::{require_structure_role, with_read, with_write};
 
@@ -40,15 +41,19 @@ pub(super) async fn get_module(
 
 pub(super) async fn create_module(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<CreateModule>,
 ) -> Result<Json<Module>, LificError> {
     require_structure_role(&db, &auth_user, input.project_id)?;
-    with_write(&db, |conn| crate::db::queries::create_module(conn, &input)).map(Json)
+    let module = with_write(&db, |conn| crate::db::queries::create_module(conn, &input))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id: module.project_id });
+    Ok(Json(module))
 }
 
 pub(super) async fn update_module(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<UpdateModule>,
@@ -57,14 +62,16 @@ pub(super) async fn update_module(
         crate::db::queries::get_resource_project_id(conn, "modules", id)
     })?;
     require_structure_role(&db, &auth_user, project_id)?;
-    with_write(&db, |conn| {
+    let module = with_write(&db, |conn| {
         crate::db::queries::update_module(conn, id, &input)
-    })
-    .map(Json)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    Ok(Json(module))
 }
 
 pub(super) async fn delete_module_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
 ) -> Result<Json<serde_json::Value>, LificError> {
@@ -73,6 +80,7 @@ pub(super) async fn delete_module_handler(
     })?;
     require_structure_role(&db, &auth_user, project_id)?;
     with_write(&db, |conn| crate::db::queries::delete_module(conn, id))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
@@ -97,15 +105,19 @@ pub(super) async fn list_labels(
 
 pub(super) async fn create_label(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<CreateLabel>,
 ) -> Result<Json<Label>, LificError> {
     require_structure_role(&db, &auth_user, input.project_id)?;
-    with_write(&db, |conn| crate::db::queries::create_label(conn, &input)).map(Json)
+    let label = with_write(&db, |conn| crate::db::queries::create_label(conn, &input))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id: input.project_id });
+    Ok(Json(label))
 }
 
 pub(super) async fn update_label_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<UpdateLabel>,
@@ -114,11 +126,16 @@ pub(super) async fn update_label_handler(
         crate::db::queries::get_resource_project_id(conn, "labels", id)
     })?;
     require_structure_role(&db, &auth_user, project_id)?;
-    with_write(&db, |conn| crate::db::queries::update_label(conn, id, &input)).map(Json)
+    let label = with_write(&db, |conn| {
+        crate::db::queries::update_label(conn, id, &input)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    Ok(Json(label))
 }
 
 pub(super) async fn delete_label_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
 ) -> Result<Json<serde_json::Value>, LificError> {
@@ -127,6 +144,7 @@ pub(super) async fn delete_label_handler(
     })?;
     require_structure_role(&db, &auth_user, project_id)?;
     with_write(&db, |conn| crate::db::queries::delete_label(conn, id))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
@@ -138,6 +156,7 @@ pub(super) struct MergeLabel {
 
 pub(super) async fn merge_label_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<MergeLabel>,
@@ -155,10 +174,11 @@ pub(super) async fn merge_label_handler(
         ));
     }
     require_structure_role(&db, &auth_user, source_project)?;
-    with_write(&db, |conn| {
+    let label = with_write(&db, |conn| {
         crate::db::queries::merge_label(conn, id, input.into)
-    })
-    .map(Json)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id: source_project });
+    Ok(Json(label))
 }
 
 // ── Folder endpoints ─────────────────────────────────────────
@@ -182,15 +202,19 @@ pub(super) async fn list_folders_handler(
 
 pub(super) async fn create_folder(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Extension(auth_user): Extension<Option<AuthUser>>,
     Json(input): Json<CreateFolder>,
 ) -> Result<Json<Folder>, LificError> {
     require_structure_role(&db, &auth_user, input.project_id)?;
-    with_write(&db, |conn| crate::db::queries::create_folder(conn, &input)).map(Json)
+    let folder = with_write(&db, |conn| crate::db::queries::create_folder(conn, &input))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id: input.project_id });
+    Ok(Json(folder))
 }
 
 pub(super) async fn delete_folder_handler(
     State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
     Path(id): Path<i64>,
     Extension(auth_user): Extension<Option<AuthUser>>,
 ) -> Result<Json<serde_json::Value>, LificError> {
@@ -199,6 +223,7 @@ pub(super) async fn delete_folder_handler(
     })?;
     require_structure_role(&db, &auth_user, project_id)?;
     with_write(&db, |conn| crate::db::queries::delete_folder(conn, id))?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
@@ -301,9 +326,7 @@ mod tests {
         let (db, _, lead, regular, project_id) = setup_lead_test();
         let lead_app = app_as_user(db.clone(), &lead);
 
-        let mk = |name: &str| {
-            serde_json::json!({ "project_id": project_id, "name": name, "color": "#FF0000" })
-        };
+        let mk = |name: &str| serde_json::json!({ "project_id": project_id, "name": name, "color": "#FF0000" });
         let a = parse_json(json_post(&lead_app, "/api/labels", mk("bug")).await).await;
         let b = parse_json(json_post(&lead_app, "/api/labels", mk("defect")).await).await;
         let a_id = a["id"].as_i64().unwrap();
@@ -329,8 +352,15 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(parse_json(resp).await["id"].as_i64().unwrap(), b_id);
 
-        let list = parse_json(json_get(&lead_app, &format!("/api/labels?project_id={project_id}")).await).await;
-        let names: Vec<&str> = list.as_array().unwrap().iter().map(|l| l["name"].as_str().unwrap()).collect();
+        let list =
+            parse_json(json_get(&lead_app, &format!("/api/labels?project_id={project_id}")).await)
+                .await;
+        let names: Vec<&str> = list
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l["name"].as_str().unwrap())
+            .collect();
         assert_eq!(names, vec!["defect"]);
     }
 }

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -71,7 +71,10 @@ pub(super) async fn create_view(
 ) -> Result<Json<SavedView>, LificError> {
     authz::require_role(&db, &auth_user, project_id, Role::Viewer)?;
     let user = require_user(auth_user)?;
-    with_write(&db, |conn| views::create_view(conn, project_id, user.id, &input)).map(Json)
+    with_write(&db, |conn| {
+        views::create_view(conn, project_id, user.id, &input)
+    })
+    .map(Json)
 }
 
 /// PATCH /api/projects/{id}/views/{view_id} — rename, replace the config,
@@ -86,7 +89,9 @@ pub(super) async fn update_view(
 ) -> Result<Json<SavedView>, LificError> {
     authz::require_role(&db, &auth_user, project_id, Role::Viewer)?;
     let user = require_user(auth_user)?;
-    with_write(&db, |conn| views::update_view(conn, view_id, project_id, user.id, &input))
+    with_write(&db, |conn| {
+        views::update_view(conn, view_id, project_id, user.id, &input)
+    })
         .map(Json)
 }
 
@@ -98,7 +103,9 @@ pub(super) async fn delete_view(
 ) -> Result<Json<serde_json::Value>, LificError> {
     authz::require_role(&db, &auth_user, project_id, Role::Viewer)?;
     let user = require_user(auth_user)?;
-    with_write(&db, |conn| views::delete_view(conn, view_id, project_id, user.id))?;
+    with_write(&db, |conn| {
+        views::delete_view(conn, view_id, project_id, user.id)
+    })?;
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
@@ -127,7 +134,8 @@ mod tests {
         assert_eq!(created["is_default"], false);
         let view_id = created["id"].as_i64().unwrap();
 
-        let list = parse_json(json_get(&app, &format!("/api/projects/{project_id}/views")).await).await;
+        let list =
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/views")).await).await;
         assert_eq!(list.as_array().unwrap().len(), 1);
 
         let resp = json_patch(
@@ -142,7 +150,8 @@ mod tests {
         let resp = json_delete(&app, &format!("/api/projects/{project_id}/views/{view_id}")).await;
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let list = parse_json(json_get(&app, &format!("/api/projects/{project_id}/views")).await).await;
+        let list =
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/views")).await).await;
         assert!(list.as_array().unwrap().is_empty());
     }
 
@@ -161,7 +170,12 @@ mod tests {
                 serde_json::json!({ "name": format!("{}'s view", actor.username), "config": "{}" }),
             )
             .await;
-            assert_eq!(resp.status(), StatusCode::OK, "{} should be able to save a view", actor.username);
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "{} should be able to save a view",
+                actor.username
+            );
         }
     }
 
@@ -199,8 +213,12 @@ mod tests {
         let b_app = app_as_user(db, &non_member);
 
         // B's list must not include A's view.
-        let b_list = parse_json(json_get(&b_app, &format!("/api/projects/{project_id}/views")).await).await;
-        assert!(b_list.as_array().unwrap().is_empty(), "B must not see A's views: {b_list:#?}");
+        let b_list =
+            parse_json(json_get(&b_app, &format!("/api/projects/{project_id}/views")).await).await;
+        assert!(
+            b_list.as_array().unwrap().is_empty(),
+            "B must not see A's views: {b_list:#?}"
+        );
 
         // B's PATCH/DELETE on A's view_id must 404, not 403 (existence
         // must not be confirmable via a different status code) and not 200.
@@ -212,11 +230,16 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
-        let resp = json_delete(&b_app, &format!("/api/projects/{project_id}/views/{view_id}")).await;
+        let resp = json_delete(
+            &b_app,
+            &format!("/api/projects/{project_id}/views/{view_id}"),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
         // A's view is untouched by B's rejected attempts.
-        let a_list = parse_json(json_get(&a_app, &format!("/api/projects/{project_id}/views")).await).await;
+        let a_list =
+            parse_json(json_get(&a_app, &format!("/api/projects/{project_id}/views")).await).await;
         assert_eq!(a_list.as_array().unwrap().len(), 1);
         assert_eq!(a_list.as_array().unwrap()[0]["name"], "A's private view");
     }
@@ -252,9 +275,18 @@ mod tests {
         .await;
         assert_eq!(second["is_default"], true);
 
-        let list = parse_json(json_get(&app, &format!("/api/projects/{project_id}/views")).await).await;
-        let first_after = list.as_array().unwrap().iter().find(|v| v["id"] == first_id).unwrap();
-        assert_eq!(first_after["is_default"], false, "first default must be cleared: {list:#?}");
+        let list =
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/views")).await).await;
+        let first_after = list
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|v| v["id"] == first_id)
+            .unwrap();
+        assert_eq!(
+            first_after["is_default"], false,
+            "first default must be cleared: {list:#?}"
+        );
     }
 
     // ── Validation ───────────────────────────────────────────────────
@@ -324,7 +356,12 @@ mod tests {
         let non_member_app = app_as_user(db, &non_member);
 
         assert_eq!(
-            json_get(&non_member_app, &format!("/api/projects/{project_id}/views")).await.status(),
+            json_get(
+                &non_member_app,
+                &format!("/api/projects/{project_id}/views")
+            )
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
         assert_eq!(
@@ -348,7 +385,10 @@ mod tests {
             StatusCode::FORBIDDEN
         );
         assert_eq!(
-            json_delete(&non_member_app, &format!("/api/projects/{project_id}/views/{view_id}"))
+            json_delete(
+                &non_member_app,
+                &format!("/api/projects/{project_id}/views/{view_id}")
+            )
                 .await
                 .status(),
             StatusCode::FORBIDDEN

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -163,6 +163,24 @@ pub fn require_role(
     require_role_conn(&conn, auth_user, project_id, min)
 }
 
+pub(crate) fn can_view_project(
+    db: &DbPool,
+    user: &AuthUser,
+    project_id: i64,
+) -> Result<bool, LificError> {
+    if user.is_admin {
+        return Ok(true);
+    }
+    let conn = db.read()?;
+    if !authz_enforced_conn(&conn)? {
+        return Ok(true);
+    }
+    Ok(matches!(
+        queries::members::get_member_role(&conn, project_id, user.id)?,
+        Some(role) if role >= Role::Viewer
+    ))
+}
+
 fn require_role_conn(
     conn: &Connection,
     auth_user: &Option<AuthUser>,

--- a/src/authz_coverage_tests.rs
+++ b/src/authz_coverage_tests.rs
@@ -92,8 +92,12 @@ fn extract_rest_routes(src: &str) -> Vec<(String, String)> {
         let call_body = &src[start..i.saturating_sub(1)];
         idx = i;
 
-        let Some(q1) = call_body.find('"') else { continue };
-        let Some(q2_rel) = call_body[q1 + 1..].find('"') else { continue };
+        let Some(q1) = call_body.find('"') else {
+            continue;
+        };
+        let Some(q2_rel) = call_body[q1 + 1..].find('"') else {
+            continue;
+        };
         let path = call_body[q1 + 1..q1 + 1 + q2_rel].to_string();
 
         for method in METHODS {
@@ -124,34 +128,66 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
     use Classification::{Exempt, Filtered, Gated};
     use Gate::*;
 
-    const NOT_PROJECT_SCOPED: &str =
-        "global account/instance surface, not project-scoped — gated (or intentionally open) independent of authz.rs";
+    const NOT_PROJECT_SCOPED: &str = "global account/instance surface, not project-scoped — gated (or intentionally open) independent of authz.rs";
     const OWNERSHIP: &str = "author-or-admin ownership check (ownership, not project role)";
     const PUBLIC: &str = "unauthenticated by design (auth screen / health check)";
 
     HashMap::from([
         // ── Public / instance ──
         (("GET", "/api/instance"), Exempt(PUBLIC)),
-        (("GET", "/api/instance/settings"), Exempt(NOT_PROJECT_SCOPED)),
-        (("PATCH", "/api/instance/settings"), Exempt(NOT_PROJECT_SCOPED)),
+        (
+            ("GET", "/api/instance/settings"),
+            Exempt(NOT_PROJECT_SCOPED),
+        ),
+        (
+            ("PATCH", "/api/instance/settings"),
+            Exempt(NOT_PROJECT_SCOPED),
+        ),
         (("GET", "/api/health"), Exempt(PUBLIC)),
+        (
+            ("GET", "/api/events/ws"),
+            Exempt("cookie-authenticated event stream, not project-scoped"),
+        ),
         // ── Auth: self-service, own account, not project-scoped ──
         (("POST", "/api/auth/signup"), Exempt(PUBLIC)),
         (("POST", "/api/auth/login"), Exempt(PUBLIC)),
-        (("POST", "/api/auth/auto-login"), Exempt("public but instance-flag gated — LIF-215")),
+        (
+            ("POST", "/api/auth/auto-login"),
+            Exempt("public but instance-flag gated — LIF-215"),
+        ),
         (("POST", "/api/auth/logout"), Exempt(NOT_PROJECT_SCOPED)),
         (("GET", "/api/auth/me"), Exempt(NOT_PROJECT_SCOPED)),
         (("PATCH", "/api/auth/me"), Exempt(NOT_PROJECT_SCOPED)),
-        (("POST", "/api/auth/me/password"), Exempt(NOT_PROJECT_SCOPED)),
-        (("DELETE", "/api/auth/me/sessions"), Exempt(NOT_PROJECT_SCOPED)),
+        (
+            ("POST", "/api/auth/me/password"),
+            Exempt(NOT_PROJECT_SCOPED),
+        ),
+        (
+            ("DELETE", "/api/auth/me/sessions"),
+            Exempt(NOT_PROJECT_SCOPED),
+        ),
         (("GET", "/api/auth/keys"), Exempt(NOT_PROJECT_SCOPED)),
         (("POST", "/api/auth/keys"), Exempt(NOT_PROJECT_SCOPED)),
-        (("DELETE", "/api/auth/keys/{id}"), Exempt(NOT_PROJECT_SCOPED)),
+        (
+            ("DELETE", "/api/auth/keys/{id}"),
+            Exempt(NOT_PROJECT_SCOPED),
+        ),
         (("GET", "/api/auth/bots"), Exempt(NOT_PROJECT_SCOPED)),
         (("POST", "/api/auth/bots"), Exempt(NOT_PROJECT_SCOPED)),
-        (("POST", "/api/auth/bots/{id}/disconnect"), Exempt(NOT_PROJECT_SCOPED)),
-        (("DELETE", "/api/auth/bots/{id}"), Exempt(NOT_PROJECT_SCOPED)),
-        (("GET", "/api/users"), Exempt("global user directory for UI dropdowns; auth-required only, via the outer auth_middleware_wrapper")),
+        (
+            ("POST", "/api/auth/bots/{id}/disconnect"),
+            Exempt(NOT_PROJECT_SCOPED),
+        ),
+        (
+            ("DELETE", "/api/auth/bots/{id}"),
+            Exempt(NOT_PROJECT_SCOPED),
+        ),
+        (
+            ("GET", "/api/users"),
+            Exempt(
+                "global user directory for UI dropdowns; auth-required only, via the outer auth_middleware_wrapper",
+            ),
+        ),
         // ── Comments: Viewer to read/create (project resolved from parent) ──
         (("GET", "/api/issues/{issue_id}/comments"), Gated(Viewer)),
         (("POST", "/api/issues/{issue_id}/comments"), Gated(Viewer)),
@@ -165,16 +201,41 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
         // Upload is open to any authenticated user (per-user rate-limited); the
         // blob only becomes project-visible once linked into an entity, so
         // there's no project to gate at upload time.
-        (("POST", "/api/attachments"), Exempt("any authenticated user may upload; per-user rate-limited; linked-to-project visibility happens on entity save — LIF-262")),
+        (
+            ("POST", "/api/attachments"),
+            Exempt(
+                "any authenticated user may upload; per-user rate-limited; linked-to-project visibility happens on entity save — LIF-262",
+            ),
+        ),
         // Download/delete authorize dynamically against EVERY project the
         // attachment is linked into (Viewer to read, Maintainer/uploader/admin
         // to delete), which no single fixed gate level captures.
-        (("GET", "/api/attachments/{id}"), Exempt("read gated at Viewer on any linked project, or uploader/admin when still unlinked — dynamic, see api::attachments::authorize_read (LIF-262)")),
-        (("DELETE", "/api/attachments/{id}"), Exempt("delete gated at uploader, Maintainer on any linked project, or admin — dynamic, see api::attachments::authorize_delete (LIF-262)")),
+        (
+            ("GET", "/api/attachments/{id}"),
+            Exempt(
+                "read gated at Viewer on any linked project, or uploader/admin when still unlinked — dynamic, see api::attachments::authorize_read (LIF-262)",
+            ),
+        ),
+        (
+            ("DELETE", "/api/attachments/{id}"),
+            Exempt(
+                "delete gated at uploader, Maintainer on any linked project, or admin — dynamic, see api::attachments::authorize_delete (LIF-262)",
+            ),
+        ),
         // ── Projects ──
         (("GET", "/api/projects"), Filtered),
-        (("POST", "/api/projects"), Exempt("open to any authenticated user; creator auto-becomes lead — LIF-DOC-7 decision #13")),
-        (("PUT", "/api/projects/reorder"), Exempt("require_authenticated only; instance-wide sidebar chrome, not a project edit — LIF-233")),
+        (
+            ("POST", "/api/projects"),
+            Exempt(
+                "open to any authenticated user; creator auto-becomes lead — LIF-DOC-7 decision #13",
+            ),
+        ),
+        (
+            ("PUT", "/api/projects/reorder"),
+            Exempt(
+                "require_authenticated only; instance-wide sidebar chrome, not a project edit — LIF-233",
+            ),
+        ),
         (("GET", "/api/projects/{id}"), Gated(Viewer)),
         (("PUT", "/api/projects/{id}"), Gated(Lead)),
         (("DELETE", "/api/projects/{id}"), Gated(ProjectDelete)),
@@ -184,14 +245,23 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
         // ── Membership management (LIF-199, REST/web-only) ──
         (("GET", "/api/projects/{id}/members"), Gated(Viewer)),
         (("POST", "/api/projects/{id}/members"), Gated(Lead)),
-        (("PATCH", "/api/projects/{id}/members/{user_id}"), Gated(Lead)),
-        (("DELETE", "/api/projects/{id}/members/{user_id}"), Gated(Lead)),
+        (
+            ("PATCH", "/api/projects/{id}/members/{user_id}"),
+            Gated(Lead),
+        ),
+        (
+            ("DELETE", "/api/projects/{id}/members/{user_id}"),
+            Gated(Lead),
+        ),
         // LIF-234: caller's own effective role — Viewer-gated, drives
         // role-aware UI affordances.
         (("GET", "/api/projects/{id}/my-role"), Gated(Viewer)),
         // @mention autocomplete candidates (LIF-263) — Viewer-gated, and
         // member-scoped in the query layer when enforcement is on.
-        (("GET", "/api/projects/{id}/mention-candidates"), Gated(Viewer)),
+        (
+            ("GET", "/api/projects/{id}/mention-candidates"),
+            Gated(Viewer),
+        ),
         // ── Saved views (LIF-242, REST/web-only) ──
         // Gated(Viewer) is the *project-role* floor only — every one of
         // these additionally enforces strict per-user ownership in the
@@ -202,8 +272,14 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
         // a teammate's. See src/api/views.rs's module doc comment.
         (("GET", "/api/projects/{id}/views"), Gated(Viewer)),
         (("POST", "/api/projects/{id}/views"), Gated(Viewer)),
-        (("PATCH", "/api/projects/{id}/views/{view_id}"), Gated(Viewer)),
-        (("DELETE", "/api/projects/{id}/views/{view_id}"), Gated(Viewer)),
+        (
+            ("PATCH", "/api/projects/{id}/views/{view_id}"),
+            Gated(Viewer),
+        ),
+        (
+            ("DELETE", "/api/projects/{id}/views/{view_id}"),
+            Gated(Viewer),
+        ),
         // ── Issues ──
         (("GET", "/api/issues"), Filtered),
         (("POST", "/api/issues"), Gated(Maintainer)),
@@ -251,8 +327,14 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
         (("GET", "/api/plans/resolve/{identifier}"), Gated(Viewer)),
         (("GET", "/api/plans/{id}/activity"), Gated(Viewer)),
         (("POST", "/api/plans/{id}/steps"), Gated(Maintainer)),
-        (("PUT", "/api/plans/{plan_id}/steps/{step_id}"), Gated(Maintainer)),
-        (("DELETE", "/api/plans/{plan_id}/steps/{step_id}"), Gated(Maintainer)),
+        (
+            ("PUT", "/api/plans/{plan_id}/steps/{step_id}"),
+            Gated(Maintainer),
+        ),
+        (
+            ("DELETE", "/api/plans/{plan_id}/steps/{step_id}"),
+            Gated(Maintainer),
+        ),
         // ── Search ──
         (("GET", "/api/search"), Filtered),
     ])
@@ -465,5 +547,3 @@ fn mcp_manifest_mixed_reasons_are_non_empty() {
         }
     }
 }
-
-

--- a/src/db/queries/projects.rs
+++ b/src/db/queries/projects.rs
@@ -239,6 +239,42 @@ pub fn delete_project(conn: &Connection, id: i64) -> Result<(), LificError> {
     Ok(())
 }
 
+pub fn delete_project_with_audience(
+    conn: &Connection,
+    id: i64,
+) -> Result<(Project, Option<Vec<i64>>), LificError> {
+    let project = get_project(conn, id)?;
+    let audience = if super::settings::get(conn)?.authz_enforced {
+        Some(project_viewer_ids(conn, &project)?)
+    } else {
+        None
+    };
+    delete_project(conn, id)?;
+    Ok((project, audience))
+}
+
+fn project_viewer_ids(conn: &Connection, project: &Project) -> Result<Vec<i64>, LificError> {
+    let mut ids: Vec<_> = super::members::list_members(conn, project.id)?
+        .into_iter()
+        .map(|member| member.user_id)
+        .collect();
+    if let Some(lead_id) = project.lead_user_id
+        && !ids.contains(&lead_id)
+    {
+        ids.push(lead_id);
+    }
+    let mut stmt = conn.prepare("SELECT id FROM users WHERE is_admin = 1")?;
+    let admins = stmt
+        .query_map([], |row| row.get::<_, i64>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    admins.into_iter().for_each(|id| {
+        if !ids.contains(&id) {
+            ids.push(id);
+        }
+    });
+    Ok(ids)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -7,6 +7,8 @@ use rusqlite::{params, Connection};
 use crate::db::models::*;
 use crate::error::LificError;
 
+pub(crate) const INVALID_SESSION_MESSAGE: &str = "invalid or expired session";
+
 // ── Password hashing ─────────────────────────────────────────
 
 /// Hash a password with argon2 using a random salt.
@@ -354,7 +356,7 @@ pub fn validate_session(conn: &Connection, token: &str) -> Result<User, LificErr
         )
         .map_err(|e| match e {
             rusqlite::Error::QueryReturnedNoRows => {
-                LificError::BadRequest("invalid or expired session".into())
+                LificError::BadRequest(INVALID_SESSION_MESSAGE.into())
             }
             other => other.into(),
         })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod import;
 mod mcp;
 mod oauth;
 mod ratelimit;
+mod realtime;
 mod storage;
 
 use std::sync::Arc;
@@ -896,6 +897,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             // MCP StreamableHTTP service
             let db_for_mcp = pool.clone();
+            let realtime = realtime::RealtimeHub::new();
+            let realtime_for_mcp = realtime.clone();
             let mut mcp_allowed_hosts: Vec<String> =
                 vec!["localhost".into(), "127.0.0.1".into(), "::1".into()];
 
@@ -914,7 +917,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .with_allowed_hosts(mcp_allowed_hosts.clone());
 
             let mcp_service = StreamableHttpService::new(
-                move || Ok(mcp::LificMcp::new(db_for_mcp.clone())),
+                move || {
+                    Ok(mcp::LificMcp::with_realtime(
+                        db_for_mcp.clone(),
+                        realtime_for_mcp.clone(),
+                    ))
+                },
                 Arc::new(LocalSessionManager::default()),
                 mcp_config,
             );
@@ -966,6 +974,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .await
                     }),
                 )
+                .layer(axum::Extension(realtime.clone()))
                 .layer(axum::Extension(login_limiter))
                 .layer(axum::Extension(attachment_store))
                 .layer(axum::Extension(attachment_config))
@@ -1034,6 +1043,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         &token,
                         authless_user,
                         mcp_allowed_hosts.clone(),
+                        realtime.clone(),
                     )
                 });
 
@@ -1708,6 +1718,7 @@ fn build_global_cors(cors_origins: &[String]) -> CorsLayer {
         .allow_methods([
             Method::GET,
             Method::POST,
+            Method::PATCH,
             Method::PUT,
             Method::DELETE,
             Method::OPTIONS,
@@ -1753,13 +1764,19 @@ fn build_authless_mcp_router(
     token: &str,
     user: Option<db::models::AuthUser>,
     allowed_hosts: Vec<String>,
+    realtime: realtime::RealtimeHub,
 ) -> Router {
     let config = StreamableHttpServerConfig::default()
         .with_stateful_mode(false)
         .with_json_response(true)
         .with_allowed_hosts(allowed_hosts);
     let service = StreamableHttpService::new(
-        move || Ok(mcp::LificMcp::new(pool.clone())),
+        move || {
+            Ok(mcp::LificMcp::with_realtime(
+                pool.clone(),
+                realtime.clone(),
+            ))
+        },
         Arc::new(LocalSessionManager::default()),
         config,
     );
@@ -1780,22 +1797,27 @@ async fn auth_middleware_wrapper(
     request: Request<Body>,
     next: middleware::Next,
 ) -> axum::response::Response {
-    let path = request.uri().path();
-    if path == "/api/health"
-        || path == "/api/instance"
-        || path == "/api/auth/signup"
-        || path == "/api/auth/login"
-        || path == "/api/auth/auto-login"
-        || path.starts_with("/.well-known/")
-        || path.starts_with("/oauth/")
-        || path == "/register"
-        || path == "/authorize"
-        || path == "/token"
-        || path == "/revoke"
-    {
+    if skips_auth_middleware(request.uri().path()) {
         return next.run(request).await;
     }
     auth::require_api_key(state, request, next).await
+}
+
+fn skips_auth_middleware(path: &str) -> bool {
+    matches!(
+        path,
+        "/api/health"
+            | "/api/instance"
+            | "/api/auth/signup"
+            | "/api/auth/login"
+            | "/api/auth/auto-login"
+            | "/api/events/ws"
+            | "/register"
+            | "/authorize"
+            | "/token"
+            | "/revoke"
+    ) || path.starts_with("/.well-known/")
+        || path.starts_with("/oauth/")
 }
 
 /// Wait for SIGINT/SIGTERM, then checkpoint WAL before shutting down.
@@ -1908,6 +1930,12 @@ mod cors_tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
+    #[test]
+    fn websocket_path_skips_header_auth_middleware() {
+        assert!(skips_auth_middleware("/api/events/ws"));
+        assert!(!skips_auth_middleware("/api/issues"));
+    }
+
     /// Build a minimal /mcp router behind an auth gate identical in spirit to
     /// the real one (returns 401 if Authorization is missing), wrapped with
     /// our global CORS layer.
@@ -1967,6 +1995,10 @@ mod cors_tests {
         assert!(
             allow_methods.contains("POST"),
             "POST must be in allowed methods, got: {allow_methods}"
+        );
+        assert!(
+            allow_methods.contains("PATCH"),
+            "PATCH must be in allowed methods, got: {allow_methods}"
         );
 
         let allow_headers = headers
@@ -2100,8 +2132,13 @@ mod authless_mcp_tests {
     async fn authless_path_serves_mcp_without_auth() {
         let pool = db::open_memory().unwrap();
         let token = "s3cret-authless-token-abcdef";
-        let router =
-            build_authless_mcp_router(pool, token, None, vec!["localhost".into()]);
+        let router = build_authless_mcp_router(
+            pool,
+            token,
+            None,
+            vec!["localhost".into()],
+            realtime::RealtimeHub::new(),
+        );
 
         let req = Request::builder()
             .method(Method::POST)
@@ -2131,8 +2168,13 @@ mod authless_mcp_tests {
     #[tokio::test]
     async fn wrong_path_token_does_not_match() {
         let pool = db::open_memory().unwrap();
-        let router =
-            build_authless_mcp_router(pool, "the-right-token", None, vec!["localhost".into()]);
+        let router = build_authless_mcp_router(
+            pool,
+            "the-right-token",
+            None,
+            vec!["localhost".into()],
+            realtime::RealtimeHub::new(),
+        );
 
         let req = Request::builder()
             .method(Method::POST)

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -12,6 +12,7 @@ use rmcp::{
 
 use crate::db::DbPool;
 use crate::db::models::AuthUser;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 /// Serialization lock for MCP request handling.
 /// Ensures only one MCP request processes at a time, preventing the race
@@ -113,15 +114,25 @@ const SERVER_INSTRUCTIONS: &str = "Lific is a local-first issue tracker. Use lis
 #[derive(Clone)]
 pub struct LificMcp {
     db: Arc<DbPool>,
+    realtime: RealtimeHub,
     tool_router: ToolRouter<Self>,
 }
 
 impl LificMcp {
     pub fn new(db: DbPool) -> Self {
+        Self::with_realtime(db, RealtimeHub::new())
+    }
+
+    pub fn with_realtime(db: DbPool, realtime: RealtimeHub) -> Self {
         Self {
             db: Arc::new(db),
+            realtime,
             tool_router: Self::create_tool_router(),
         }
+    }
+
+    fn emit(&self, event: RealtimeEvent) {
+        self.realtime.send(event);
     }
 
     fn read<F, T>(&self, f: F) -> Result<T, String>
@@ -278,9 +289,12 @@ mod tests {
             })
             .await
         }
-        Router::new().route("/mcp-echo", get(echo)).layer(
-            middleware::from_fn_with_state(auth_state, crate::auth::require_api_key),
-        )
+        Router::new()
+            .route("/mcp-echo", get(echo))
+            .layer(middleware::from_fn_with_state(
+                auth_state,
+                crate::auth::require_api_key,
+            ))
     }
 
     #[tokio::test]
@@ -347,10 +361,16 @@ mod tests {
         assert!(!current_is_operator());
 
         let seen = with_request_identity(None, true, || async { current_is_operator() }).await;
-        assert!(seen, "operator flag must be visible inside the request scope");
+        assert!(
+            seen,
+            "operator flag must be visible inside the request scope"
+        );
 
         // Cleared after the request completes.
-        assert!(!current_is_operator(), "operator flag must be cleared after the request");
+        assert!(
+            !current_is_operator(),
+            "operator flag must be cleared after the request"
+        );
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -79,7 +79,10 @@ fn fmt_steps(nodes: &[models::PlanStepNode], depth: usize, out: &mut String) {
             n.id, n.title, suffix
         ));
         if !n.description.is_empty() {
-            out.push_str(&format!("{indent}    {}\n", truncate_value(&n.description, 100)));
+            out.push_str(&format!(
+                "{indent}    {}\n",
+                truncate_value(&n.description, 100)
+            ));
         }
         if !n.children.is_empty() {
             fmt_steps(&n.children, depth + 1, out);
@@ -267,7 +270,10 @@ fn fmt_activity(a: &models::Activity) -> String {
         other => format!("{label} {other}"),
     };
 
-    format!("[{}] {}{} via {} — {}", a.ts, who, agent, a.transport, detail)
+    format!(
+        "[{}] {}{} via {} — {}",
+        a.ts, who, agent, a.transport, detail
+    )
 }
 
 // ── LIF-198: MCP authorization gates ────────────────────────────
@@ -430,7 +436,9 @@ impl LificMcp {
     fn require_step_issue_role_mcp(&self, step_id: i64, min: models::Role) -> Result<(), String> {
         match self.read(|conn| queries::plans::step_issue_id(conn, step_id))? {
             Some(issue_id) => {
-                let project_id = self.read(|conn| queries::get_issue(conn, issue_id))?.project_id;
+                let project_id = self
+                    .read(|conn| queries::get_issue(conn, issue_id))?
+                    .project_id;
                 require_role_mcp(&self.db, project_id, min)
             }
             None => Ok(()),
@@ -507,10 +515,7 @@ impl LificMcp {
                     // match on its parent so the reader knows to open the
                     // parent issue/page to find the thread (LIF-146).
                     if r.result_type == "comment" {
-                        out.push_str(&format!(
-                            "- [comment] on {ident} — {}\n",
-                            r.snippet
-                        ));
+                        out.push_str(&format!("- [comment] on {ident} — {}\n", r.snippet));
                     } else {
                         out.push_str(&format!(
                             "- [{}] {} {} — {}\n",
@@ -581,9 +586,9 @@ impl LificMcp {
             return format!("Error: {e}");
         }
 
-        match self.read(|conn| {
-            queries::activity::list_activity(conn, scope, Some(limit), Some(offset))
-        }) {
+        match self
+            .read(|conn| queries::activity::list_activity(conn, scope, Some(limit), Some(offset)))
+        {
             Ok(feed) if feed.items.is_empty() && offset == 0 => {
                 format!("No recorded activity for {ident} yet.")
             }
@@ -699,7 +704,10 @@ impl LificMcp {
                     out.push_str(&format!("Duplicates: {}\n", issue.duplicates.join(", ")));
                 }
                 if !issue.duplicated_by.is_empty() {
-                    out.push_str(&format!("Duplicated by: {}\n", issue.duplicated_by.join(", ")));
+                    out.push_str(&format!(
+                        "Duplicated by: {}\n",
+                        issue.duplicated_by.join(", ")
+                    ));
                 }
                 if !issue.description.is_empty() {
                     out.push_str(&format!("\n{}\n", issue.description));
@@ -784,7 +792,13 @@ impl LificMcp {
                 },
             )
         }) {
-            Ok(issue) => format!("Created {}: {}", issue.identifier, issue.title),
+            Ok(issue) => {
+                self.emit(crate::realtime::RealtimeEvent::IssueCreated {
+                    project_id: issue.project_id,
+                    issue_id: issue.id,
+                });
+                format!("Created {}: {}", issue.identifier, issue.title)
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -811,7 +825,11 @@ impl LificMcp {
                 Some(name) if name.is_empty() => Some(None),
                 Some(name) => {
                     let issue = queries::get_issue(conn, id)?;
-                    Some(Some(queries::resolve_module_name(conn, issue.project_id, name)?))
+                    Some(Some(queries::resolve_module_name(
+                        conn,
+                        issue.project_id,
+                        name,
+                    )?))
                 }
                 None => None,
             };
@@ -831,7 +849,13 @@ impl LificMcp {
                 },
             )
         }) {
-            Ok(issue) => format!("Updated {}: {}", issue.identifier, fmt_issue(&issue)),
+            Ok(issue) => {
+                self.emit(crate::realtime::RealtimeEvent::IssueUpdated {
+                    project_id: issue.project_id,
+                    issue_id: issue.id,
+                });
+                format!("Updated {}: {}", issue.identifier, fmt_issue(&issue))
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -879,8 +903,9 @@ impl LificMcp {
                     ..Default::default()
                 },
             )?;
-            let mut count = 0usize;
-            for issue in &issues {
+            issues
+                .iter()
+                .map(|issue| {
                 queries::update_issue(
                     conn,
                     issue.id,
@@ -895,12 +920,20 @@ impl LificMcp {
                         target_date: None,
                         labels: None,
                     },
-                )?;
-                count += 1;
-            }
-            Ok(count)
+                    )
+                    .map(|issue| (issue.project_id, issue.id))
+                })
+                .collect::<Result<Vec<_>, _>>()
         }) {
-            Ok(count) => format!("Updated {count} issue(s)"),
+            Ok(events) => {
+                for (project_id, issue_id) in &events {
+                    self.emit(crate::realtime::RealtimeEvent::IssueUpdated {
+                        project_id: *project_id,
+                        issue_id: *issue_id,
+                    });
+                }
+                format!("Updated {} issue(s)", events.len())
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -971,7 +1004,13 @@ impl LificMcp {
 
             queries::update_issue(conn, id, &patch)
         }) {
-            Ok(issue) => format!("Edited {}: {}", issue.identifier, fmt_issue(&issue)),
+            Ok(issue) => {
+                self.emit(crate::realtime::RealtimeEvent::IssueUpdated {
+                    project_id: issue.project_id,
+                    issue_id: issue.id,
+                });
+                format!("Edited {}: {}", issue.identifier, fmt_issue(&issue))
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -1075,54 +1114,74 @@ impl LificMcp {
 
     #[tool(description = "Link two issues with a relation: blocks, relates_to, or duplicate")]
     fn link_issues(&self, Parameters(input): Parameters<LinkIssuesInput>) -> String {
-        let (source_id, target_id, source_project, target_project) = match self.read(|conn| {
+        let (source, target) = match self.read(|conn| {
             let source_id = queries::resolve_identifier(conn, &input.source)?;
             let target_id = queries::resolve_identifier(conn, &input.target)?;
-            let source_project = queries::get_issue(conn, source_id)?.project_id;
-            let target_project = queries::get_issue(conn, target_id)?.project_id;
-            Ok((source_id, target_id, source_project, target_project))
+            Ok((
+                queries::get_issue(conn, source_id)?,
+                queries::get_issue(conn, target_id)?,
+            ))
         }) {
             Ok(v) => v,
             Err(e) => return format!("Error: {e}"),
         };
         // Cross-project relation: Maintainer required on BOTH sides (LIF-198
         // scope item 3), even when source and target share a project.
-        if let Err(e) = require_role_mcp(&self.db, source_project, models::Role::Maintainer) {
+        if let Err(e) = require_role_mcp(&self.db, source.project_id, models::Role::Maintainer) {
             return format!("Error: {e}");
         }
-        if let Err(e) = require_role_mcp(&self.db, target_project, models::Role::Maintainer) {
+        if let Err(e) = require_role_mcp(&self.db, target.project_id, models::Role::Maintainer) {
             return format!("Error: {e}");
         }
-        match self.write(|conn| {
-            queries::link_issues(conn, source_id, target_id, &input.relation_type)
-        }) {
-            Ok(()) => format!("{} {} {}", input.source, input.relation_type, input.target),
+        match self
+            .write(|conn| queries::link_issues(conn, source.id, target.id, &input.relation_type))
+        {
+            Ok(()) => {
+                self.emit(crate::realtime::RealtimeEvent::IssueLinked {
+                    project_id: source.project_id,
+                    issue_id: source.id,
+                });
+                self.emit(crate::realtime::RealtimeEvent::IssueLinked {
+                    project_id: target.project_id,
+                    issue_id: target.id,
+                });
+                format!("{} {} {}", input.source, input.relation_type, input.target)
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
 
     #[tool(description = "Remove a relation between two issues")]
     fn unlink_issues(&self, Parameters(input): Parameters<UnlinkIssuesInput>) -> String {
-        let (source_id, target_id, source_project, target_project) = match self.read(|conn| {
+        let (source, target) = match self.read(|conn| {
             let source_id = queries::resolve_identifier(conn, &input.source)?;
             let target_id = queries::resolve_identifier(conn, &input.target)?;
-            let source_project = queries::get_issue(conn, source_id)?.project_id;
-            let target_project = queries::get_issue(conn, target_id)?.project_id;
-            Ok((source_id, target_id, source_project, target_project))
+            Ok((
+                queries::get_issue(conn, source_id)?,
+                queries::get_issue(conn, target_id)?,
+            ))
         }) {
             Ok(v) => v,
             Err(e) => return format!("Error: {e}"),
         };
-        if let Err(e) = require_role_mcp(&self.db, source_project, models::Role::Maintainer) {
+        if let Err(e) = require_role_mcp(&self.db, source.project_id, models::Role::Maintainer) {
             return format!("Error: {e}");
         }
-        if let Err(e) = require_role_mcp(&self.db, target_project, models::Role::Maintainer) {
+        if let Err(e) = require_role_mcp(&self.db, target.project_id, models::Role::Maintainer) {
             return format!("Error: {e}");
         }
-        match self.write(|conn| {
-            queries::unlink_issues(conn, source_id, target_id)
-        }) {
-            Ok(()) => format!("Unlinked {} and {}", input.source, input.target),
+        match self.write(|conn| queries::unlink_issues(conn, source.id, target.id)) {
+            Ok(()) => {
+                self.emit(crate::realtime::RealtimeEvent::IssueUnlinked {
+                    project_id: source.project_id,
+                    issue_id: source.id,
+                });
+                self.emit(crate::realtime::RealtimeEvent::IssueUnlinked {
+                    project_id: target.project_id,
+                    issue_id: target.id,
+                });
+                format!("Unlinked {} and {}", input.source, input.target)
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -1139,7 +1198,9 @@ impl LificMcp {
             Ok((page, folder_name))
         }) {
             Ok((page, folder_name)) => {
-                if let Err(e) = require_page_role_mcp(&self.db, page.project_id, models::Role::Viewer) {
+                if let Err(e) =
+                    require_page_role_mcp(&self.db, page.project_id, models::Role::Viewer)
+                {
                     return format!("Error: {e}");
                 }
                 let mut out = format!(
@@ -1368,19 +1429,26 @@ impl LificMcp {
     fn delete(&self, Parameters(input): Parameters<DeleteInput>) -> String {
         match input.resource_type.as_str() {
             "issue" => {
-                let (id, project_id) = match self.read(|conn| {
+                let issue = match self.read(|conn| {
                     let id = queries::resolve_identifier(conn, &input.identifier)?;
-                    let project_id = queries::get_issue(conn, id)?.project_id;
-                    Ok((id, project_id))
+                    queries::get_issue(conn, id)
                 }) {
                     Ok(v) => v,
                     Err(e) => return format!("Error: {e}"),
                 };
-                if let Err(e) = require_role_mcp(&self.db, project_id, models::Role::Maintainer) {
+                if let Err(e) =
+                    require_role_mcp(&self.db, issue.project_id, models::Role::Maintainer)
+                {
                     return format!("Error: {e}");
                 }
-                match self.write(|conn| queries::delete_issue(conn, id)) {
-                    Ok(()) => format!("Deleted issue {}", input.identifier),
+                match self.write(|conn| queries::delete_issue(conn, issue.id)) {
+                    Ok(()) => {
+                        self.emit(crate::realtime::RealtimeEvent::IssueDeleted {
+                            project_id: issue.project_id,
+                            issue_id: issue.id,
+                        });
+                        format!("Deleted issue {}", input.identifier)
+                    }
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -1397,7 +1465,10 @@ impl LificMcp {
                     return format!("Error: {e}");
                 }
                 match self.write(|conn| queries::plans::delete_plan(conn, id)) {
-                    Ok(()) => format!("Deleted plan {}", input.identifier),
+                    Ok(()) => {
+                        self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
+                        format!("Deleted plan {}", input.identifier)
+                    }
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -1410,26 +1481,42 @@ impl LificMcp {
                     Ok(v) => v,
                     Err(e) => return format!("Error: {e}"),
                 };
-                if let Err(e) = require_page_role_mcp(&self.db, project_id, models::Role::Maintainer) {
+                if let Err(e) =
+                    require_page_role_mcp(&self.db, project_id, models::Role::Maintainer)
+                {
                     return format!("Error: {e}");
                 }
                 match self.write(|conn| queries::delete_page(conn, id)) {
-                    Ok(()) => format!("Deleted page {}", input.identifier),
+                    Ok(()) => {
+                        if let Some(project_id) = project_id {
+                            self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
+                        }
+                        format!("Deleted page {}", input.identifier)
+                    }
                     Err(e) => format!("Error: {e}"),
                 }
             }
             "project" => {
-                let id = match self.read(|conn| {
-                    queries::resolve_project_identifier(conn, &input.identifier)
-                }) {
+                let id = match self
+                    .read(|conn| queries::resolve_project_identifier(conn, &input.identifier))
+                {
                     Ok(id) => id,
                     Err(e) => return format!("Error: {e}"),
                 };
                 if let Err(e) = require_project_delete_role_mcp(&self.db, id) {
                     return format!("Error: {e}");
                 }
-                match self.write(|conn| queries::delete_project(conn, id)) {
-                    Ok(()) => format!("Deleted project {}", input.identifier),
+                match self.write(|conn| queries::delete_project_with_audience(conn, id)) {
+                    Ok((project, audience)) => {
+                        let event = crate::realtime::RealtimeEvent::ProjectDeleted {
+                            project_id: project.id,
+                        };
+                        match audience {
+                            Some(user_ids) => self.realtime.send_to_users(event, user_ids),
+                            None => self.emit(event),
+                        }
+                        format!("Deleted project {}", input.identifier)
+                    }
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -1813,7 +1900,12 @@ impl LificMcp {
                         },
                     )
                 }) {
-                    Ok(p) => format!("Created project {} | {}", p.identifier, p.name),
+                    Ok(p) => {
+                        self.emit(crate::realtime::RealtimeEvent::ProjectCreated {
+                            project_id: p.id,
+                        });
+                        format!("Created project {} | {}", p.identifier, p.name)
+                    }
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -1841,7 +1933,12 @@ impl LificMcp {
                         },
                     )
                 }) {
-                    Ok(p) => format!("Updated project {} | {}", p.identifier, p.name),
+                    Ok(p) => {
+                        self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
+                            project_id: p.id,
+                        });
+                        format!("Updated project {} | {}", p.identifier, p.name)
+                    }
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -2050,15 +2147,13 @@ impl LificMcp {
         // For stdio/local MCP sessions (no HTTP auth), fall back to the first admin user.
         let user_id = match super::current_auth_user() {
             Some(u) => u.id,
-            None => {
-                match self.read(queries::users::first_admin) {
+            None => match self.read(queries::users::first_admin) {
                     Ok(Some(admin)) => admin.id,
                     Ok(None) => {
                         return "Error: no admin user exists to attribute comments to.".into();
                     }
                     Err(e) => return format!("Error: {e}"),
-                }
-            }
+            },
         };
 
         // LIF-263: resolve the parent's project + the enforcement flag up
@@ -2089,16 +2184,32 @@ impl LificMcp {
                 queries::comments::mention_candidates(conn, project_id, member_scoped)?;
             let c = queries::comments::create_comment(conn, parent, user_id, &input.content)?;
             queries::comments::sync_mentions(conn, c.id, &c.content, &candidates)?;
-            Ok(c)
+            let event = c
+                .issue_id
+                .map(|issue_id| {
+                    queries::get_issue(conn, issue_id).map(|issue| {
+                        crate::realtime::RealtimeEvent::IssueUpdated {
+                            project_id: issue.project_id,
+                            issue_id: issue.id,
+                        }
+                    })
+                })
+                .transpose()?;
+            Ok((c, event))
         }) {
             // Don't echo c.content back — the agent already supplied it in the
             // tool args, so repeating it just duplicates tokens in context
             // (LIF-115). The comment id is the useful new handle for any
             // follow-up edit/delete.
-            Ok(c) => format!(
+            Ok((c, event)) => {
+                if let Some(event) = event {
+                    self.emit(event);
+                }
+                format!(
                 "Comment #{} added to {} by {} at {}",
                 c.id, input.identifier, c.author, c.created_at
-            ),
+                )
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -2154,8 +2265,8 @@ impl LificMcp {
 
         // Ownership: only the author or an admin may edit (mirrors
         // api::comments::update_comment_handler).
-        let existing = match self.read(|conn| queries::comments::get_comment(conn, input.comment_id))
-        {
+        let existing =
+            match self.read(|conn| queries::comments::get_comment(conn, input.comment_id)) {
             Ok(c) => c,
             Err(e) => return format!("Error: {e}"),
         };
@@ -2183,7 +2294,15 @@ impl LificMcp {
         }) {
             // Don't echo the new content back — the agent already supplied it
             // (LIF-115). The id is the stable handle.
-            Ok(c) => format!("Comment #{} edited at {}", c.id, c.updated_at),
+            Ok(c) => {
+                if let (Some(issue_id), Some(project_id)) = (c.issue_id, project_id) {
+                    self.emit(crate::realtime::RealtimeEvent::IssueUpdated {
+                        project_id,
+                        issue_id,
+                    });
+                }
+                format!("Comment #{} edited at {}", c.id, c.updated_at)
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -2200,8 +2319,8 @@ impl LificMcp {
 
         // Ownership: only the author or an admin may delete (mirrors
         // api::comments::delete_comment_handler).
-        let existing = match self.read(|conn| queries::comments::get_comment(conn, input.comment_id))
-        {
+        let existing =
+            match self.read(|conn| queries::comments::get_comment(conn, input.comment_id)) {
             Ok(c) => c,
             Err(e) => return format!("Error: {e}"),
         };
@@ -2209,8 +2328,21 @@ impl LificMcp {
             return "Error: you can only delete your own comments".into();
         }
 
+        let project_id = match self.read(|conn| resolve_comment_project(conn, &existing)) {
+            Ok(project_id) => project_id,
+            Err(e) => return format!("Error: {e}"),
+        };
+
         match self.write(|conn| queries::comments::delete_comment(conn, input.comment_id)) {
-            Ok(()) => format!("Comment #{} deleted", input.comment_id),
+            Ok(()) => {
+                if let (Some(issue_id), Some(project_id)) = (existing.issue_id, project_id) {
+                    self.emit(crate::realtime::RealtimeEvent::IssueUpdated {
+                        project_id,
+                        issue_id,
+                    });
+                }
+                format!("Comment #{} deleted", input.comment_id)
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -2247,7 +2379,12 @@ impl LificMcp {
                 },
             )
         }) {
-            Ok(plan) => format!("Created {}\n{}", plan.identifier, fmt_plan(&plan)),
+            Ok(plan) => {
+                self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
+                    project_id: plan.project_id,
+                });
+                format!("Created {}\n{}", plan.identifier, fmt_plan(&plan))
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -2306,7 +2443,17 @@ impl LificMcp {
             )?;
             queries::plans::get_plan(conn, plan_id)
         }) {
-            Ok(plan) => format!("Edited step #{} in {}\n{}", input.step_id, plan.identifier, fmt_plan(&plan)),
+            Ok(plan) => {
+                self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
+                    project_id: plan.project_id,
+                });
+                format!(
+                    "Edited step #{} in {}\n{}",
+                    input.step_id,
+                    plan.identifier,
+                    fmt_plan(&plan)
+                )
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -2352,6 +2499,7 @@ impl LificMcp {
         match self.write(|conn| {
             let plan_id = queries::plans::resolve_plan_identifier(conn, &input.plan)?;
             let mut notes: Vec<String> = Vec::new();
+            let mut events = Vec::new();
 
             match input.step_id {
                 // ── Plan-level update ──
@@ -2400,6 +2548,12 @@ impl LificMcp {
                             );
                             if let Some(iss) = &effect.issue_identifier {
                                 if effect.issue_status_changed {
+                                    let issue_id = queries::resolve_identifier(conn, iss)?;
+                                    let issue = queries::get_issue(conn, issue_id)?;
+                                    events.push(crate::realtime::RealtimeEvent::IssueUpdated {
+                                        project_id: issue.project_id,
+                                        issue_id: issue.id,
+                                    });
                                     msg.push_str(&format!(" → {iss} marked done"));
                                 } else if done {
                                     msg.push_str(&format!(" (linked {iss} already done)"));
@@ -2433,7 +2587,12 @@ impl LificMcp {
                             } else {
                                 queries::plans::step_parent(conn, step_id)?
                             };
-                            queries::plans::move_step(conn, step_id, new_parent, input.move_position)?;
+                            queries::plans::move_step(
+                                conn,
+                                step_id,
+                                new_parent,
+                                input.move_position,
+                            )?;
                             notes.push(format!("Moved step #{step_id}"));
                         }
                         if notes.is_empty() {
@@ -2444,9 +2603,15 @@ impl LificMcp {
             }
 
             let plan = queries::plans::get_plan(conn, plan_id)?;
-            Ok((notes, plan))
+            Ok((notes, plan, events))
         }) {
-            Ok((notes, plan)) => format!("{}\n{}", notes.join("; "), fmt_plan(&plan)),
+            Ok((notes, plan, events)) => {
+                events.into_iter().for_each(|event| self.emit(event));
+                self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
+                    project_id: plan.project_id,
+                });
+                format!("{}\n{}", notes.join("; "), fmt_plan(&plan))
+            }
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -2486,6 +2651,26 @@ mod tests {
     fn mcp() -> LificMcp {
         let db = crate::db::open_memory().expect("test db");
         LificMcp::new(db)
+    }
+
+    fn mcp_with_realtime() -> (
+        LificMcp,
+        tokio::sync::broadcast::Receiver<crate::realtime::RealtimeMessage>,
+    ) {
+        let db = crate::db::open_memory().expect("test db");
+        let realtime = crate::realtime::RealtimeHub::new();
+        let rx = realtime.subscribe();
+        (LificMcp::with_realtime(db, realtime), rx)
+    }
+
+    fn drain_realtime(rx: &mut tokio::sync::broadcast::Receiver<crate::realtime::RealtimeMessage>) {
+        while rx.try_recv().is_ok() {}
+    }
+
+    fn realtime_events(
+        rx: &mut tokio::sync::broadcast::Receiver<crate::realtime::RealtimeMessage>,
+    ) -> Vec<crate::realtime::RealtimeEvent> {
+        std::iter::from_fn(|| rx.try_recv().ok().map(|message| message.event)).collect()
     }
 
     /// Seed a project via manage_resource, return identifier.
@@ -2545,7 +2730,15 @@ mod tests {
             display_name: u.display_name,
             is_admin: u.is_admin,
         };
-        (mcp, au(admin), au(lead), au(maintainer), au(viewer), au(non_member), project_id)
+        (
+            mcp,
+            au(admin),
+            au(lead),
+            au(maintainer),
+            au(viewer),
+            au(non_member),
+            project_id,
+        )
     }
 
     // ── manage_resource ──
@@ -2881,6 +3074,34 @@ mod tests {
     }
 
     #[test]
+    fn bulk_update_emits_issue_updates() {
+        let (m, mut rx) = mcp_with_realtime();
+        seed_project(&m, "Bulk Events", "BLE");
+        seed_issue(&m, "BLE", "One");
+        seed_issue(&m, "BLE", "Two");
+        drain_realtime(&mut rx);
+
+        let result = m.bulk_update(Parameters(BulkUpdateInput {
+            project: "BLE".into(),
+            set_status: Some("done".into()),
+            ..Default::default()
+        }));
+
+        assert_eq!(result, "Updated 2 issue(s)", "got: {result}");
+        let events = realtime_events(&mut rx);
+        assert_eq!(events.len(), 2);
+        assert!(events.into_iter().all(|event| {
+            matches!(
+                event,
+                crate::realtime::RealtimeEvent::IssueUpdated {
+                    project_id: _,
+                    issue_id: _
+                }
+            )
+        }));
+    }
+
+    #[test]
     fn issue_delete() {
         let m = mcp();
         seed_project(&m, "Test", "DEL");
@@ -3070,10 +3291,7 @@ mod tests {
             ..Default::default()
         }));
         assert!(result.contains("1 issues"), "got: {result}");
-        assert!(
-            !result.contains("more results available"),
-            "got: {result}"
-        );
+        assert!(!result.contains("more results available"), "got: {result}");
     }
 
     // ── link / unlink ──
@@ -3651,7 +3869,8 @@ mod tests {
         drop(conn);
         *crate::mcp::MCP_REQUEST_USER
             .lock()
-            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner()) = Some(models::AuthUser {
+            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner()) =
+            Some(models::AuthUser {
             id: user.id,
             username: user.username.clone(),
             display_name: user.display_name,
@@ -3885,15 +4104,24 @@ mod tests {
             identifier: "MIX-1".into(),
             ..Default::default()
         }));
-        assert!(issue_listing.contains("issue thread"), "got: {issue_listing}");
-        assert!(!issue_listing.contains("page thread"), "got: {issue_listing}");
+        assert!(
+            issue_listing.contains("issue thread"),
+            "got: {issue_listing}"
+        );
+        assert!(
+            !issue_listing.contains("page thread"),
+            "got: {issue_listing}"
+        );
 
         let page_listing = m.list_comments(Parameters(ListCommentsInput {
             identifier: "MIX-DOC-1".into(),
             ..Default::default()
         }));
         assert!(page_listing.contains("page thread"), "got: {page_listing}");
-        assert!(!page_listing.contains("issue thread"), "got: {page_listing}");
+        assert!(
+            !page_listing.contains("issue thread"),
+            "got: {page_listing}"
+        );
     }
 
     #[test]
@@ -3920,7 +4148,10 @@ mod tests {
             identifier: "DOC-1".into(),
             ..Default::default()
         }));
-        assert!(listing.contains("comment on workspace page"), "got: {listing}");
+        assert!(
+            listing.contains("comment on workspace page"),
+            "got: {listing}"
+        );
     }
 
     // ── LIF-113: edit_issue / edit_page (surgical string replacement) ────
@@ -3976,7 +4207,12 @@ mod tests {
 
     // ── edit_issue (MCP tool) ────
 
-    fn seed_issue_with_description(mcp: &LificMcp, project: &str, title: &str, desc: &str) -> String {
+    fn seed_issue_with_description(
+        mcp: &LificMcp,
+        project: &str,
+        title: &str,
+        desc: &str,
+    ) -> String {
         let result = mcp.create_issue(Parameters(CreateIssueInput {
             project: project.into(),
             title: title.into(),
@@ -4011,6 +4247,28 @@ mod tests {
         }));
         assert!(detail.contains("The quick red fox"), "got: {detail}");
         assert!(!detail.contains("brown"), "got: {detail}");
+    }
+
+    #[test]
+    fn edit_issue_emits_issue_update() {
+        let (m, mut rx) = mcp_with_realtime();
+        seed_project(&m, "Edit Events", "EDE");
+        seed_issue_with_description(&m, "EDE", "T", "hello world");
+        drain_realtime(&mut rx);
+
+        let result = m.edit_issue(Parameters(EditIssueInput {
+            identifier: "EDE-1".into(),
+            old_string: "world".into(),
+            new_string: "there".into(),
+            field: None,
+            replace_all: None,
+        }));
+
+        assert!(result.starts_with("Edited"), "got: {result}");
+        assert!(matches!(
+            realtime_events(&mut rx).as_slice(),
+            [crate::realtime::RealtimeEvent::IssueUpdated { .. }]
+        ));
     }
 
     #[test]
@@ -4178,7 +4436,10 @@ mod tests {
         assert!(detail.contains("Stays"), "title preserved, got: {detail}");
         assert!(detail.contains("active"), "status preserved, got: {detail}");
         assert!(detail.contains("high"), "priority preserved, got: {detail}");
-        assert!(detail.contains("kept me"), "description edited, got: {detail}");
+        assert!(
+            detail.contains("kept me"),
+            "description edited, got: {detail}"
+        );
     }
 
     // ── edit_page (MCP tool) ────
@@ -4274,7 +4535,10 @@ mod tests {
             identifier: "EPP-DOC-1".into(),
         }));
         // Title preserved, content edited.
-        assert!(detail.contains("Original Title"), "title preserved, got: {detail}");
+        assert!(
+            detail.contains("Original Title"),
+            "title preserved, got: {detail}"
+        );
         assert!(detail.contains("kept me"), "content edited, got: {detail}");
 
         // Folder preserved — verified via list_pages with the folder filter.
@@ -4287,7 +4551,10 @@ mod tests {
             offset: None,
             ..Default::default()
         }));
-        assert!(listing.contains("EPP-DOC-1"), "folder preserved, got: {listing}");
+        assert!(
+            listing.contains("EPP-DOC-1"),
+            "folder preserved, got: {listing}"
+        );
     }
 
     #[test]
@@ -4752,13 +5019,19 @@ mod tests {
         let detail = m.get_page(Parameters(GetPageInput {
             identifier: "MET-DOC-1".into(),
         }));
-        assert!(detail.contains("Status: active | Folder: Specs"), "got: {detail}");
+        assert!(
+            detail.contains("Status: active | Folder: Specs"),
+            "got: {detail}"
+        );
         assert!(detail.contains("Created: "), "got: {detail}");
         assert!(detail.contains("Updated: "), "got: {detail}");
         // Metadata header comes BEFORE the content.
         let header_pos = detail.find("Status: active").unwrap();
         let body_pos = detail.find("Body text").unwrap();
-        assert!(header_pos < body_pos, "metadata must precede content: {detail}");
+        assert!(
+            header_pos < body_pos,
+            "metadata must precede content: {detail}"
+        );
     }
 
     #[test]
@@ -4777,7 +5050,10 @@ mod tests {
         let detail = m.get_page(Parameters(GetPageInput {
             identifier: "MET-DOC-1".into(),
         }));
-        assert!(detail.contains("Status: draft | Folder: none"), "got: {detail}");
+        assert!(
+            detail.contains("Status: draft | Folder: none"),
+            "got: {detail}"
+        );
     }
 
     #[test]
@@ -5101,9 +5377,15 @@ mod tests {
             comment_id: cid,
             content: "revised".into(),
         }));
-        assert!(edited.contains(&format!("Comment #{cid} edited")), "got: {edited}");
+        assert!(
+            edited.contains(&format!("Comment #{cid} edited")),
+            "got: {edited}"
+        );
         // LIF-115: must not echo the new content back.
-        assert!(!edited.contains("revised"), "must not echo content: {edited}");
+        assert!(
+            !edited.contains("revised"),
+            "must not echo content: {edited}"
+        );
 
         // The listing reflects the new body.
         let listing = m.list_comments(Parameters(ListCommentsInput {
@@ -5111,7 +5393,10 @@ mod tests {
             ..Default::default()
         }));
         assert!(listing.contains("revised"), "got: {listing}");
-        assert!(!listing.contains("original"), "old body should be gone: {listing}");
+        assert!(
+            !listing.contains("original"),
+            "old body should be gone: {listing}"
+        );
     }
 
     #[test]
@@ -5129,13 +5414,56 @@ mod tests {
         let cid = comment_id_from(&added);
 
         let deleted = m.delete_comment(Parameters(DeleteCommentInput { comment_id: cid }));
-        assert!(deleted.contains(&format!("Comment #{cid} deleted")), "got: {deleted}");
+        assert!(
+            deleted.contains(&format!("Comment #{cid} deleted")),
+            "got: {deleted}"
+        );
 
         let listing = m.list_comments(Parameters(ListCommentsInput {
             identifier: "PRJ-1".into(),
             ..Default::default()
         }));
-        assert!(listing.contains("No comments"), "comment should be gone: {listing}");
+        assert!(
+            listing.contains("No comments"),
+            "comment should be gone: {listing}"
+        );
+    }
+
+    #[test]
+    fn issue_comment_edit_and_delete_emit_updates() {
+        let (m, mut events) = mcp_with_realtime();
+        seed_project(&m, "Proj", "PRJ");
+        seed_issue(&m, "PRJ", "Realtime comments");
+        let author = make_user(&m, "author", false);
+        let _guard = act_as(&author);
+
+        let added = m.add_comment(Parameters(AddCommentInput {
+            identifier: "PRJ-1".into(),
+            content: "original".into(),
+        }));
+        let comment_id = comment_id_from(&added);
+        drain_realtime(&mut events);
+
+        m.edit_comment(Parameters(EditCommentInput {
+            comment_id,
+            content: "revised".into(),
+        }));
+        assert!(matches!(
+            realtime_events(&mut events).as_slice(),
+            [crate::realtime::RealtimeEvent::IssueUpdated {
+                project_id: _,
+                issue_id: _
+            }]
+        ));
+
+        m.delete_comment(Parameters(DeleteCommentInput { comment_id }));
+        assert!(matches!(
+            realtime_events(&mut events).as_slice(),
+            [crate::realtime::RealtimeEvent::IssueUpdated {
+                project_id: _,
+                issue_id: _
+            }]
+        ));
     }
 
     #[test]
@@ -5200,7 +5528,10 @@ mod tests {
 
         let _guard = act_as(&admin);
         let deleted = m.delete_comment(Parameters(DeleteCommentInput { comment_id: cid }));
-        assert!(deleted.contains("deleted"), "admin delete must succeed: {deleted}");
+        assert!(
+            deleted.contains("deleted"),
+            "admin delete must succeed: {deleted}"
+        );
     }
 
     #[test]
@@ -5422,10 +5753,7 @@ mod tests {
             identifier: "TST-1".into(),
             ..Default::default()
         }));
-        assert!(
-            out.contains("opencode-blake (agent) via mcp"),
-            "got: {out}"
-        );
+        assert!(out.contains("opencode-blake (agent) via mcp"), "got: {out}");
     }
 
     /// Regression (LIF-155): rmcp executes tools on internally-spawned
@@ -5501,20 +5829,34 @@ mod tests {
                 PlanStepInput {
                     title: "Backend".into(),
                     steps: Some(vec![
-                        PlanStepInput { title: "schema".into(), ..Default::default() },
-                        PlanStepInput { title: "queries".into(), ..Default::default() },
+                        PlanStepInput {
+                            title: "schema".into(),
+                            ..Default::default()
+                        },
+                        PlanStepInput {
+                            title: "queries".into(),
+                            ..Default::default()
+                        },
                     ]),
                     ..Default::default()
                 },
-                PlanStepInput { title: "Frontend".into(), ..Default::default() },
+                PlanStepInput {
+                    title: "Frontend".into(),
+                    ..Default::default()
+                },
             ]),
         }));
         assert!(created.contains("PLN-PLAN-1"), "got: {created}");
         assert!(created.contains("Backend"));
         assert!(created.contains("schema"));
 
-        let got = m.get_plan(Parameters(GetPlanInput { plan: "PLN-PLAN-1".into() }));
-        assert!(got.contains("Frontend"), "get_plan should rehydrate tree: {got}");
+        let got = m.get_plan(Parameters(GetPlanInput {
+            plan: "PLN-PLAN-1".into(),
+        }));
+        assert!(
+            got.contains("Frontend"),
+            "get_plan should rehydrate tree: {got}"
+        );
         assert!(got.contains("0/4 done"), "header should count steps: {got}");
     }
 
@@ -5554,8 +5896,50 @@ mod tests {
         );
 
         // The issue is actually closed.
-        let issue = m.get_issue(Parameters(GetIssueInput { identifier: "PLN-1".into() }));
+        let issue = m.get_issue(Parameters(GetIssueInput {
+            identifier: "PLN-1".into(),
+        }));
         assert!(issue.contains("done"), "issue should be done: {issue}");
+    }
+
+    #[test]
+    fn update_plan_step_done_emits_issue_update() {
+        let (m, mut rx) = mcp_with_realtime();
+        seed_project(&m, "Plan Events", "PLE");
+        seed_issue(&m, "PLE", "Real work");
+
+        let created = m.create_plan(Parameters(CreatePlanInput {
+            project: "PLE".into(),
+            title: "Plan".into(),
+            anchor_issue: None,
+            steps: Some(vec![PlanStepInput {
+                title: "mirror".into(),
+                issue: Some("PLE-1".into()),
+                ..Default::default()
+            }]),
+        }));
+        let step_id: i64 = created
+            .split('#')
+            .nth(1)
+            .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|s| s.parse().ok())
+            .expect("step id in output");
+        drain_realtime(&mut rx);
+
+        m.update_plan_step(Parameters(UpdatePlanStepInput {
+            plan: "PLE-PLAN-1".into(),
+            step_id: Some(step_id),
+            done: Some(true),
+            ..Default::default()
+        }));
+
+        assert!(matches!(
+            realtime_events(&mut rx).as_slice(),
+            [
+                crate::realtime::RealtimeEvent::IssueUpdated { .. },
+                crate::realtime::RealtimeEvent::ProjectUpdated { .. },
+            ]
+        ));
     }
 
     #[test]
@@ -5588,7 +5972,9 @@ mod tests {
             replace_all: None,
         }));
         assert!(out.contains("Edited step"), "got: {out}");
-        let got = m.get_plan(Parameters(GetPlanInput { plan: "PLN-PLAN-1".into() }));
+        let got = m.get_plan(Parameters(GetPlanInput {
+            plan: "PLN-PLAN-1".into(),
+        }));
         assert!(got.contains("new text"), "edit should persist: {got}");
     }
 
@@ -5619,7 +6005,10 @@ mod tests {
             status: Some("active".into()),
             ..Default::default()
         }));
-        assert!(active.contains("No plans found."), "archived plan must not show as active: {active}");
+        assert!(
+            active.contains("No plans found."),
+            "archived plan must not show as active: {active}"
+        );
 
         let archived = m.list_resources(Parameters(ListResourcesInput {
             resource_type: "plan".into(),
@@ -5656,7 +6045,9 @@ mod tests {
             ..Default::default()
         }));
 
-        let got = m.get_plan(Parameters(GetPlanInput { plan: "PLN-PLAN-1".into() }));
+        let got = m.get_plan(Parameters(GetPlanInput {
+            plan: "PLN-PLAN-1".into(),
+        }));
         assert!(got.contains("[x]"), "step should be auto-completed: {got}");
         assert!(got.contains("via PLN-1"), "provenance should show: {got}");
     }
@@ -5677,8 +6068,13 @@ mod tests {
             project: None,
         }));
         assert!(out.contains("Deleted plan"), "got: {out}");
-        let got = m.get_plan(Parameters(GetPlanInput { plan: "PLN-PLAN-1".into() }));
-        assert!(got.contains("Error"), "deleted plan should not be found: {got}");
+        let got = m.get_plan(Parameters(GetPlanInput {
+            plan: "PLN-PLAN-1".into(),
+        }));
+        assert!(
+            got.contains("Error"),
+            "deleted plan should not be found: {got}"
+        );
     }
 }
 
@@ -5706,7 +6102,10 @@ mod authz_gating_tests {
     /// Run `f` as `user` via the production MCP identity wrapper, return
     /// the tool's string result.
     fn as_user(user: &models::AuthUser, f: impl FnOnce() -> String) -> String {
-        run(crate::mcp::with_request_user(Some(user.clone()), || async { f() }))
+        run(crate::mcp::with_request_user(
+            Some(user.clone()),
+            || async { f() },
+        ))
     }
 
     fn is_forbidden(s: &str) -> bool {
@@ -5761,8 +6160,7 @@ mod authz_gating_tests {
 
     #[test]
     fn issue_read_denies_non_member_allows_viewer() {
-        let (m, _admin, lead, _maintainer, viewer, non_member, project_id) =
-            setup_membership_mcp();
+        let (m, _admin, lead, _maintainer, viewer, non_member, project_id) = setup_membership_mcp();
         let _ = project_id;
         let created = as_user(&lead, || {
             m.create_issue(Parameters(CreateIssueInput {
@@ -5779,12 +6177,16 @@ mod authz_gating_tests {
         assert!(created.starts_with("Created"), "got: {created}");
 
         let denied = as_user(&non_member, || {
-            m.get_issue(Parameters(GetIssueInput { identifier: "MEM-1".into() }))
+            m.get_issue(Parameters(GetIssueInput {
+                identifier: "MEM-1".into(),
+            }))
         });
         assert!(is_forbidden(&denied), "non-member get_issue: {denied}");
 
         let allowed = as_user(&viewer, || {
-            m.get_issue(Parameters(GetIssueInput { identifier: "MEM-1".into() }))
+            m.get_issue(Parameters(GetIssueInput {
+                identifier: "MEM-1".into(),
+            }))
         });
         assert!(!is_forbidden(&allowed), "viewer get_issue: {allowed}");
         assert!(allowed.contains("Secret work"), "got: {allowed}");
@@ -5816,20 +6218,28 @@ mod authz_gating_tests {
         assert!(plan.starts_with("Created"), "got: {plan}");
 
         let denied_page = as_user(&non_member, || {
-            m.get_page(Parameters(GetPageInput { identifier: "MEM-DOC-1".into() }))
+            m.get_page(Parameters(GetPageInput {
+                identifier: "MEM-DOC-1".into(),
+            }))
         });
         assert!(is_forbidden(&denied_page), "got: {denied_page}");
         let denied_plan = as_user(&non_member, || {
-            m.get_plan(Parameters(GetPlanInput { plan: "MEM-PLAN-1".into() }))
+            m.get_plan(Parameters(GetPlanInput {
+                plan: "MEM-PLAN-1".into(),
+            }))
         });
         assert!(is_forbidden(&denied_plan), "got: {denied_plan}");
 
         let allowed_page = as_user(&viewer, || {
-            m.get_page(Parameters(GetPageInput { identifier: "MEM-DOC-1".into() }))
+            m.get_page(Parameters(GetPageInput {
+                identifier: "MEM-DOC-1".into(),
+            }))
         });
         assert!(!is_forbidden(&allowed_page), "got: {allowed_page}");
         let allowed_plan = as_user(&viewer, || {
-            m.get_plan(Parameters(GetPlanInput { plan: "MEM-PLAN-1".into() }))
+            m.get_plan(Parameters(GetPlanInput {
+                plan: "MEM-PLAN-1".into(),
+            }))
         });
         assert!(!is_forbidden(&allowed_plan), "got: {allowed_plan}");
     }
@@ -5879,7 +6289,10 @@ mod authz_gating_tests {
                 ..Default::default()
             }))
         });
-        assert!(none_visible.starts_with("0 projects"), "got: {none_visible}");
+        assert!(
+            none_visible.starts_with("0 projects"),
+            "got: {none_visible}"
+        );
 
         let one_visible = as_user(&viewer, || {
             m.list_resources(Parameters(ListResourcesInput {
@@ -5905,7 +6318,10 @@ mod authz_gating_tests {
                 ..Default::default()
             }))
         });
-        assert!(!projects.contains(NO_PROJECTS_NUDGE), "leaked nudge: {projects}");
+        assert!(
+            !projects.contains(NO_PROJECTS_NUDGE),
+            "leaked nudge: {projects}"
+        );
         assert!(projects.starts_with("0 projects"), "got: {projects}");
 
         let searched = as_user(&non_member, || {
@@ -5914,15 +6330,17 @@ mod authz_gating_tests {
                 ..Default::default()
             }))
         });
-        assert!(!searched.contains(NO_PROJECTS_NUDGE), "leaked nudge: {searched}");
+        assert!(
+            !searched.contains(NO_PROJECTS_NUDGE),
+            "leaked nudge: {searched}"
+        );
     }
 
     // ── Writes: content mutations gated at Maintainer ────────────
 
     #[test]
     fn issue_create_gated_by_maintainer_role() {
-        let (m, admin, lead, maintainer, viewer, non_member, _project_id) =
-            setup_membership_mcp();
+        let (m, admin, lead, maintainer, viewer, non_member, _project_id) = setup_membership_mcp();
 
         for (user, expect_ok) in [
             (&non_member, false),
@@ -5954,8 +6372,7 @@ mod authz_gating_tests {
 
     #[test]
     fn issue_update_and_delete_gated_by_maintainer_role() {
-        let (m, _admin, lead, maintainer, viewer, non_member, _project_id) =
-            setup_membership_mcp();
+        let (m, _admin, lead, maintainer, viewer, non_member, _project_id) = setup_membership_mcp();
         let created = as_user(&maintainer, || {
             m.create_issue(Parameters(CreateIssueInput {
                 project: "MEM".into(),
@@ -6041,7 +6458,10 @@ mod authz_gating_tests {
                 content: "viewers can comment".into(),
             }))
         });
-        assert!(!is_forbidden(&allowed), "viewer must be allowed to comment: {allowed}");
+        assert!(
+            !is_forbidden(&allowed),
+            "viewer must be allowed to comment: {allowed}"
+        );
 
         let denied = as_user(&non_member, || {
             m.add_comment(Parameters(AddCommentInput {
@@ -6271,7 +6691,10 @@ mod authz_gating_tests {
                 relation_type: "relates_to".into(),
             }))
         });
-        assert!(is_forbidden(&denied), "maintainer has no role on target's project: {denied}");
+        assert!(
+            is_forbidden(&denied),
+            "maintainer has no role on target's project: {denied}"
+        );
 
         {
             let conn = m.db.write().unwrap();
@@ -6290,7 +6713,10 @@ mod authz_gating_tests {
                 relation_type: "relates_to".into(),
             }))
         });
-        assert!(!is_forbidden(&allowed), "maintainer now has Maintainer on both sides: {allowed}");
+        assert!(
+            !is_forbidden(&allowed),
+            "maintainer now has Maintainer on both sides: {allowed}"
+        );
     }
 
     /// LIF-198 scope: `update_plan_step`'s `attach_issue` is the plan
@@ -6305,7 +6731,10 @@ mod authz_gating_tests {
                 project: "MEM".into(),
                 title: "Plan".into(),
                 anchor_issue: None,
-                steps: Some(vec![PlanStepInput { title: "step".into(), ..Default::default() }]),
+                steps: Some(vec![PlanStepInput {
+                    title: "step".into(),
+                    ..Default::default()
+                }]),
             }))
         });
         assert!(plan.starts_with("Created"), "got: {plan}");
@@ -6420,14 +6849,15 @@ mod authz_gating_tests {
             setup_membership_mcp();
         let bot = {
             let conn = m.db.write().unwrap();
-            let bot = crate::db::queries::users::create_bot_user(
-                &conn,
-                maintainer.id,
-                "bot1",
-                "bot1",
-            )
+            let bot =
+                crate::db::queries::users::create_bot_user(&conn, maintainer.id, "bot1", "bot1")
             .unwrap();
-            models::AuthUser { id: bot.id, username: bot.username, display_name: bot.display_name, is_admin: bot.is_admin }
+            models::AuthUser {
+                id: bot.id,
+                username: bot.username,
+                display_name: bot.display_name,
+                is_admin: bot.is_admin,
+            }
         };
 
         let created = as_user(&bot, || {
@@ -6442,12 +6872,20 @@ mod authz_gating_tests {
                 ..Default::default()
             }))
         });
-        assert!(!is_forbidden(&created), "bot inherits maintainer's write access: {created}");
+        assert!(
+            !is_forbidden(&created),
+            "bot inherits maintainer's write access: {created}"
+        );
 
         let read = as_user(&bot, || {
-            m.get_issue(Parameters(GetIssueInput { identifier: "MEM-1".into() }))
+            m.get_issue(Parameters(GetIssueInput {
+                identifier: "MEM-1".into(),
+            }))
         });
-        assert!(!is_forbidden(&read), "bot inherits maintainer's read access: {read}");
+        assert!(
+            !is_forbidden(&read),
+            "bot inherits maintainer's read access: {read}"
+        );
     }
 
     // ── Headline regression: non-member denied everywhere ────────
@@ -6471,7 +6909,9 @@ mod authz_gating_tests {
         assert!(created.starts_with("Created"), "got: {created}");
 
         let read = as_user(&non_member, || {
-            m.get_issue(Parameters(GetIssueInput { identifier: "MEM-1".into() }))
+            m.get_issue(Parameters(GetIssueInput {
+                identifier: "MEM-1".into(),
+            }))
         });
         assert!(is_forbidden(&read), "read: {read}");
 
@@ -6521,9 +6961,14 @@ mod authz_gating_tests {
         assert!(created.starts_with("Created"), "got: {created}");
 
         let read = as_user(&admin, || {
-            m.get_issue(Parameters(GetIssueInput { identifier: "MEM-1".into() }))
+            m.get_issue(Parameters(GetIssueInput {
+                identifier: "MEM-1".into(),
+            }))
         });
-        assert!(!is_forbidden(&read), "admin must read a project they're not a member of: {read}");
+        assert!(
+            !is_forbidden(&read),
+            "admin must read a project they're not a member of: {read}"
+        );
         assert!(read.contains("Admin spot-check"), "got: {read}");
 
         let write = as_user(&admin, || {
@@ -6538,7 +6983,10 @@ mod authz_gating_tests {
                 ..Default::default()
             }))
         });
-        assert!(!is_forbidden(&write), "admin must write to a project they're not a member of: {write}");
+        assert!(
+            !is_forbidden(&write),
+            "admin must write to a project they're not a member of: {write}"
+        );
     }
 
     // ── Token-backed lockout regression (the epic's landmine) ────
@@ -6585,8 +7033,10 @@ mod authz_gating_tests {
 
         fn insert_oauth_token(db: &crate::db::DbPool, suffix: &str, user_id: i64) -> String {
             let token = format!("lific_at_test-{suffix}");
-            let hash: String =
-                Sha256::digest(token.as_bytes()).iter().map(|b| format!("{b:02x}")).collect();
+            let hash: String = Sha256::digest(token.as_bytes())
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
             let expires = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
             let client_id = format!("client-{suffix}");
             let conn = db.write().unwrap();
@@ -6642,7 +7092,10 @@ mod authz_gating_tests {
         let app = Router::new()
             .route("/call/get_issue/{ident}", get(get_issue_h))
             .route("/call/create_issue", post(create_issue_h))
-            .layer(axum::middleware::from_fn_with_state(auth_state, crate::auth::require_api_key))
+            .layer(axum::middleware::from_fn_with_state(
+                auth_state,
+                crate::auth::require_api_key,
+            ))
             .with_state(m.clone());
 
         async fn call_get(app: Router, uri: String, token: &str) -> String {
@@ -6656,8 +7109,15 @@ mod authz_gating_tests {
                 )
                 .await
                 .unwrap();
-            assert_eq!(resp.status(), StatusCode::OK, "dispatcher itself must not error");
-            let bytes = http_body_util::BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "dispatcher itself must not error"
+            );
+            let bytes = http_body_util::BodyExt::collect(resp.into_body())
+                .await
+                .unwrap()
+                .to_bytes();
             String::from_utf8(bytes.to_vec()).unwrap()
         }
         async fn call_create(app: Router, body: serde_json::Value, token: &str) -> String {
@@ -6673,30 +7133,57 @@ mod authz_gating_tests {
                 )
                 .await
                 .unwrap();
-            assert_eq!(resp.status(), StatusCode::OK, "dispatcher itself must not error");
-            let bytes = http_body_util::BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "dispatcher itself must not error"
+            );
+            let bytes = http_body_util::BodyExt::collect(resp.into_body())
+                .await
+                .unwrap()
+                .to_bytes();
             String::from_utf8(bytes.to_vec()).unwrap()
         }
 
-        let member_read = run(call_get(app.clone(), "/call/get_issue/MEM-1".into(), &member_token));
-        assert!(!is_forbidden(&member_read), "token-backed member must be able to read: {member_read}");
+        let member_read = run(call_get(
+            app.clone(),
+            "/call/get_issue/MEM-1".into(),
+            &member_token,
+        ));
+        assert!(
+            !is_forbidden(&member_read),
+            "token-backed member must be able to read: {member_read}"
+        );
 
         let member_write = run(call_create(
             app.clone(),
             serde_json::json!({"project": "MEM", "title": "by token member"}),
             &member_token,
         ));
-        assert!(!is_forbidden(&member_write), "token-backed member must be able to write: {member_write}");
+        assert!(
+            !is_forbidden(&member_write),
+            "token-backed member must be able to write: {member_write}"
+        );
 
-        let outsider_read = run(call_get(app.clone(), "/call/get_issue/MEM-1".into(), &outsider_token));
-        assert!(is_forbidden(&outsider_read), "token-backed non-member must be denied on read: {outsider_read}");
+        let outsider_read = run(call_get(
+            app.clone(),
+            "/call/get_issue/MEM-1".into(),
+            &outsider_token,
+        ));
+        assert!(
+            is_forbidden(&outsider_read),
+            "token-backed non-member must be denied on read: {outsider_read}"
+        );
 
         let outsider_write = run(call_create(
             app.clone(),
             serde_json::json!({"project": "MEM", "title": "by token outsider"}),
             &outsider_token,
         ));
-        assert!(is_forbidden(&outsider_write), "token-backed non-member must be denied on write: {outsider_write}");
+        assert!(
+            is_forbidden(&outsider_write),
+            "token-backed non-member must be denied on write: {outsider_write}"
+        );
     }
 
     // ── Flag OFF smoke: non-member agent can still mutate ────────

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -1,0 +1,505 @@
+use axum::extract::ws::{Message, WebSocket};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::time::{self, Duration};
+use tracing::{trace, warn};
+
+const EVENT_BUFFER: usize = 256;
+const SESSION_REVALIDATE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Debug, Clone)]
+pub struct RealtimeHub {
+    tx: broadcast::Sender<RealtimeMessage>,
+}
+
+impl RealtimeHub {
+    pub fn new() -> Self {
+        Self::with_capacity(EVENT_BUFFER)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<RealtimeMessage> {
+        self.tx.subscribe()
+    }
+
+    pub fn send(&self, event: RealtimeEvent) {
+        self.send_message(event, RealtimeAudience::Event);
+    }
+
+    pub fn send_to_users(&self, event: RealtimeEvent, user_ids: Vec<i64>) {
+        self.send_message(event, RealtimeAudience::Users(user_ids));
+    }
+
+    fn send_message(&self, event: RealtimeEvent, audience: RealtimeAudience) {
+        match self.tx.receiver_count() {
+            0 => trace!("dropped realtime event because no receivers are subscribed"),
+            _ => match serde_json::to_string(&event) {
+                Ok(json) => {
+                    let message = RealtimeMessage {
+                        event,
+                        message: Message::Text(json.into()),
+                        audience,
+                    };
+                    if self.tx.send(message).is_err() {
+                        trace!("dropped realtime event because no receivers are subscribed");
+                    }
+                }
+                Err(_) => warn!("failed to serialize realtime event"),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum RealtimeAudience {
+    Event,
+    Users(Vec<i64>),
+}
+
+#[derive(Debug, Clone)]
+pub struct RealtimeMessage {
+    pub event: RealtimeEvent,
+    pub message: Message,
+    audience: RealtimeAudience,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RealtimeEvent {
+    #[serde(rename = "resync.required")]
+    ResyncRequired,
+    #[serde(rename = "project.created")]
+    ProjectCreated { project_id: i64 },
+    #[serde(rename = "project.updated")]
+    ProjectUpdated { project_id: i64 },
+    #[serde(rename = "project.deleted")]
+    ProjectDeleted { project_id: i64 },
+    #[serde(rename = "projects.reordered")]
+    ProjectsReordered,
+    #[serde(rename = "issue.created")]
+    IssueCreated { project_id: i64, issue_id: i64 },
+    #[serde(rename = "issue.updated")]
+    IssueUpdated { project_id: i64, issue_id: i64 },
+    #[serde(rename = "issue.deleted")]
+    IssueDeleted { project_id: i64, issue_id: i64 },
+    #[serde(rename = "issue.linked")]
+    IssueLinked { project_id: i64, issue_id: i64 },
+    #[serde(rename = "issue.unlinked")]
+    IssueUnlinked { project_id: i64, issue_id: i64 },
+}
+
+pub async fn serve_socket(
+    mut socket: WebSocket,
+    hub: RealtimeHub,
+    db: crate::db::DbPool,
+    session_token: String,
+) {
+    let mut auth_user = match session_user(&db, &session_token) {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            let _ = socket.send(Message::Close(None)).await;
+            return;
+        }
+        Err(e) => {
+            warn!(error = %e, "websocket session lookup failed");
+            let _ = socket.send(Message::Close(None)).await;
+            return;
+        }
+    };
+    let mut visible_projects = visible_projects_for(&db, &auth_user);
+    let mut rx = hub.subscribe();
+    let mut revalidate = time::interval(SESSION_REVALIDATE_INTERVAL);
+    revalidate.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+    while let SocketFlow::Open = tokio::select! {
+        _ = revalidate.tick() => {
+            let flow = revalidate_session(&mut socket, &db, &session_token, &mut auth_user).await;
+            if flow == SocketFlow::Open {
+                visible_projects = visible_projects_for(&db, &auth_user);
+            }
+            flow
+        },
+        event = rx.recv() => forward_event(&mut socket, &db, &auth_user, &mut visible_projects, event).await,
+        message = socket.recv() => handle_client_message(&mut socket, message).await,
+    } {}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SocketFlow {
+    Open,
+    Close,
+}
+
+impl SocketFlow {
+    fn from_send(result: Result<(), axum::Error>) -> Self {
+        match result {
+            Ok(()) => Self::Open,
+            Err(_) => Self::Close,
+        }
+    }
+}
+
+async fn revalidate_session(
+    socket: &mut WebSocket,
+    db: &crate::db::DbPool,
+    session_token: &str,
+    auth_user: &mut crate::db::models::AuthUser,
+) -> SocketFlow {
+    match session_state(db, session_token) {
+        SessionState::Valid(user) => {
+            *auth_user = user;
+            SocketFlow::Open
+        }
+        SessionState::Invalid => {
+            let _ = socket.send(Message::Close(None)).await;
+            SocketFlow::Close
+        }
+        SessionState::Error(error) => {
+            warn!(error = %error, "websocket session revalidation failed");
+            let _ = socket.send(Message::Close(None)).await;
+            SocketFlow::Close
+        }
+    }
+}
+
+async fn forward_event(
+    socket: &mut WebSocket,
+    db: &crate::db::DbPool,
+    auth_user: &crate::db::models::AuthUser,
+    visible_projects: &mut Option<HashSet<i64>>,
+    event: Result<RealtimeMessage, RecvError>,
+) -> SocketFlow {
+    match event {
+        Ok(message) => match event_flow(db, auth_user, &message) {
+            EventFlow::Forward => {
+                if let Some(project_id) = message.event.project_id() {
+                    if matches!(message.event, RealtimeEvent::ProjectDeleted { .. }) {
+                        if let Some(projects) = visible_projects {
+                            projects.remove(&project_id);
+                        }
+                    } else if let Some(projects) = visible_projects {
+                        projects.insert(project_id);
+                    }
+                }
+                SocketFlow::from_send(socket.send(message.message).await)
+            }
+            EventFlow::Drop => {
+                let revoked = matches!(message.event, RealtimeEvent::ProjectUpdated { .. })
+                    && message
+                        .event
+                        .project_id()
+                        .is_some_and(|project_id| {
+                            visible_projects
+                                .as_mut()
+                                .is_some_and(|projects| projects.remove(&project_id))
+                        });
+                if revoked {
+                    send_event(socket, &RealtimeEvent::ResyncRequired).await
+                } else {
+                    SocketFlow::Open
+                }
+            }
+        },
+        Err(RecvError::Lagged(dropped)) => {
+            warn!(
+                dropped,
+                "realtime websocket lagged; asking client to resync"
+            );
+            send_event(socket, &RealtimeEvent::ResyncRequired).await
+        }
+        Err(RecvError::Closed) => SocketFlow::Close,
+    }
+}
+
+async fn handle_client_message(
+    socket: &mut WebSocket,
+    message: Option<Result<Message, axum::Error>>,
+) -> SocketFlow {
+    match message {
+        Some(Ok(Message::Ping(payload))) => {
+            SocketFlow::from_send(socket.send(Message::Pong(payload)).await)
+        }
+        Some(Ok(Message::Close(_))) | Some(Err(_)) | None => SocketFlow::Close,
+        Some(Ok(Message::Pong(_))) | Some(Ok(_)) => SocketFlow::Open,
+    }
+}
+
+async fn send_event(socket: &mut WebSocket, event: &RealtimeEvent) -> SocketFlow {
+    match serde_json::to_string(event) {
+        Ok(json) => SocketFlow::from_send(socket.send(Message::Text(json.into())).await),
+        Err(_) => {
+            warn!("failed to serialize realtime event");
+            SocketFlow::from_send(socket.send(Message::Close(None)).await)
+        }
+    }
+}
+
+enum SessionState {
+    Valid(crate::db::models::AuthUser),
+    Invalid,
+    Error(crate::error::LificError),
+}
+
+fn session_state(db: &crate::db::DbPool, token: &str) -> SessionState {
+    match session_user(db, token) {
+        Ok(Some(user)) => SessionState::Valid(user),
+        Ok(None) => SessionState::Invalid,
+        Err(error) => SessionState::Error(error),
+    }
+}
+
+fn session_user(
+    db: &crate::db::DbPool,
+    token: &str,
+) -> Result<Option<crate::db::models::AuthUser>, crate::error::LificError> {
+    let conn = db.read()?;
+    match crate::db::queries::users::validate_session(&conn, token) {
+        Ok(user) => Ok(Some(crate::db::models::AuthUser {
+            id: user.id,
+            username: user.username,
+            display_name: user.display_name,
+            is_admin: user.is_admin,
+        })),
+        Err(crate::error::LificError::BadRequest(message))
+            if message == crate::db::queries::users::INVALID_SESSION_MESSAGE =>
+        {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn visible_projects_for(
+    db: &crate::db::DbPool,
+    auth_user: &crate::db::models::AuthUser,
+) -> Option<HashSet<i64>> {
+    crate::authz::visible_project_ids(db, &Some(auth_user.clone()))
+        .ok()
+        .flatten()
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EventVisibility {
+    Visible,
+    Hidden,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EventFlow {
+    Forward,
+    Drop,
+}
+
+fn event_flow(
+    db: &crate::db::DbPool,
+    auth_user: &crate::db::models::AuthUser,
+    message: &RealtimeMessage,
+) -> EventFlow {
+    match visible_to(db, auth_user, message) {
+        EventVisibility::Visible => EventFlow::Forward,
+        EventVisibility::Hidden => EventFlow::Drop,
+    }
+}
+
+fn visible_to(
+    db: &crate::db::DbPool,
+    auth_user: &crate::db::models::AuthUser,
+    message: &RealtimeMessage,
+) -> EventVisibility {
+    match &message.audience {
+        RealtimeAudience::Users(user_ids) => {
+            if auth_user.is_admin || user_ids.contains(&auth_user.id) {
+                EventVisibility::Visible
+            } else {
+                EventVisibility::Hidden
+            }
+        }
+        RealtimeAudience::Event => match message.event.project_id() {
+            Some(project_id) => match crate::authz::can_view_project(db, auth_user, project_id) {
+                Ok(true) => EventVisibility::Visible,
+                Ok(false) | Err(_) => EventVisibility::Hidden,
+            },
+            None => EventVisibility::Visible,
+        },
+    }
+}
+
+impl RealtimeEvent {
+    fn project_id(&self) -> Option<i64> {
+        match self {
+            Self::ProjectCreated { project_id }
+            | Self::ProjectUpdated { project_id }
+            | Self::ProjectDeleted { project_id }
+            | Self::IssueCreated { project_id, .. }
+            | Self::IssueUpdated { project_id, .. }
+            | Self::IssueDeleted { project_id, .. }
+            | Self::IssueLinked { project_id, .. }
+            | Self::IssueUnlinked { project_id, .. } => Some(*project_id),
+            Self::ResyncRequired | Self::ProjectsReordered => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_serializes_with_dotted_type() {
+        let event = RealtimeEvent::IssueUpdated {
+            project_id: 7,
+            issue_id: 42,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "issue.updated");
+        assert_eq!(json["project_id"], 7);
+        assert_eq!(json["issue_id"], 42);
+    }
+
+    #[tokio::test]
+    async fn lagged_receiver_requests_resync() {
+        let hub = RealtimeHub::with_capacity(1);
+        let mut rx = hub.subscribe();
+
+        hub.send(RealtimeEvent::ProjectUpdated { project_id: 1 });
+        hub.send(RealtimeEvent::ProjectUpdated { project_id: 2 });
+
+        assert!(matches!(rx.recv().await, Err(RecvError::Lagged(1))));
+        assert_eq!(
+            event_json(rx.recv().await.unwrap().message)["project_id"],
+            2
+        );
+    }
+
+    fn event_json(message: Message) -> serde_json::Value {
+        match message {
+            Message::Text(text) => serde_json::from_str(&text).unwrap(),
+            other => panic!("expected text event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn project_event_is_visible_to_project_viewer() {
+        let (db, auth_user, project_id, _) = visibility_fixture(true);
+        let event = RealtimeEvent::IssueUpdated {
+            project_id,
+            issue_id: 42,
+        };
+
+        assert_eq!(
+            visible_to(&db, &auth_user, &event_message(event)),
+            EventVisibility::Visible
+        );
+    }
+
+    #[test]
+    fn project_event_is_hidden_from_non_member_when_authz_is_enforced() {
+        let (db, auth_user, project_id, _) = visibility_fixture(false);
+        let event = RealtimeEvent::IssueUpdated {
+            project_id,
+            issue_id: 42,
+        };
+
+        assert_eq!(
+            visible_to(&db, &auth_user, &event_message(event)),
+            EventVisibility::Hidden
+        );
+    }
+
+    #[test]
+    fn deleted_project_snapshot_is_visible_after_project_is_deleted() {
+        let (db, auth_user, project_id, _) = visibility_fixture(true);
+        {
+            let conn = db.write().unwrap();
+            crate::db::queries::delete_project(&conn, project_id).unwrap();
+        }
+
+        let message = RealtimeMessage {
+            event: RealtimeEvent::ProjectDeleted { project_id },
+            message: Message::Text("{}".into()),
+            audience: RealtimeAudience::Users(vec![auth_user.id]),
+        };
+
+        assert_eq!(
+            visible_to(&db, &auth_user, &message),
+            EventVisibility::Visible
+        );
+    }
+
+    fn event_message(event: RealtimeEvent) -> RealtimeMessage {
+        RealtimeMessage {
+            event,
+            message: Message::Text("{}".into()),
+            audience: RealtimeAudience::Event,
+        }
+    }
+
+    fn visibility_fixture(
+        member: bool,
+    ) -> (crate::db::DbPool, crate::db::models::AuthUser, i64, String) {
+        let db = crate::db::open_memory().unwrap();
+        let (auth_user, project_id, token) = {
+            let conn = db.write().unwrap();
+            crate::db::queries::settings::update(
+                &conn,
+                crate::db::queries::settings::InstanceSettingsPatch {
+                    authz_enforced: Some(true),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let user = crate::db::queries::users::create_user(
+                &conn,
+                &crate::db::models::CreateUser {
+                    username: "viewer".into(),
+                    email: "viewer@example.test".into(),
+                    password: "password".into(),
+                    display_name: Some("Viewer".into()),
+                    is_admin: false,
+                    is_bot: false,
+                },
+            )
+            .unwrap();
+            let project = crate::db::queries::create_project(
+                &conn,
+                &crate::db::models::CreateProject {
+                    name: "Visible".into(),
+                    identifier: "VIS".into(),
+                    description: String::new(),
+                    emoji: None,
+                    lead_user_id: None,
+                },
+            )
+            .unwrap();
+            if member {
+                crate::db::queries::members::upsert_member(
+                    &conn,
+                    project.id,
+                    user.id,
+                    crate::db::models::Role::Viewer,
+                )
+                .unwrap();
+            }
+            let token = crate::db::queries::users::create_session(&conn, user.id, None)
+                .unwrap()
+                .token;
+            (
+                crate::db::models::AuthUser {
+                    id: user.id,
+                    username: user.username,
+                    display_name: user.display_name,
+                    is_admin: user.is_admin,
+                },
+                project.id,
+                token,
+            )
+        };
+        (db, auth_user, project_id, token)
+    }
+}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -21,6 +21,7 @@
   import ErrorState from "./lib/ErrorState.svelte";
   import Toaster from "./lib/toast/Toaster.svelte"; // LIF-243
   import { hasSession, getInstance, autoLogin, saveSession } from "./lib/api";
+  import { REALTIME_INVALIDATE_EVENT, type RealtimeEvent } from "./lib/autoRefresh.svelte";
   import { motionReduced } from "./lib/theme";
   import { fade } from "svelte/transition";
   import { onMount } from "svelte";
@@ -48,6 +49,9 @@
   // "bootstrapping" only when there's no session, so the logged-in common case
   // never shows a spinner.
   let bootstrapping = $state(!hasSession());
+  let realtimeSocket: WebSocket | null = null;
+  let realtimeReconnect: ReturnType<typeof setTimeout> | null = null;
+  let realtimeDelayMs = 1000;
 
   onMount(async () => {
     if (!hasSession()) {
@@ -58,11 +62,13 @@
       }
     }
     bootstrapping = false;
+    syncRealtimeSocket();
   });
 
   function navigate(path: string) {
     window.location.hash = path;
     route = path;
+    syncRealtimeSocket();
   }
 
   $effect(() => {
@@ -77,15 +83,14 @@
   $effect(() => {
     // Hold off until the single-user auto-login probe resolves, so we don't
     // flash /login and then bounce into the app once the session lands.
-    if (bootstrapping) return;
-    if (hasSession()) {
-      // LIF-237: "/" is now a real route (Home) rather than a redirect
-      // target — only /login and /signup bounce once a session exists.
-      if (route === "/login" || route === "/signup") {
-        redirectToDefault();
-      }
-    } else {
-      if (route !== "/login" && route !== "/signup") {
+    if (!bootstrapping) {
+      if (hasSession()) {
+        // LIF-237: "/" is now a real route (Home) rather than a redirect
+        // target — only /login and /signup bounce once a session exists.
+        if (route === "/login" || route === "/signup") {
+          redirectToDefault();
+        }
+      } else if (route !== "/login" && route !== "/signup") {
         navigate("/login");
       }
     }
@@ -96,6 +101,84 @@
   // project.)
   function redirectToDefault() {
     navigate("/");
+  }
+
+  function socketUrl(): string {
+    const url = new URL("/api/events/ws", window.location.origin);
+    url.protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return url.toString();
+  }
+
+  function closeRealtimeSocket() {
+    if (realtimeReconnect) {
+      clearTimeout(realtimeReconnect);
+      realtimeReconnect = null;
+    }
+    realtimeDelayMs = 1000;
+    if (realtimeSocket) {
+      realtimeSocket.close(1000, "teardown");
+      realtimeSocket = null;
+    }
+  }
+
+  function scheduleRealtimeReconnect() {
+    if (!realtimeReconnect && hasSession()) {
+      realtimeReconnect = window.setTimeout(() => {
+        realtimeReconnect = null;
+        syncRealtimeSocket();
+      }, realtimeDelayMs);
+      realtimeDelayMs = Math.min(realtimeDelayMs * 2, 10_000);
+    }
+  }
+
+  function hasLiveRealtimeSocket() {
+    return (
+      realtimeSocket?.readyState === WebSocket.OPEN ||
+      realtimeSocket?.readyState === WebSocket.CONNECTING
+    );
+  }
+
+  function syncRealtimeSocket() {
+    const shouldConnect = hasSession() && !bootstrapping;
+    const shouldOpen = shouldConnect && !hasLiveRealtimeSocket();
+
+    if (!shouldConnect) {
+      closeRealtimeSocket();
+    }
+
+    if (shouldOpen) {
+      openRealtimeSocket();
+    }
+  }
+
+  function openRealtimeSocket() {
+    const socket = new WebSocket(socketUrl());
+    realtimeSocket = socket;
+    socket.addEventListener("open", () => {
+      realtimeDelayMs = 1000;
+    });
+    socket.addEventListener("message", (message) => {
+      if (typeof message.data !== "string") return;
+      try {
+        const event = JSON.parse(message.data) as RealtimeEvent;
+        if (typeof event?.type === "string") {
+          window.dispatchEvent(
+            new CustomEvent<RealtimeEvent>(REALTIME_INVALIDATE_EVENT, { detail: event }),
+          );
+        }
+      } catch {
+        // HTTP refresh remains source of truth.
+      }
+    });
+    socket.addEventListener("close", () => {
+      if (realtimeSocket === socket) {
+        realtimeSocket = null;
+        scheduleRealtimeReconnect();
+      }
+    });
+    socket.addEventListener("error", () => {
+      socket.close();
+    });
   }
 
   type ParsedRoute =

--- a/web/src/lib/Layout.svelte
+++ b/web/src/lib/Layout.svelte
@@ -23,6 +23,7 @@
   import { toggleShortcutHelp } from "./shortcutHelpState.svelte";
   import { isTypingContext } from "./shortcuts";
   import { loadProjectRole } from "./projectRole.svelte"; // LIF-234
+  import { startAutoRefresh } from "./autoRefresh.svelte";
 
   // Ref to the command palette so the sidebar's "Jump to…" affordance can
   // summon it (LIF-192).
@@ -138,6 +139,17 @@
     refreshProjects();
     closeDrawer();
   });
+
+  $effect(() =>
+    startAutoRefresh({
+      refresh: refreshProjects,
+      isBusy: () => dragActive,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        event.type === "projects.reordered" ||
+        event.type.startsWith("project."),
+    }),
+  );
 
   async function loadUser() {
     const res = await me();

--- a/web/src/lib/autoRefresh.svelte.ts
+++ b/web/src/lib/autoRefresh.svelte.ts
@@ -1,26 +1,6 @@
-// LIF-129 — Tier 0 auto-refresh.
-//
-// The issue/page views load once on mount and then go stale: anything
-// that mutates data out-of-band (the MCP agent, the REST API, a second
-// tab) is invisible until you navigate away and back. This helper gives
-// those views a gentle "converge on server state" loop without any
-// backend change.
-//
-// Design constraints (the anti-enshittification rules from LIF-129):
-//   - Pause while the tab is hidden; refetch once the moment it's shown
-//     or the window regains focus. Focus-revalidation does most of the
-//     real work — the interval is just a backstop for a left-open tab.
-//   - Never refetch mid-interaction. The caller passes `isBusy()` and we
-//     skip any tick it vetoes (drag in progress, a popover open, inline
-//     create open, a page mid-edit, or a mutation in flight). A refresh
-//     that yanks state out from under the user is worse than a stale one.
-//   - Coalesce: visibility + focus can fire together; we debounce the
-//     eager revalidate so that's one fetch, not two.
-//
-// This intentionally owns no data and does no merging. Each view passes
-// its own `refresh` (which already knows how to load and how to keep
-// optimistic state coherent). Keeping the helper dumb keeps the per-view
-// safety logic where the state actually lives.
+// Auto-refresh keeps mounted views close to server state. It owns no data:
+// callers decide when a refresh is relevant and when local UI state is too
+// busy to disturb.
 
 export interface AutoRefreshOptions {
   /** Re-fetch the view's data. Should be safe to call repeatedly; the
@@ -35,7 +15,17 @@ export interface AutoRefreshOptions {
    *  timer) — used by the page detail view, where the body editor makes
    *  a periodic poll more disruptive than it's worth. */
   intervalMs?: number;
+  /** Return true when a realtime event is relevant to this mounted view. */
+  shouldRefresh?: (event: RealtimeEvent) => boolean;
 }
+
+export const REALTIME_INVALIDATE_EVENT = "lific:realtime";
+const BUSY_RETRY_MS = 2000;
+
+export type RealtimeEvent = {
+  type: string;
+  [key: string]: unknown;
+};
 
 /**
  * Start an auto-refresh loop. Returns a cleanup function that clears the
@@ -43,7 +33,7 @@ export interface AutoRefreshOptions {
  * tears down on unmount / dependency change:
  *
  * ```ts
- * $effect(() => startAutoRefresh({ refresh, isBusy, intervalMs: 15_000 }));
+ * $effect(() => startAutoRefresh({ refresh, isBusy }));
  * ```
  */
 export function startAutoRefresh(opts: AutoRefreshOptions): () => void {
@@ -52,49 +42,92 @@ export function startAutoRefresh(opts: AutoRefreshOptions): () => void {
     return () => {};
   }
 
-  const { refresh, isBusy, intervalMs } = opts;
+  const { refresh, isBusy, intervalMs, shouldRefresh } = opts;
 
   let timer: ReturnType<typeof setInterval> | null = null;
   let eagerDebounce: ReturnType<typeof setTimeout> | null = null;
+  let retryDebounce: ReturnType<typeof setTimeout> | null = null;
   let disposed = false;
+  let refreshing = false;
+  let pending = false;
 
-  const hidden = () => document.hidden;
-  const busy = () => (isBusy ? isBusy() : false);
+  function schedulePendingRetry() {
+    if (!disposed && !retryDebounce) {
+      retryDebounce = setTimeout(() => {
+        retryDebounce = null;
+        if (pending) void runRefresh();
+      }, BUSY_RETRY_MS);
+    }
+  }
 
-  function tick() {
-    if (disposed || hidden() || busy()) return;
-    void refresh();
+  async function runRefresh() {
+    const busy = isBusy?.() ?? false;
+    const waiting = disposed || document.hidden || busy || refreshing;
+
+    pending ||= busy || refreshing;
+    if (busy) schedulePendingRetry();
+
+    if (!waiting) {
+      pending = false;
+      refreshing = true;
+      try {
+        await refresh();
+      } catch (err) {
+        console.warn("auto-refresh failed", err);
+      } finally {
+        refreshing = false;
+      }
+      if (pending) {
+        pending = false;
+        void runRefresh();
+      }
+    }
   }
 
   // Visibility/focus revalidate, debounced so the visibilitychange +
   // window.focus pair that fires on tab-switch-back is a single fetch.
   function scheduleEager() {
-    if (disposed || hidden()) return;
-    if (eagerDebounce) clearTimeout(eagerDebounce);
-    eagerDebounce = setTimeout(() => {
-      eagerDebounce = null;
-      if (disposed || hidden() || busy()) return;
-      void refresh();
-    }, 50);
+    if (!disposed && !document.hidden) {
+      if (eagerDebounce) clearTimeout(eagerDebounce);
+      eagerDebounce = setTimeout(() => {
+        eagerDebounce = null;
+        void runRefresh();
+      }, 50);
+    }
   }
 
   function onVisibility() {
-    if (document.hidden) return;
-    scheduleEager();
+    if (!document.hidden) {
+      scheduleEager();
+    }
+  }
+
+  function onRealtime(event: Event) {
+    const detail = (event as CustomEvent<RealtimeEvent>).detail;
+    if (detail && shouldRefresh?.(detail)) {
+      scheduleEager();
+    }
   }
 
   document.addEventListener("visibilitychange", onVisibility);
   window.addEventListener("focus", scheduleEager);
+  if (shouldRefresh) {
+    window.addEventListener(REALTIME_INVALIDATE_EVENT, onRealtime);
+  }
 
   if (intervalMs && intervalMs > 0) {
-    timer = setInterval(tick, intervalMs);
+    timer = setInterval(() => void runRefresh(), intervalMs);
   }
 
   return () => {
     disposed = true;
     if (timer) clearInterval(timer);
     if (eagerDebounce) clearTimeout(eagerDebounce);
+    if (retryDebounce) clearTimeout(retryDebounce);
     document.removeEventListener("visibilitychange", onVisibility);
     window.removeEventListener("focus", scheduleEager);
+    if (shouldRefresh) {
+      window.removeEventListener(REALTIME_INVALIDATE_EVENT, onRealtime);
+    }
   };
 }

--- a/web/src/routes/Home.svelte
+++ b/web/src/routes/Home.svelte
@@ -44,6 +44,7 @@
     Moon,
   } from "lucide-svelte";
   import { getContext } from "svelte";
+  import { startAutoRefresh } from "../lib/autoRefresh.svelte";
 
   const topbarCtx = getContext<{
     set: (s: import("svelte").Snippet | undefined) => void;
@@ -74,17 +75,33 @@
     loadData();
   });
 
-  async function loadData() {
-    loading = true;
-    error = "";
+  $effect(() =>
+    startAutoRefresh({
+      refresh: () => loadData(false),
+      isBusy: () => loading,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        event.type.startsWith("project.") ||
+        event.type.startsWith("issue."),
+    }),
+  );
+
+  async function loadData(initial = true) {
+    if (initial) {
+      loading = true;
+      error = "";
+    }
     recents = getRecents();
 
     const [meRes, projRes] = await Promise.all([me(), listProjects()]);
     if (!meRes.ok) {
+      if (initial) {
       error = meRes.error;
       loading = false;
+      }
       return;
     }
+    error = "";
     user = meRes.data;
     if (projRes.ok) projects = projRes.data;
 
@@ -123,7 +140,7 @@
       activityItems = [];
     }
 
-    loading = false;
+    if (initial) loading = false;
   }
 
   function topProjectIds(issues: Issue[], projs: Project[]): number[] {
@@ -385,7 +402,7 @@
       <ErrorState title="Couldn't load your dashboard" message={error}>
         <button
           class="text-body-sm font-medium text-[var(--btn-success-text)] bg-[var(--btn-success)] px-3 py-1.5 rounded-md hover:bg-[var(--btn-success-hover)] transition-colors"
-          onclick={loadData}
+          onclick={() => loadData()}
         >
           Try again
         </button>

--- a/web/src/routes/IssueDetail.svelte
+++ b/web/src/routes/IssueDetail.svelte
@@ -26,6 +26,7 @@
   import { scheduleDelete } from "../lib/issues/deferredDelete.svelte"; // LIF-283
   import { openPeek } from "../lib/issues/peek.svelte"; // LIF-248
   import { projectRole, loadProjectRole } from "../lib/projectRole.svelte"; // LIF-234
+  import { startAutoRefresh } from "../lib/autoRefresh.svelte";
   import { toast } from "../lib/toast/toast.svelte"; // LIF-284
   import { ArrowUpRight } from "lucide-svelte";
 
@@ -81,6 +82,7 @@
 
   // Sidebar dropdown states (issue-specific; the body's read/edit mode
   // lives inside DocumentDetail).
+  let bodyMode = $state<"read" | "edit">("read");
   let statusOpen = $state(false);
   let priorityOpen = $state(false);
   let moduleOpen = $state(false);
@@ -120,8 +122,29 @@
     loadIssue(id);
   });
 
-  async function loadIssue(identifier: string) {
-    loading = true;
+  $effect(() =>
+    startAutoRefresh({
+      refresh: () => loadIssue(issueIdentifier, true),
+      isBusy: () =>
+        bodyMode === "edit" ||
+        saving ||
+        loading ||
+        statusOpen ||
+        priorityOpen ||
+        moduleOpen ||
+        labelsOpen,
+      intervalMs: 0,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        (typeof event.issue_id === "number" && event.issue_id === issue?.id) ||
+        (event.type.startsWith("project.") &&
+          typeof event.project_id === "number" &&
+          event.project_id === issue?.project_id),
+    }),
+  );
+
+  async function loadIssue(identifier: string, background = false) {
+    loading = !background;
     error = "";
     const res = await resolveIssue(identifier);
     if (!res.ok) {
@@ -451,6 +474,7 @@
   bodyEmptyReadText="No description"
   bodyProseMinHeight="60px"
   onSaveBody={saveDescription}
+  bind:bodyMode
   autofocusWhenEmpty
   {saving}
   {lastSaved}

--- a/web/src/routes/IssueList.svelte
+++ b/web/src/routes/IssueList.svelte
@@ -330,7 +330,9 @@
     startAutoRefresh({
       refresh: refreshIssues,
       isBusy: autoRefreshBusy,
-      intervalMs: 15_000,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        (typeof event.project_id === "number" && event.project_id === project?.id),
     }),
   );
 
@@ -2075,6 +2077,5 @@
     onHoverModuleOption={(mi) => { view.modulePickerIdx = mi; }}
   />
 {/snippet}
-
 
 

--- a/web/src/routes/PageDetail.svelte
+++ b/web/src/routes/PageDetail.svelte
@@ -123,12 +123,14 @@
   // the request was in flight.
   async function refreshPage() {
     const gen = loadGen;
-    const [res, actRes] = await Promise.all([
+    const [res, commentsRes, actRes] = await Promise.all([
       getPage(pageId),
+      listPageComments(pageId),
       listPageActivity(pageId),
     ]);
     if (gen !== loadGen) return; // navigated away mid-flight — discard
     if (res.ok) page = res.data;
+    if (commentsRes.ok) comments = commentsRes.data;
     if (actRes.ok) activity = actRes.data.items;
   }
 
@@ -140,6 +142,11 @@
       isBusy: () => bodyMode === "edit" || saving || loading,
       // Focus-only — no background interval for the page editor.
       intervalMs: 0,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        (event.type.startsWith("project.") &&
+          typeof event.project_id === "number" &&
+          event.project_id === page?.project_id),
     }),
   );
 

--- a/web/src/routes/PageList.svelte
+++ b/web/src/routes/PageList.svelte
@@ -289,8 +289,15 @@
     ]);
     if (pRes.ok) pages = pRes.data;
     if (fRes.ok) {
+      const previousFolderIds = new Set(folders.map((folder) => folder.id));
+      const nextFolderIds = new Set(fRes.data.map((folder) => folder.id));
       folders = fRes.data;
-      expandedFolders = new Set(fRes.data.map((f: Folder) => f.id));
+      expandedFolders = new Set(
+        [...expandedFolders].filter((id) => nextFolderIds.has(id)),
+      );
+      for (const folder of fRes.data) {
+        if (!previousFolderIds.has(folder.id)) expandedFolders.add(folder.id);
+      }
     }
     if (lRes.ok) labels = lRes.data;
     loading = false;
@@ -298,22 +305,32 @@
 
   async function reloadPages() {
     if (!project) return;
-    const res = await listPages(
-      project.id,
-      undefined,
-      filterLabel || undefined,
-      serverStatusFilter(),
-    );
-    if (res.ok) pages = res.data;
+    const [pagesRes, foldersRes, labelsRes] = await Promise.all([
+      listPages(project.id, undefined, filterLabel || undefined, serverStatusFilter()),
+      listFolders(project.id),
+      listLabels(project.id),
+    ]);
+    if (pagesRes.ok) pages = pagesRes.data;
+    if (foldersRes.ok) {
+      const previousFolderIds = new Set(folders.map((folder) => folder.id));
+      const nextFolderIds = new Set(foldersRes.data.map((folder) => folder.id));
+      folders = foldersRes.data;
+      expandedFolders = new Set(
+        [...expandedFolders].filter((id) => nextFolderIds.has(id)),
+      );
+      for (const folder of foldersRes.data) {
+        if (!previousFolderIds.has(folder.id)) expandedFolders.add(folder.id);
+      }
+    }
+    if (labelsRes.ok) labels = labelsRes.data;
   }
 
   // ── LIF-129: auto-refresh ────────────────────────────
-  // Background poll (15s) + revalidate on tab focus so the page tree picks
-  // up pages created/edited/deleted out-of-band. Vetoed while dragging a
+  // Revalidate on tab focus and relevant realtime events so the page tree
+  // picks up pages created/edited/deleted out-of-band. Vetoed while dragging a
   // page/folder, while an inline create input is open, or while the
   // search box is focused — refreshing under any of those would yank the
-  // user's interaction. Only re-pulls pages (folders/labels change rarely
-  // and reconcile on the next mount/navigation).
+  // user's interaction. The refresh keeps the full project tree in sync.
   function autoRefreshBusy(): boolean {
     return (
       loading ||
@@ -327,7 +344,9 @@
     startAutoRefresh({
       refresh: reloadPages,
       isBusy: autoRefreshBusy,
-      intervalMs: 15_000,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        (typeof event.project_id === "number" && event.project_id === project?.id),
     }),
   );
 

--- a/web/src/routes/PlanDetail.svelte
+++ b/web/src/routes/PlanDetail.svelte
@@ -96,7 +96,11 @@
         addingChildOf !== null ||
         editingTitleOf !== null ||
         editingDescOf !== null,
-      intervalMs: 15_000,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        (event.type.startsWith("project.") &&
+          typeof event.project_id === "number" &&
+          event.project_id === plan?.project_id),
     }),
   );
 

--- a/web/src/routes/PlanList.svelte
+++ b/web/src/routes/PlanList.svelte
@@ -64,7 +64,9 @@
     startAutoRefresh({
       refresh: reload,
       isBusy: () => creating || createSaving,
-      intervalMs: 15_000,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        (typeof event.project_id === "number" && event.project_id === project?.id),
     }),
   );
 
@@ -287,5 +289,3 @@
     {/if}
   </div>
 </div>
-
-

--- a/web/src/routes/ProjectActivity.svelte
+++ b/web/src/routes/ProjectActivity.svelte
@@ -125,7 +125,9 @@
     startAutoRefresh({
       refresh: refreshFeed,
       isBusy: () => loading || loadingMore,
-      intervalMs: 15_000,
+      shouldRefresh: (event) =>
+        event.type === "resync.required" ||
+        (typeof event.project_id === "number" && event.project_id === project?.id),
     }),
   );
 


### PR DESCRIPTION
## Summary

Adds a small realtime invalidation path for the web UI: writes broadcast that affected issue/project data changed, and mounted views refetch through their existing HTTP loaders. The socket does not stream canonical object state or try to merge data client-side.

This keeps the change scoped to the delay called out in #3 while covering both write paths that can change what the UI is showing: REST handlers and MCP tools.

## What Changed

- Adds an authenticated `/api/events/ws` endpoint backed by the existing browser session cookie.
- Applies websocket-safe origin handling: non-browser clients without `Origin`, same-origin browser requests, or explicitly configured origins are accepted.
- Broadcasts issue/project invalidation events from REST writes, including relation link/unlink with the correct project for each affected issue.
- Broadcasts matching invalidation events from MCP writes, including authless MCP.
- Keeps the realtime event enum limited to events this PR actually emits.
- Replaces broad refresh-on-everything behavior with relevant-event refresh checks, coalescing, and logged refresh failures.
- Removes the old 15-second polling from the views now covered by focus revalidation plus websocket invalidation.

## Deliberate Scope

This is invalidation-only realtime. HTTP remains the source of truth for view data.
