### PR TITLE
docs: specify REST API contracts

### DIFF
--- a/site/content/docs/concepts/projects.mdx
+++ b/site/content/docs/concepts/projects.mdx
@@ -26,9 +26,10 @@ Project membership connects one user to one project role. The roles are ordered 
 
 | Role | Permission level |
 | --- | --- |
-| `viewer` | Read-level access |
-| `maintainer` | Maintainer-level access |
-| `lead` | Lead-level access |
+| `viewer` | Read project resources and create/read comments. |
+| `maintainer` | Viewer access plus issue/page/plan content mutations, issue relations and plan-step links, and project structure mutations such as modules, labels, and folders. |
+| `lead` | Maintainer access plus project settings, membership/role management, and project deletion. |
+| administrator | Bypasses project membership checks. Workspace-level administrative actions still require administrator access. |
 
 A project can have a primary lead. Setting a primary lead also creates or updates that user's `lead` membership. A project can have more than one member with the `lead` role.
 
@@ -38,7 +39,9 @@ The system prevents removal or demotion of the last `lead` member. Another membe
 
 Project-scoped authorization is controlled by the instance setting `authz_enforced`.
 
-When enforcement is enabled, a user must be a project member with a sufficient role to access project content. Viewer access is used for reads. Maintainer access is used for content mutations. Lead access is used for lead-level actions. Administrators pass project access checks.
+When enforcement is enabled, a user must be a project member with a sufficient role to access project content. Viewer access is used for reads. Maintainer access is used for content, structure, relation, and plan-step mutations. Lead access is used for project settings, membership, and deletion. Administrators pass project access checks. Workspace-level page mutations require an administrator; project-page mutations use the containing project's role.
+
+Operations that touch two projects, such as linking issues or attaching an issue to a plan step, require the required role in both projects. API clients can inspect their effective role with `GET /api/projects/{id}/my-role`.
 
 When enforcement is disabled, membership rows do not create default-deny visibility. Interfaces retain their legacy permission behavior.
 

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -81,6 +81,8 @@ required = true
 
 Use an HTTPS URL for `public_url` when Lific is exposed through a public HTTPS endpoint. The server includes the configured hostname in its MCP host allowlist for reverse proxy requests.
 
+`trusted_proxies` identifies proxy hops, not trusted clients. Forwarding headers are ignored unless the immediate TCP peer is in this list. For a trusted peer, Lific walks `X-Forwarded-For` from right to left, skips configured proxy addresses, and uses the first untrusted address as the client IP. It uses `X-Real-IP` only when `X-Forwarded-For` is absent. Malformed or entirely trusted chains fall back to the TCP peer, and IPv4-mapped IPv6 addresses are normalized. List every proxy layer you operate; do not add client networks merely because they appear in a header.
+
 `mcp_path_token` bypasses API key and OAuth authentication. Anyone who knows the resulting URL can use the endpoint. Use a long random token and HTTPS when this key is configured.
 
 ## `[database]`
@@ -115,7 +117,9 @@ Automatic backups use the same archive format as `lific dump`.
 | `allow_signup` | boolean | `true` | Initial self-service signup setting. Lific seeds the database-backed instance setting from this value when it first creates the setting. Later changes through instance settings are stored in the database. |
 | `required` | boolean | `true` | Requires a bearer credential on REST and MCP requests. |
 
-When `required = false`, a request with no credential is treated as an operator request. A request with an invalid credential still fails authentication. Lific refuses to start with `required = false` when `server.public_url` is not a localhost URL.
+When `required = false`, a request with no credential is treated as an operator request. In the web UI, the browser automatically signs in as the first administrator; a new instance with no accounts shows signup once so an attribution identity can be created. A request with an invalid credential still fails authentication. Lific refuses to start with `required = false` when `server.public_url` is not a localhost URL.
+
+The `public_url` guard does not restrict the listener. Because the default `host` is `0.0.0.0`, an auth-disabled instance may still be reachable from the LAN. Bind it to `127.0.0.1` or protect it with a firewall.
 
 The runtime `secure_cookies` value is not a TOML key. Lific derives it at startup. It is false only when `server.public_url` explicitly begins with `http://`. It is true for HTTPS and for an unset public URL.
 

--- a/site/content/docs/rest-api/index.mdx
+++ b/site/content/docs/rest-api/index.mdx
@@ -28,6 +28,24 @@ API keys use the `lific_sk` prefix. Session tokens use the `lific_sess_` prefix.
 
 `GET /api/events/ws` is not Bearer authenticated. It requires a valid `lific_token` cookie containing a session token. `GET /api/attachments/{id}` also accepts that session cookie for browser downloads. Other attachment requests require a Bearer header.
 
+## Authorization by endpoint family
+
+When `authz_enforced` is enabled, REST handlers use the following minimum roles. Administrators bypass project membership checks.
+
+| Operation family | Minimum access |
+| --- | --- |
+| Project content reads, issue/page/plan reads, search, and activity | `viewer` on the relevant project |
+| Issue/page/plan/comment content mutations, relations, plan-step links, modules, labels, and folders | `maintainer` on the relevant project; cross-project operations require it in both projects |
+| Project settings, membership/role changes, and project deletion | `lead` on the project |
+| Workspace-level page reads/mutations | Workspace rules; mutations require an administrator |
+| Attachment upload | Any authenticated user; the resulting attachment is private until linked or otherwise authorized |
+| Linked attachment list/download | `viewer` on an owning project; an unlinked attachment is readable only by its uploader or an administrator |
+| Attachment deletion | The uploader, a project `maintainer` on an owning project, or an administrator |
+
+Saved views are additionally caller-owned: a member can list or modify only their own views, and every saved-view request requires an authenticated user.
+
+This matrix applies to project-scoped requests made by users and bot identities. Instance administrators and operator-trusted credentials intentionally bypass project membership checks; auth-disabled requests are operator-equivalent, and instance-scoped endpoints have their own authentication rules.
+
 ## Content types
 
 JSON request bodies use `Content-Type: application/json`.

--- a/site/content/docs/rest-api/projects.mdx
+++ b/site/content/docs/rest-api/projects.mdx
@@ -150,19 +150,39 @@ Response: an object with `role` (string or null), `enforced` (boolean), and `is_
 
 Lists saved views owned by the caller for one project. Path parameter: `id` (integer project ID). It has no query parameters or request body.
 
-Response: an array of objects with `id` (integer), `project_id` (integer), `user_id` (integer), `name` (string), `config` (string containing JSON), `is_default` (boolean), `created_at` (string), and `updated_at` (string).
+Response: an array of objects with `id` (integer), `project_id` (integer), `user_id` (integer), `name` (string), `config` (string containing JSON), `is_default` (boolean), `created_at` (string), and `updated_at` (string). Views are returned only for the authenticated caller.
 
 ### POST `/api/projects/{id}/views`
 
 Creates a saved view owned by the caller. Path parameter: `id` (integer project ID). It has no query parameters.
 
-Request body fields are `name` (string), `config` (string containing valid JSON), and `is_default` (boolean, optional). Response: a saved view object.
+Request body fields are `name` (string), `config` (string containing valid JSON, at most 8 KiB), and `is_default` (boolean, optional). Response: a saved view object. The server treats `config` as opaque JSON; the web client currently uses the shape below and tolerates missing fields when applying older views.
+
+```json
+{
+  "version": 1,
+  "layout": "list",
+  "filterStatus": "",
+  "filterPriority": "",
+  "filterLabel": "",
+  "filterModule": "",
+  "searchQuery": "",
+  "sortField": "updated",
+  "sortDir": "desc",
+  "groupBy": "status",
+  "density": "comfortable",
+  "laneBy": "status",
+  "hiddenStatuses": []
+}
+```
+
+The recognized client fields are `version`, `layout` (`list` or `board`), filters, `searchQuery`, sorting, `groupBy`, `density`, `laneBy`, and `hiddenStatuses`. Clients may evolve this object without a database migration; invalid JSON is rejected, while unknown or missing fields are tolerated by the web client.
 
 ### PATCH `/api/projects/{id}/views/{view_id}`
 
 Updates a caller-owned saved view. Path parameters are `id` (integer project ID) and `view_id` (integer saved view ID). It has no query parameters.
 
-Request body fields are `name` (string, optional), `config` (string containing valid JSON, optional), and `is_default` (boolean, optional). Response: a saved view object.
+Request body fields are `name` (string, optional), `config` (string containing valid JSON, at most 8 KiB, optional), and `is_default` (boolean, optional). Response: a saved view object. The caller must own the view.
 
 ### DELETE `/api/projects/{id}/views/{view_id}`
 

--- a/site/content/docs/rest-api/work.mdx
+++ b/site/content/docs/rest-api/work.mdx
@@ -349,9 +349,11 @@ It has no path parameters or request body. Response: an attachment array. Each a
 
 ### POST `/api/attachments`
 
-Uploads a `file` part in a multipart request. Optional `entity_type` and `entity_id` form fields immediately link the attachment to an issue, page, or comment.
+Uploads a `file` part in a multipart request. Uploads require authentication. The production default maximum is 10 MiB per file and the per-user rate limit is 30 uploads per 10 minutes. Optional `entity_type` and `entity_id` form fields immediately link the attachment to an issue, page, or comment; otherwise the attachment remains unlinked until content is saved and rescanned.
 
 Form fields are `file` (file, required), `entity_type` (string, optional), and `entity_id` (integer, optional). Response: an object with `id` (integer), `url` (string), `filename` (string), `mime` (string), and `size` (integer).
+
+Allowed content types are PNG, JPEG, GIF, WebP, SVG, PDF, plain text, and ZIP. Lific validates magic bytes where available, rejects empty files and executable-looking content, normalizes the stored MIME, and does not trust the client-declared type alone. The maximum can be configured per instance. Unlinked attachments are swept by the hourly orphan collector after their grace period; content-addressed blobs are removed only when no attachment row still references them.
 
 ```bash
 curl -X POST https://your-server.example/api/attachments \
@@ -401,7 +403,16 @@ Response: Markdown bytes with `Content-Type: text/markdown; charset=utf-8`.
 
 Exports a project. Path parameter: `identifier` (string such as `LIF`). Query parameter: `format` (string, optional). `format` accepts `zip` by default or `json`.
 
-It has no request body. Response: ZIP bytes for `format=zip`. For `format=json`, the response is an export bundle JSON object. The bundle structure is defined by the export implementation and is not a REST request schema.
+It has no request body. Response: ZIP bytes for `format=zip`. For `format=json`, the response is an export bundle with `root` (string) and `files` (array). Each `files` item has `path` (string) and `content` (string). The JSON form is a serialization of the ZIP file list; paths and content are not a versioned request schema, so consumers should tolerate new files and avoid assuming a fixed complete list.
+
+```json
+{
+  "root": "LIF",
+  "files": [
+    { "path": "LIF/issues/lif-1-example.md", "content": "# Example\n" }
+  ]
+}
+```
 
 ## Search, health, and realtime
 
@@ -424,6 +435,10 @@ Response: plain text `ok`.
 Upgrades the request to a WebSocket that receives project and issue update events. It has no path or query parameters. It has no request body.
 
 The request requires a `lific_token` cookie containing a valid session token. Response: a WebSocket connection. Event JSON uses a `type` field. Event types are `resync.required`, `project.created`, `project.updated`, `project.deleted`, `projects.reordered`, `issue.created`, `issue.updated`, `issue.deleted`, `issue.linked`, and `issue.unlinked`.
+
+Events are invalidation signals, not complete resource snapshots. `project.updated` covers changes to non-issue project resources such as pages, plans, comments, labels, folders, and modules; clients should refetch the affected view. On `resync.required`, refetch visible projects and the current resource state before resuming incremental updates. The server filters events by the caller's visible projects, revalidates the session about once per minute, and closes the connection when the session becomes invalid. A user may have at most 16 concurrent event sockets.
+
+These events cover writes routed through the running HTTP/MCP server. CLI data commands and stdio MCP access SQLite directly and cannot publish into another Lific process's in-memory hub; clients should refresh or rely on normal revalidation after such direct database changes.
 
 ```json
 {

--- a/site/content/docs/self-hosting.mdx
+++ b/site/content/docs/self-hosting.mdx
@@ -106,6 +106,8 @@ Each archive contains these entries.
 
 On Unix, completed archives use owner-only `0600` permissions. The backup task retains the newest `backup.retain` matching archives and removes older matching archives. It also counts legacy `.db` backup artifacts during rotation.
 
+Failed backup staging files are cleaned immediately, and the automatic backup task removes stale staging artifacts left by interrupted runs.
+
 ## Manual backup and restore
 
 `lific dump` writes the same archive format as the automatic backup task. It can run while the server is running because the database snapshot uses `VACUUM INTO`.
@@ -145,6 +147,10 @@ trusted_proxies = ["127.0.0.0/8", "::1/128"]
 ```
 
 When a proxy supplies client IP headers, add only that proxy's addresses or CIDR ranges to `server.trusted_proxies`. Lific validates this configuration at startup. The default trusts loopback proxy addresses only.
+
+The proxy must forward `/api/events/ws` as a WebSocket connection, including the `Upgrade` and `Connection` headers, and must allow an idle timeout long enough for the session to remain connected. If ordinary page actions and REST requests work but changes in other tabs or agent writes do not appear live, test the WebSocket Upgrade path and proxy timeout before debugging the application.
+
+Lific trusts the proxy, not the header: it accepts client-IP forwarding only from a configured immediate peer, walks `X-Forwarded-For` right-to-left, skips trusted proxy hops, and chooses the first untrusted address. `X-Real-IP` is used only without XFF; malformed or all-trusted chains fall back to the TCP peer.
 
 `server.cors_origins = []` allows every browser origin. Set explicit origins when the deployment requires a browser origin allowlist.
 


### PR DESCRIPTION
This patch documents the REST and operational contracts that maintainers need to keep stable.

It adds the project-role matrix and cross-project authorization rules, saved-view and export formats, attachment lifecycle constraints, WebSocket invalidation and resync behavior, auth-disabled browser/LAN behavior, trusted-proxy requirements, reverse-proxy WebSocket setup, and backup staging cleanup.