### PR TITLE
docs: add repository guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 # Triggered by pushing a version tag (e.g. v1.4.0).
 #
-# The tag MUST originate on magi (origin) so the magi→github push mirror
+# The tag MUST originate on the maintainer-only `magi` remote (origin in that
+# checkout) so the magi→github push mirror
 # replicates it. Do NOT have this workflow create the tag on the github side:
 # the mirror runs `git push --mirror`, which prunes any github ref that isn't
 # on magi. A github-only tag therefore gets deleted on the next mirror sync,
@@ -10,8 +11,9 @@ name: Release
 # stranded every release v1.2.0–v1.3.1 (LIF-120). Because the tag now comes
 # from magi, the mirror keeps it and the release stays published.
 #
-# Release ritual (see AGENTS.md "Releasing a new version"):
-#   1. bump Cargo.toml, commit, `git push`            (no release yet)
+# Release ritual (maintainer-only mirror details are not required in public
+# clones):
+#   1. bump Cargo.toml, commit, and push the version change (no release yet)
 #   2. `git tag vX.Y.Z && git push origin vX.Y.Z`     (fires this workflow)
 on:
   push:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security policy
+
+## Supported versions
+
+The latest released version receives security fixes. If a vulnerability affects an older release, upgrade to the latest release before requesting a backport assessment.
+
+## Reporting a vulnerability
+
+Do not open a public issue for an undisclosed vulnerability. Use the repository's private security-advisory flow on GitHub when available. If that flow is unavailable, contact the maintainers through the private contact channel listed in the repository owner profile and include `Lific security report` in the subject.
+
+Include the affected version, deployment type, configuration relevant to the issue, reproduction steps, impact, and any proposed mitigation. Remove API keys, session tokens, passwords, database files, and personal data from the report.
+
+## Security-sensitive deployment areas
+
+Operators should treat the following as trust boundaries:
+
+- API keys, OAuth access tokens, sessions, and unbound shell-minted operator keys;
+- `authz_enforced`, `[auth] required`, signup, and browser auto-login settings;
+- `server.public_url`, CORS, and `server.trusted_proxies` when running behind a proxy;
+- attachment uploads, MIME validation, content-addressed storage, and orphan cleanup; and
+- service files, database backups, and any host account with shell access.
+
+Keep auth-optional instances local or firewalled. Configure only proxy ranges you operate. Rotate credentials that appear in logs, shell history, configuration files, or incident reports.
+
+## Disclosure
+
+Maintainers will acknowledge receipt, investigate the report, coordinate a fix and release, and credit reporters when they request it and disclosure is safe.

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -164,11 +164,13 @@ will fail the release if you forget.
    the top-level `version` and the `packages[0].version`. They must always
    equal `Cargo.toml`'s version and the release tag — the `verify` job asserts
    this and fails fast on drift.
-3. Cut the release as normal (see `AGENTS.md` → "Releasing a new version":
-   commit, `git push` to magi, then `git tag vX.Y.Z && git push origin vX.Y.Z`).
-   That fires `release.yml`, which builds binaries, runs `cargo publish` to
-   crates.io, and then (in `publish-registry`) publishes `server.json` to the
-   MCP Registry automatically.
+3. Cut the release using `.github/workflows/release.yml`: update the version,
+   commit it, and push the release tag. The `magi` mirror mentioned in the
+   workflow is maintainer-only infrastructure and may not exist in a public
+   checkout; do not add or invent that remote. The release workflow builds
+   binaries, runs `cargo publish` to crates.io, and then (in
+   `publish-registry`) publishes `server.json` to the MCP Registry
+   automatically.
 4. **Only if `publish-registry` failed** (it's `continue-on-error`, so check the
    run): re-run the manual `mcp-publisher publish` from the repo root, per
    "Every publish" above.


### PR DESCRIPTION
This patch adds repository-maintainer guidance that is currently missing or misleading.

It adds security-reporting guidance, clarifies the MCP Registry release and mirror topology, and replaces dangling site instructions with the current Bun and Remotion workflow.