### PR TITLE
docs: add Web UI and 2.0-to-2.2 upgrade guides

### DIFF
--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: An overview of Lific and its documentation.
 ---
 
-Lific is a local-first issue tracker. It runs as a single Rust binary. It stores data in SQLite.
+Lific is a local-first issue tracker: it runs on your machine, stores its data locally in SQLite and the attachments directory, and requires no hosted Lific service. A Lific instance is one authoritative source of truth; separate instances do not synchronize or merge. It runs as a single Rust binary.
 
 The binary provides an embedded Svelte web UI, a command-line interface, a REST API, and an MCP server. The web UI assets are embedded from the frontend build output.
 
@@ -13,6 +13,8 @@ The binary provides an embedded Svelte web UI, a command-line interface, a REST 
 - [Quickstart](/docs/quickstart) covers initializing an instance and creating a first issue.
 - [Connect agents](/docs/connect) covers `lific connect`, which writes MCP configuration for installed AI tools.
 - [Windows](/docs/windows) covers native Windows setup and WSL 2.
+- [Web UI guide](/docs/web-ui) covers dashboard, issue views, pages, plans, accounts, and mobile workflows.
+- [Upgrade from 2.0 to 2.2](/docs/upgrading) covers backups, version-specific changes, authorization, and verification.
 - [Concepts](/docs/concepts) describes Lific resources and identifiers.
 - [CLI](/docs/cli) documents command-line operations.
 - [Configuration](/docs/configuration) documents `lific.toml` and command-line overrides.

--- a/site/content/docs/meta.json
+++ b/site/content/docs/meta.json
@@ -5,6 +5,8 @@
     "quickstart",
     "connect",
     "windows",
+    "web-ui",
+    "upgrading",
     "concepts",
     "cli",
     "configuration",

--- a/site/content/docs/upgrading.mdx
+++ b/site/content/docs/upgrading.mdx
@@ -1,0 +1,80 @@
+---
+title: Upgrade from 2.0 to 2.2
+description: Back up, upgrade, verify, and adopt the v2.1 and v2.2 changes from an existing Lific 2.0 installation.
+---
+
+This guide covers upgrades from Lific 2.0 through 2.2. It assumes an existing 2.0 instance and deliberately does not describe older migration paths.
+
+## Before upgrading
+
+1. Record the selected configuration and database paths with `lific instance info` and your service status command.
+2. Make a complete backup while the service is stopped or quiesced:
+
+   ```shell
+   lific dump --out ./lific-before-2.2.tar.gz
+   ```
+
+   The archive includes a consistent database snapshot, attachments, and `manifest.json`.
+3. Record how clients connect: browser URL, API-key users, OAuth clients, and MCP configuration files. Keep one known-good operator key available for recovery.
+4. If the instance is behind a reverse proxy, review `server.trusted_proxies` before starting 2.2. Add only proxy networks you operate; the default trusts loopback proxies.
+
+Stop the background service before replacing the binary or restoring a backup. Keep the same `lific.toml`, database path, attachments directory, and public URL unless you are intentionally relocating the instance.
+
+## Changes to account for
+
+### v2.1
+
+- `lific member` manages project membership and roles from the CLI.
+- `lific user set-password` provides an operator password reset and invalidates the user's sessions.
+- `--config` is honored by `init` and service installation, and configuration/database discovery follows standard OS directories.
+- Private instances may set `[auth] required = false`; this is a shell-controlled operator setting and must remain local or firewalled.
+
+### v2.2
+
+- Browser views use credentialed realtime invalidation. Sessions are revalidated, connections are capped per user, and reconnects trigger a resync.
+- `server.trusted_proxies` controls when forwarded client-IP headers are trusted for rate limiting.
+- MCP output is compact by default. Use the documented opt-in fields such as `include_closed`, `include_comments`, or `echo_tree` when an agent needs the full view.
+- MCP search supports literal mode, comments are searchable, and list/comment operations expose pagination hints.
+- The web UI adds list sub-tabs, sidebar recents, touch page movement, PWA install metadata, and improved command-palette results.
+- Auth-optional mode now reaches the browser through the instance auto-login flow; with no accounts, the signup screen still appears.
+
+### v2.2.1
+
+- The three export MCP tools are now one `export` tool. It dispatches by identifier: `PRO-42` for an issue, `PRO-DOC-3` for a page, and bare `PRO` for a project.
+- The MCP surface is 27 tools. Clients that assumed the older 29-tool count or the removed export tool names must refresh their discovery data.
+
+## Upgrade and verify
+
+1. Install the v2.2 binary and restart the existing service.
+2. Run `lific doctor` with the operator credential. Resolve configuration, database, backup, server, OAuth, and MCP failures before opening the instance to users.
+3. Check `lific instance info` and confirm the expected database, public URL, signup policy, and `authz_enforced` state.
+4. Review membership and operator keys:
+
+   ```shell
+   lific key list
+   lific member list --project <PROJECT>
+   ```
+
+   Unbound API keys are operator-trusted/admin-equivalent because they can only be minted with shell access. Audit or rotate any key that is no longer needed. Use user-owned bot keys when an agent should inherit project membership.
+5. Test the browser login and one representative project workflow. Confirm issue, page, plan, comment, attachment, and saved-view data before testing writes.
+6. Test one API and one MCP client. For MCP, refresh tool discovery and replace calls to `export_issue`, `export_page`, or `export_project` with `export`.
+7. If the instance uses a proxy, confirm the server logs the expected client IP and that rate limits do not trust arbitrary forwarded headers.
+8. Keep the pre-upgrade archive until the browser, API, MCP, backups, and service restart have all been verified.
+
+## Authorization rollout
+
+An existing 2.0 instance keeps its persisted authorization setting during the upgrade. Inspect it before changing anything. With enforcement on, viewers can read and comment, maintainers can mutate project content and structure, and leads manage settings, membership, and deletion. Cross-project relations and plan-step links require the appropriate role in every project involved.
+
+To change the setting deliberately:
+
+```shell
+lific instance set --authz-enforced true
+```
+
+Before enabling it, ensure every human and bot that needs access has a project membership, and keep an operator-trusted key available for recovery. To roll back the setting on a private instance, use `--authz-enforced false` and then investigate the missing membership or role rather than distributing a broader key.
+
+For a private local deployment, `[auth] required = false` is a separate setting from project authorization. It grants credential-less operator access and is unsafe on a public URL; Lific refuses that combination at startup. Treat both settings as operator changes that require shell access and a verification step.
+
+## If the upgrade fails
+
+Stop the service, preserve its logs and the failed database state, and do not repeatedly rerun migrations against the only copy. Restore the pre-upgrade archive to a separate data directory or use `lific restore <ARCHIVE> --force` only after confirming the archive and intended target. Re-run `lific doctor`, then compare the restored instance's configuration and client credentials before switching traffic back.

--- a/site/content/docs/web-ui.mdx
+++ b/site/content/docs/web-ui.mdx
@@ -1,0 +1,62 @@
+---
+title: Web UI guide
+description: Task-oriented guide to Lific's dashboard, issue views, pages, plans, and account settings.
+---
+
+The web UI is the browser workspace for Lific. Use it for visual triage, Markdown editing, project navigation, and account administration; use the [CLI](/docs/cli), [REST API](/docs/rest-api), or [MCP](/docs/mcp) when you need scripts or agents.
+
+## Start with My Work
+
+The home dashboard groups active issues by project and provides recently viewed items, pinned pages, an activity digest, and quick actions. Use it as the jump-off point for work that spans several projects.
+
+## Navigate project work
+
+Each project keeps its own navigation state. Issue tabs are All, Recent, Open, and Closed; page tabs are Browse, Recent, Drafts, and Archived; plan tabs are Active, Done, Archived, and All; and module tabs are Active, Backlog, Archive, and All. Count badges show the current totals, and the selected tab persists per project and resource area.
+
+The sidebar shows recent items for the active section and deliberately excludes transient search results and items from unrelated sections. Its width is resizable and persists in the browser.
+
+## Triage issues
+
+Open a project's issue list to:
+
+- switch between All, Recent, Open, and Closed sub-tabs;
+- filter by status, priority, module, or label;
+- search, sort, group, and choose list density;
+- save a named view for your own filters, grouping, sorting, layout, swimlanes, and hidden statuses; and
+- switch between list and board layouts.
+
+Board views support status or priority swimlanes, collapsible columns, and hidden columns. On small screens, the board snaps to a usable column at a time. Select an issue to open its peek panel without losing your place in the list.
+
+## Edit an issue
+
+The issue editor supports Markdown preview, a formatting toolbar, issue-reference autocomplete, Mermaid diagrams, code-block copy, labels, modules, dates, relations, comments, and attachments. Use the keyboard shortcut help or command palette when you do not remember a shortcut.
+
+Changes can be undone from the UI. Deletes use a deferred undo window, so confirm the item and use Undo immediately if the deletion was accidental.
+
+## Work with pages and plans
+
+Pages can be project-scoped or workspace-scoped. Browse, Recent, Drafts, and Archived page sub-tabs provide stable homes for each lifecycle state. Move project pages into folders with drag-and-drop on desktop or the Move-to-folder picker on touch devices; a page and its folder must belong to the same project.
+
+Plans organize nested steps. Link a step to an issue when the step should follow that issue's lifecycle. Plan lists provide Active, Done, Archived, and All sub-tabs. Comments and activity are available on issues and pages, while plan activity records plan and step changes.
+
+Labels and modules are managed from the project structure controls. Labels are project-scoped and can be attached to issues and pages; workspace pages do not use project labels.
+
+## Navigate and personalize
+
+The command palette searches actions and content and highlights matching result text. Deep links let you share or bookmark an issue, page, or plan directly.
+
+Appearance settings include accent color, density, font scale, and reduced motion. The interface also provides a dark/light theme choice where supported by the current release. Keyboard shortcuts are listed in the shortcut help panel.
+
+## Accounts and administration
+
+From account settings, manage your profile, password, active sessions, and connected tools. Instance settings control signups, browser auto-login, authorization enforcement, and login messaging. Project settings manage members and their viewer, maintainer, or lead roles; the last lead cannot be removed or demoted.
+
+Use the connected-tools and API-key controls to review which agents can access the instance. Prefer user-owned bot identities for agents that should follow project membership. See [self-hosting](/docs/self-hosting) and the [REST authorization notes](/docs/rest-api) for operator-level access rules.
+
+The browser's Connected Tools page is a smaller manual-configuration subset: OpenCode, Cursor, Claude Code, Claude Desktop, Codex, Pi, VS Code, and Zed. The CLI [connect](/docs/connect) flow supports those clients plus Gemini CLI, Windsurf, Goose, and Crush, with detection and per-client file writes.
+
+## Mobile and realtime behavior
+
+Lific includes a PWA manifest and icons, so supported browsers can add the site to a phone or desktop home screen and open it in a standalone window. Installation does not provide offline editing or replica synchronization; the app still connects to the Lific server for data.
+
+Open views update through realtime invalidation. If a second browser tab or an agent changes data, the current view refetches the affected state. After a reconnect or resync, wait for the view to refresh before continuing an edit.


### PR DESCRIPTION
This patch adds the missing Web UI and 2.0-to-2.2 upgrade guidance.

It gives maintainers and operators a task-oriented guide to the dashboard, navigation, issues, pages, plans, accounts, mobile behavior, and realtime updates. It also distinguishes PWA installation from offline editing, separates browser and CLI connected-tool setup, documents the upgrade and security path, and defines local-first deployment semantics.