### PR TITLE
docs: clarify Codex connection setup

### DIFF
--- a/site/content/docs/connect.mdx
+++ b/site/content/docs/connect.mdx
@@ -3,7 +3,7 @@ title: Connect agents
 description: lific connect detects installed AI tools and writes MCP configuration for them.
 ---
 
-`lific connect` configures AI coding tools to use your Lific server over MCP. It detects the clients installed on your machine, writes a `lific` server entry into each client's MCP configuration, and mints an API key for each client.
+`lific connect` configures AI coding tools to use your Lific server over MCP. It detects the clients installed on your machine and writes a `lific` server entry into each client's MCP configuration. The default remote mode mints an API key per client; `--key`, `--oauth`, and `--stdio` use different credential paths.
 
 ```bash
 lific connect
@@ -37,7 +37,7 @@ VS Code global paths: `~/Library/Application Support/Code/User/mcp.json` on macO
 
 Every entry is named `lific`. The shape follows each client's own configuration format. In the default remote mode, most clients receive the MCP URL plus an `Authorization: Bearer` header. Two clients differ:
 
-- Codex uses TOML and references the key through `bearer_token_env_var = "LIFIC_API_KEY"`. The key is never written into the file.
+- Codex uses TOML and references the key through `bearer_token_env_var = "LIFIC_API_KEY"`. See [Codex environment variable](#codex-environment-variable) below for the required export step. The key is never written into the file or into your shell startup files.
 - Claude Desktop does not support remote MCP servers natively. Its entry launches `npx -y mcp-remote <url>` with the bearer header as an argument.
 
 Writes are merge-preserving. Unrelated keys and sibling MCP server entries remain in place. Only the `lific` entry is inserted or replaced. If an existing configuration file fails to parse, `lific connect` leaves the file unchanged and reports the failure with the entry contents for manual editing.
@@ -58,9 +58,20 @@ Without a terminal, `--client` is required. `--json` switches the output to JSON
 
 ## API keys
 
-Without `--key`, `lific connect` mints one API key per selected client. The plaintext key is embedded in the written configuration and is not otherwise persisted by connect. On a server with human accounts, minted keys belong to bot users named `{tool}-{owner}`. Use `--user <username>` to select the owner when more than one account exists. Re-running rotates existing active keys with the same tool name.
+In the default remote-key mode, when `--key` is not supplied, `lific connect` mints one API key per selected client. The plaintext key is embedded in the written configuration and is not otherwise persisted by connect. On a server with human accounts, minted keys belong to bot users named `{tool}-{owner}`. Use `--user <username>` to select the owner when more than one account exists. Re-running rotates existing active keys with the same tool name. `--oauth` and `--stdio` do not mint API keys.
 
 Use `--key <key>` to reuse an existing key verbatim instead of minting new ones.
+
+### Codex environment variable
+
+For a remote bearer-key connection, Codex reads `LIFIC_API_KEY` because the generated TOML uses `bearer_token_env_var`. `lific connect` displays the one-time key and an export command after it writes the Codex entry, but it does not change your shell environment. Export the key in the shell that launches Codex, or add it to a protected secret store or shell configuration:
+
+```bash
+export LIFIC_API_KEY="<KEY_SHOWN_BY_LIFIC_CONNECT>"
+codex
+```
+
+Do not commit the key or paste it into a shared project configuration. With `--oauth`, Codex performs its own login flow and does not use `LIFIC_API_KEY`; with `--stdio`, no API key is needed.
 
 ## Server URL
 


### PR DESCRIPTION
This patch makes Codex connection setup and credential handling explicit.

It explains the LIFIC_API_KEY handoff and export step, distinguishes the default remote-key flow from --key, --oauth, and --stdio, and states which modes mint keys.