### PR TITLE
Show websocket activity rate on the home screen

### DIFF
--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -271,6 +271,57 @@ mod tests {
             .items
     }
 
+    #[test]
+    fn activity_count_filters_to_last_day_and_visible_projects() {
+        let pool = crate::db::open_memory().expect("test db");
+        let (first_project, second_project) = {
+            let conn = pool.write().unwrap();
+            let first = queries::create_project(
+                &conn,
+                &CreateProject {
+                    name: "First".into(),
+                    identifier: "FIRST".into(),
+                    description: String::new(),
+                    emoji: None,
+                    lead_user_id: None,
+                },
+            )
+            .unwrap();
+            let second = queries::create_project(
+                &conn,
+                &CreateProject {
+                    name: "Second".into(),
+                    identifier: "SECND".into(),
+                    description: String::new(),
+                    emoji: None,
+                    lead_user_id: None,
+                },
+            )
+            .unwrap();
+
+            // Exclude setup activity so the fresh issue rows below are the
+            // only events inside the rolling 24-hour window.
+            conn.execute("UPDATE audit_log SET ts = datetime('now', '-25 hours')", [])
+                .unwrap();
+            queries::create_issue(&conn, &new_issue(first.id, "Fresh first")).unwrap();
+            queries::create_issue(&conn, &new_issue(second.id, "Fresh second one")).unwrap();
+            queries::create_issue(&conn, &new_issue(second.id, "Fresh second two")).unwrap();
+            (first.id, second.id)
+        };
+
+        let conn = pool.read().unwrap();
+        assert_eq!(activity_count(&conn, None).unwrap(), 3);
+        assert_eq!(
+            activity_count(&conn, Some(&HashSet::from([first_project]))).unwrap(),
+            1
+        );
+        assert_eq!(
+            activity_count(&conn, Some(&HashSet::from([second_project]))).unwrap(),
+            2
+        );
+        assert_eq!(activity_count(&conn, Some(&HashSet::new())).unwrap(), 0);
+    }
+
     // ── Capture: per-field diffs ─────────────────────────
 
     #[test]

--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -5,6 +5,7 @@
 //! along, degrading gracefully when the actor's account is gone.
 
 use rusqlite::Connection;
+use std::collections::HashSet;
 
 use crate::db::models::{Activity, ActivityFeed};
 use crate::error::LificError;
@@ -27,6 +28,42 @@ pub enum ActivityScope {
 
 const MAX_LIMIT: i64 = 200;
 const DEFAULT_LIMIT: i64 = 50;
+
+/// Return the trailing-24-hour activity count for the websocket's initial snapshot.
+/// `None` means unrestricted visibility; `Some` limits rows to visible projects.
+pub fn activity_count(
+    conn: &Connection,
+    visible_project_ids: Option<&HashSet<i64>>,
+) -> Result<i64, LificError> {
+    let Some(project_filter) = project_filter(visible_project_ids) else {
+        return Ok(0);
+    };
+
+    let ids: Vec<i64> = visible_project_ids
+        .into_iter()
+        .flat_map(|ids| ids.iter().copied())
+        .collect();
+    let sql = format!(
+        "SELECT COUNT(*) FROM audit_log a
+         WHERE a.ts >= datetime('now', '-24 hours'){project_filter}"
+    );
+    conn.query_row(&sql, rusqlite::params_from_iter(ids.iter()), |row| row.get(0))
+        .map_err(LificError::Database)
+}
+
+fn project_filter(visible_project_ids: Option<&HashSet<i64>>) -> Option<String> {
+    match visible_project_ids {
+        None => Some(String::new()),
+        Some(ids) if ids.is_empty() => None,
+        Some(ids) => Some(format!(
+            " AND a.project_id IN ({})",
+            (1..=ids.len())
+                .map(|index| format!("?{index}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
 
 /// List activity newest-first. `limit` is clamped to 1..=200 (default 50).
 /// Fetches limit+1 rows internally to compute `has_more` without a COUNT.

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -115,6 +115,13 @@ pub struct RealtimeMessage {
     audience: RealtimeAudience,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum RealtimeRequest {
+    #[serde(rename = "activity.baseline.request")]
+    ActivityBaselineRequest,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum RealtimeEvent {
@@ -138,6 +145,8 @@ pub enum RealtimeEvent {
     IssueLinked { project_id: i64, issue_id: i64 },
     #[serde(rename = "issue.unlinked")]
     IssueUnlinked { project_id: i64, issue_id: i64 },
+    #[serde(rename = "activity.baseline")]
+    ActivityBaseline { day_count: i64 },
 }
 
 pub async fn serve_socket(
@@ -180,7 +189,9 @@ pub async fn serve_socket(
             flow
         },
         event = rx.recv() => forward_event(&mut socket, &db, &auth_user, &mut visible_projects, event).await,
-        message = socket.recv() => handle_client_message(&mut socket, message).await,
+        message = socket.recv() => {
+            handle_client_message(&mut socket, &db, &auth_user, message).await
+        },
     } {}
 }
 
@@ -273,6 +284,8 @@ async fn forward_event(
 
 async fn handle_client_message(
     socket: &mut WebSocket,
+    db: &crate::db::DbPool,
+    auth_user: &crate::db::models::AuthUser,
     message: Option<Result<Message, axum::Error>>,
 ) -> SocketFlow {
     match message {
@@ -280,8 +293,34 @@ async fn handle_client_message(
             SocketFlow::from_send(socket.send(Message::Pong(payload)).await)
         }
         Some(Ok(Message::Close(_))) | Some(Err(_)) | None => SocketFlow::Close,
+        Some(Ok(Message::Text(text))) => {
+            if matches!(
+                serde_json::from_str::<RealtimeRequest>(&text),
+                Ok(RealtimeRequest::ActivityBaselineRequest)
+            ) {
+                match activity_baseline(db, auth_user) {
+                    Ok(event) => send_event(socket, &event).await,
+                    Err(error) => {
+                        warn!(error = %error, "failed to load websocket activity baseline");
+                        SocketFlow::Open
+                    }
+                }
+            } else {
+                SocketFlow::Open
+            }
+        }
         Some(Ok(Message::Pong(_))) | Some(Ok(_)) => SocketFlow::Open,
     }
+}
+
+fn activity_baseline(
+    db: &crate::db::DbPool,
+    auth_user: &crate::db::models::AuthUser,
+) -> Result<RealtimeEvent, crate::error::LificError> {
+    let visible_projects = crate::authz::visible_project_ids(db, &Some(auth_user.clone()))?;
+    let conn = db.read()?;
+    let day_count = crate::db::queries::activity::activity_count(&conn, visible_projects.as_ref())?;
+    Ok(RealtimeEvent::ActivityBaseline { day_count })
 }
 
 async fn send_event(socket: &mut WebSocket, event: &RealtimeEvent) -> SocketFlow {
@@ -395,7 +434,7 @@ impl RealtimeEvent {
             | Self::IssueDeleted { project_id, .. }
             | Self::IssueLinked { project_id, .. }
             | Self::IssueUnlinked { project_id, .. } => Some(*project_id),
-            Self::ResyncRequired | Self::ProjectsReordered => None,
+            Self::ResyncRequired | Self::ProjectsReordered | Self::ActivityBaseline { .. } => None,
         }
     }
 }

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -455,6 +455,56 @@ mod tests {
         assert_eq!(json["issue_id"], 42);
     }
 
+    #[test]
+    fn activity_baseline_serializes_with_day_count() {
+        let event = RealtimeEvent::ActivityBaseline { day_count: 123 };
+        let json = serde_json::to_value(&event).unwrap();
+
+        assert_eq!(json["type"], "activity.baseline");
+        assert_eq!(json["day_count"], 123);
+    }
+
+    #[test]
+    fn activity_baseline_rechecks_current_project_visibility() {
+        let (db, auth_user, project_id, _) = visibility_fixture(true);
+        {
+            let conn = db.write().unwrap();
+            conn.execute("UPDATE audit_log SET ts = datetime('now', '-25 hours')", [])
+                .unwrap();
+            crate::db::queries::create_issue(
+                &conn,
+                &crate::db::models::CreateIssue {
+                    project_id,
+                    title: "Visible activity".into(),
+                    description: String::new(),
+                    status: "backlog".into(),
+                    priority: "none".into(),
+                    module_id: None,
+                    start_date: None,
+                    target_date: None,
+                    labels: vec![],
+                    source: None,
+                },
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            activity_baseline(&db, &auth_user).unwrap(),
+            RealtimeEvent::ActivityBaseline { day_count: 1 }
+        );
+
+        {
+            let conn = db.write().unwrap();
+            crate::db::queries::members::remove_member(&conn, project_id, auth_user.id).unwrap();
+        }
+
+        assert_eq!(
+            activity_baseline(&db, &auth_user).unwrap(),
+            RealtimeEvent::ActivityBaseline { day_count: 0 }
+        );
+    }
+
     #[tokio::test]
     async fn lagged_receiver_requests_resync() {
         let hub = RealtimeHub::with_capacity(1);

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -22,6 +22,7 @@
   import Toaster from "./lib/toast/Toaster.svelte"; // LIF-243
   import { hasSession, getInstance, autoLogin, saveSession, clearSession, me } from "./lib/api";
   import { REALTIME_INVALIDATE_EVENT, type RealtimeEvent } from "./lib/autoRefresh.svelte";
+  import { createActivityRateCounter } from "./lib/activityRate";
   import { motionReduced } from "./lib/theme";
   import { fade } from "svelte/transition";
   import { onDestroy, onMount } from "svelte";
@@ -54,6 +55,7 @@
   let realtimeDelayMs = 1000;
   let realtimeNeedsResync = false;
   let realtimeDisposed = false;
+  const realtimeActivity = createActivityRateCounter();
 
   onMount(async () => {
     if (!hasSession()) {
@@ -123,6 +125,7 @@
     }
     realtimeDelayMs = 1000;
     realtimeNeedsResync = false;
+    realtimeActivity.reset();
     const socket = realtimeSocket;
     realtimeSocket = null;
     if (socket) {
@@ -201,6 +204,9 @@
       try {
         const event = JSON.parse(message.data) as RealtimeEvent;
         if (typeof event?.type === "string") {
+          if (event.type !== "resync.required") {
+            realtimeActivity.record(Date.now());
+          }
           dispatchRealtimeEvent(event);
         }
       } catch {
@@ -458,7 +464,7 @@
     {#key routeTransitionKey}
     <div class="h-full" in:fade={routeFadeParams()}>
     {#if parsed.page === "home"}
-      <Home {navigate} />
+      <Home {navigate} realtimeActivityCounts={realtimeActivity.counts} />
     {:else if parsed.page === "settings"}
       <Settings {navigate} />
     {:else if parsed.page === "instance-settings"}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -22,7 +22,10 @@
   import Toaster from "./lib/toast/Toaster.svelte"; // LIF-243
   import { hasSession, getInstance, autoLogin, saveSession, clearSession, me } from "./lib/api";
   import { REALTIME_INVALIDATE_EVENT, type RealtimeEvent } from "./lib/autoRefresh.svelte";
-  import { createActivityRateCounter } from "./lib/activityRate";
+  import {
+    createActivityRateCounter,
+    type ActivityBaseline,
+  } from "./lib/activityRate";
   import { motionReduced } from "./lib/theme";
   import { fade } from "svelte/transition";
   import { onDestroy, onMount } from "svelte";
@@ -56,6 +59,39 @@
   let realtimeNeedsResync = false;
   let realtimeDisposed = false;
   const realtimeActivity = createActivityRateCounter();
+  let realtimeActivityReady = $state(false);
+  let realtimeActivityRevision = $state(0);
+  let realtimeActivityRefresh: ReturnType<typeof setTimeout> | null = null;
+
+  function refreshRealtimeActivity() {
+    realtimeActivityRefresh = null;
+    realtimeActivityRevision += 1;
+  }
+
+  function scheduleRealtimeActivityRefresh() {
+    if (realtimeActivityRefresh) clearTimeout(realtimeActivityRefresh);
+    realtimeActivityRefresh = setTimeout(refreshRealtimeActivity, 100);
+  }
+
+  function resetRealtimeActivity() {
+    if (realtimeActivityRefresh) {
+      clearTimeout(realtimeActivityRefresh);
+      realtimeActivityRefresh = null;
+    }
+    realtimeActivity.reset();
+    realtimeActivityReady = false;
+    realtimeActivityRevision += 1;
+  }
+
+  function parseActivityBaseline(event: RealtimeEvent): ActivityBaseline | null {
+    if (event.type !== "activity.baseline") return null;
+    if (typeof event.day_count !== "number" || !Number.isFinite(event.day_count)) {
+      return null;
+    }
+    return {
+      dayCount: event.day_count,
+    };
+  }
 
   onMount(async () => {
     if (!hasSession()) {
@@ -125,7 +161,7 @@
     }
     realtimeDelayMs = 1000;
     realtimeNeedsResync = false;
-    realtimeActivity.reset();
+    resetRealtimeActivity();
     const socket = realtimeSocket;
     realtimeSocket = null;
     if (socket) {
@@ -169,6 +205,13 @@
     );
   }
 
+  function requestRealtimeActivityBaseline() {
+    const socket = realtimeSocket;
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: "activity.baseline.request" }));
+    }
+  }
+
   async function reconnectAfterFailedRealtimeAttempt(sessionToken: string | null) {
     const session = await me();
 
@@ -196,18 +239,32 @@
       realtimeDelayMs = 1000;
       if (realtimeNeedsResync) {
         realtimeNeedsResync = false;
+        resetRealtimeActivity();
         dispatchRealtimeEvent({ type: "resync.required" });
       }
+      requestRealtimeActivityBaseline();
     });
     socket.addEventListener("message", (message) => {
       if (typeof message.data !== "string") return;
       try {
         const event = JSON.parse(message.data) as RealtimeEvent;
         if (typeof event?.type === "string") {
-          if (event.type !== "resync.required") {
-            realtimeActivity.record(Date.now());
+          const baseline = parseActivityBaseline(event);
+          if (baseline) {
+            realtimeActivity.seed(baseline);
+            realtimeActivityReady = true;
+            scheduleRealtimeActivityRefresh();
+          } else if (event.type === "resync.required") {
+            resetRealtimeActivity();
+            dispatchRealtimeEvent(event);
+            requestRealtimeActivityBaseline();
+          } else {
+            if (realtimeActivityReady) {
+              realtimeActivity.record(Date.now());
+              scheduleRealtimeActivityRefresh();
+            }
+            dispatchRealtimeEvent(event);
           }
-          dispatchRealtimeEvent(event);
         }
       } catch {
         // HTTP refresh remains source of truth.
@@ -216,6 +273,7 @@
     socket.addEventListener("close", () => {
       if (realtimeSocket === socket) {
         realtimeSocket = null;
+        resetRealtimeActivity();
         realtimeNeedsResync = true;
         if (opened) {
           scheduleRealtimeReconnect();
@@ -464,7 +522,12 @@
     {#key routeTransitionKey}
     <div class="h-full" in:fade={routeFadeParams()}>
     {#if parsed.page === "home"}
-      <Home {navigate} realtimeActivityCounts={realtimeActivity.counts} />
+      <Home
+        {navigate}
+        realtimeActivityCounts={realtimeActivity.counts}
+        {realtimeActivityReady}
+        {realtimeActivityRevision}
+      />
     {:else if parsed.page === "settings"}
       <Settings {navigate} />
     {:else if parsed.page === "instance-settings"}

--- a/web/src/lib/activityRate.ts
+++ b/web/src/lib/activityRate.ts
@@ -1,0 +1,88 @@
+export type ActivityCounts = {
+  perSecond: number;
+  perMinute: number;
+  perHour: number;
+  perDay: number;
+};
+
+export type ActivityCountsReader = (now: number) => ActivityCounts;
+
+export type ActivityRate = {
+  value: number;
+  unit: "updates/s" | "updates/min" | "updates/hr" | "updates/day";
+};
+
+const EVENT_COMPACTION_THRESHOLD = 4_096;
+
+export function createActivityRateCounter() {
+  const eventTimes: number[] = [];
+  let eventHead = 0;
+  const minuteBuckets: { minute: number; count: number }[] = [];
+
+  function prune(now: number) {
+    const minuteAgo = now - 60_000;
+    while (eventHead < eventTimes.length && eventTimes[eventHead] < minuteAgo) {
+      eventHead += 1;
+    }
+    if (eventHead > EVENT_COMPACTION_THRESHOLD && eventHead * 2 > eventTimes.length) {
+      eventTimes.splice(0, eventHead);
+      eventHead = 0;
+    }
+
+    const dayAgo = now - 86_400_000;
+    while (minuteBuckets.length > 0 && (minuteBuckets[0].minute + 1) * 60_000 <= dayAgo) {
+      minuteBuckets.shift();
+    }
+  }
+
+  function record(now: number) {
+    prune(now);
+    eventTimes.push(now);
+    const minute = Math.floor(now / 60_000);
+    const bucket = minuteBuckets.at(-1);
+    if (bucket?.minute === minute) {
+      bucket.count += 1;
+    } else {
+      minuteBuckets.push({ minute, count: 1 });
+    }
+  }
+
+  function counts(now: number): ActivityCounts {
+    prune(now);
+    let perSecond = 0;
+    for (let i = eventTimes.length - 1; i >= eventHead; i -= 1) {
+      if (eventTimes[i] < now - 1_000) break;
+      perSecond += 1;
+    }
+    let perHour = 0;
+    const hourAgo = now - 3_600_000;
+    for (let i = minuteBuckets.length - 1; i >= 0; i -= 1) {
+      const bucket = minuteBuckets[i];
+      if ((bucket.minute + 1) * 60_000 <= hourAgo) break;
+      perHour += bucket.count;
+    }
+    return {
+      perSecond,
+      perMinute: eventTimes.length - eventHead,
+      perHour,
+      perDay: minuteBuckets.reduce((total, bucket) => total + bucket.count, 0),
+    };
+  }
+
+  function reset() {
+    eventTimes.length = 0;
+    eventHead = 0;
+    minuteBuckets.length = 0;
+  }
+
+  return { record, counts, reset };
+}
+
+export function selectActivityRate(counts: ActivityCounts): ActivityRate {
+  // Two or more events select the shortest meaningful window; otherwise the
+  // trailing day remains the conservative fallback.
+  if (counts.perSecond >= 2) return { value: counts.perSecond, unit: "updates/s" };
+  if (counts.perMinute >= 2) return { value: counts.perMinute, unit: "updates/min" };
+  if (counts.perHour >= 2) return { value: counts.perHour, unit: "updates/hr" };
+  return { value: counts.perDay, unit: "updates/day" };
+}

--- a/web/src/lib/activityRate.ts
+++ b/web/src/lib/activityRate.ts
@@ -7,75 +7,82 @@ export type ActivityCounts = {
 
 export type ActivityCountsReader = (now: number) => ActivityCounts;
 
+type ActivityBucket = {
+  at: number;
+  count: number;
+};
+
+export type ActivityBaseline = {
+  dayCount: number;
+};
+
 export type ActivityRate = {
   value: number;
   unit: "updates/s" | "updates/min" | "updates/hr" | "updates/day";
 };
 
-const EVENT_COMPACTION_THRESHOLD = 4_096;
-
 export function createActivityRateCounter() {
-  const eventTimes: number[] = [];
-  let eventHead = 0;
-  const minuteBuckets: { minute: number; count: number }[] = [];
+  const secondBuckets: ActivityBucket[] = [];
+  const minuteBuckets: ActivityBucket[] = [];
+  let baselineDayCount = 0;
 
   function prune(now: number) {
     const minuteAgo = now - 60_000;
-    while (eventHead < eventTimes.length && eventTimes[eventHead] < minuteAgo) {
-      eventHead += 1;
+    while (secondBuckets.length > 0 && secondBuckets[0].at + 1_000 <= minuteAgo) {
+      secondBuckets.shift();
     }
-    if (eventHead > EVENT_COMPACTION_THRESHOLD && eventHead * 2 > eventTimes.length) {
-      eventTimes.splice(0, eventHead);
-      eventHead = 0;
-    }
-
     const dayAgo = now - 86_400_000;
-    while (minuteBuckets.length > 0 && (minuteBuckets[0].minute + 1) * 60_000 <= dayAgo) {
+    while (minuteBuckets.length > 0 && minuteBuckets[0].at + 60_000 <= dayAgo) {
       minuteBuckets.shift();
+    }
+  }
+
+  function addBucket(buckets: ActivityBucket[], at: number, count = 1) {
+    const bucket = buckets.at(-1);
+    if (bucket?.at === at) {
+      bucket.count += count;
+    } else {
+      buckets.push({ at, count });
     }
   }
 
   function record(now: number) {
     prune(now);
-    eventTimes.push(now);
-    const minute = Math.floor(now / 60_000);
-    const bucket = minuteBuckets.at(-1);
-    if (bucket?.minute === minute) {
-      bucket.count += 1;
-    } else {
-      minuteBuckets.push({ minute, count: 1 });
-    }
+    addBucket(secondBuckets, Math.floor(now / 1_000) * 1_000);
+    addBucket(minuteBuckets, Math.floor(now / 60_000) * 60_000);
+  }
+
+  function seed(baseline: ActivityBaseline) {
+    secondBuckets.length = 0;
+    minuteBuckets.length = 0;
+    baselineDayCount = baseline.dayCount;
+  }
+
+  function sumSince(buckets: ActivityBucket[], now: number, window: number, bucketSize: number) {
+    const cutoff = now - window;
+    return buckets.reduce(
+      (total, bucket) => total + (bucket.at + bucketSize > cutoff ? bucket.count : 0),
+      0,
+    );
   }
 
   function counts(now: number): ActivityCounts {
     prune(now);
-    let perSecond = 0;
-    for (let i = eventTimes.length - 1; i >= eventHead; i -= 1) {
-      if (eventTimes[i] < now - 1_000) break;
-      perSecond += 1;
-    }
-    let perHour = 0;
-    const hourAgo = now - 3_600_000;
-    for (let i = minuteBuckets.length - 1; i >= 0; i -= 1) {
-      const bucket = minuteBuckets[i];
-      if ((bucket.minute + 1) * 60_000 <= hourAgo) break;
-      perHour += bucket.count;
-    }
     return {
-      perSecond,
-      perMinute: eventTimes.length - eventHead,
-      perHour,
-      perDay: minuteBuckets.reduce((total, bucket) => total + bucket.count, 0),
+      perSecond: sumSince(secondBuckets, now, 1_000, 1_000),
+      perMinute: sumSince(secondBuckets, now, 60_000, 1_000),
+      perHour: sumSince(minuteBuckets, now, 3_600_000, 60_000),
+      perDay: baselineDayCount + minuteBuckets.reduce((total, bucket) => total + bucket.count, 0),
     };
   }
 
   function reset() {
-    eventTimes.length = 0;
-    eventHead = 0;
+    secondBuckets.length = 0;
     minuteBuckets.length = 0;
+    baselineDayCount = 0;
   }
 
-  return { record, counts, reset };
+  return { record, seed, counts, reset };
 }
 
 export function selectActivityRate(counts: ActivityCounts): ActivityRate {

--- a/web/src/routes/Home.svelte
+++ b/web/src/routes/Home.svelte
@@ -21,6 +21,10 @@
     type Activity,
   } from "../lib/api";
   import { getRecents, type RecentEntry } from "../lib/home/recents";
+  import {
+    selectActivityRate,
+    type ActivityCountsReader,
+  } from "../lib/activityRate";
   import StatusIcon from "../lib/StatusIcon.svelte";
   import PriorityIcon from "../lib/PriorityIcon.svelte";
   import ProjectIcon from "../lib/ProjectIcon.svelte";
@@ -55,13 +59,20 @@
     return () => topbarCtx?.set(undefined);
   });
 
-  let { navigate }: { navigate: (path: string) => void } = $props();
+  let {
+    navigate,
+    realtimeActivityCounts,
+  }: {
+    navigate: (path: string) => void;
+    realtimeActivityCounts: ActivityCountsReader;
+  } = $props();
 
   let user = $state<AuthUser | null>(null);
   let projects = $state<Project[]>([]);
   let myIssues = $state<Issue[]>([]);
   let allPages = $state<Page[]>([]);
   let activityItems = $state<Activity[]>([]);
+  let activityNow = $state(Date.now());
   let recents = $state<RecentEntry[]>([]);
   let loading = $state(true);
   let error = $state("");
@@ -70,6 +81,16 @@
   // reused as the destination for the "New issue" quick action so it lands
   // wherever the user has been most active rather than an arbitrary project.
   let digestProjectIds = $state<number[]>([]);
+
+  // Cadence uses a one-second window, so it needs a finer-grained clock than
+  // the shared 30-second relative-time heartbeat. Keep this timer local to
+  // Home so other timestamp displays do not rerender every second.
+  $effect(() => {
+    const interval = setInterval(() => {
+      activityNow = Date.now();
+    }, 1_000);
+    return () => clearInterval(interval);
+  });
 
   $effect(() => {
     loadData();
@@ -243,6 +264,8 @@
   function activityActor(a: Activity): string {
     return a.actor_display_name || a.actor_username || "system";
   }
+
+  let activityRate = $derived(selectActivityRate(realtimeActivityCounts(activityNow)));
 
   function activityDest(a: Activity): string | null {
     const ident = projectIdent(a.project_id);
@@ -616,12 +639,18 @@
             {#if activityItems.length > 0}
               <section>
                 <div class="flex items-center justify-between mb-3">
-                  <div class="flex items-center gap-2">
+                  <div class="flex items-center gap-2 min-w-0">
                     <ArrowUpRight size={12} class="text-[var(--text-faint)]" />
                     <h2 class="text-micro font-semibold uppercase tracking-widest text-[var(--text-muted)]">
                       Recent activity
                     </h2>
                   </div>
+                  <span
+                    class="text-micro text-[var(--text-faint)] tabular-nums text-right"
+                    title="Live websocket activity observed this session; counts use 1-second, 1-minute, 1-hour, or 1-day windows"
+                  >
+                    {activityRate.value} {activityRate.unit}
+                  </span>
                 </div>
                 <div class="flex flex-col gap-0.5">
                   {#each activityItems as a (a.id)}

--- a/web/src/routes/Home.svelte
+++ b/web/src/routes/Home.svelte
@@ -25,6 +25,7 @@
     selectActivityRate,
     type ActivityCountsReader,
   } from "../lib/activityRate";
+  import { now } from "../lib/now.svelte";
   import StatusIcon from "../lib/StatusIcon.svelte";
   import PriorityIcon from "../lib/PriorityIcon.svelte";
   import ProjectIcon from "../lib/ProjectIcon.svelte";
@@ -62,9 +63,13 @@
   let {
     navigate,
     realtimeActivityCounts,
+    realtimeActivityReady,
+    realtimeActivityRevision,
   }: {
     navigate: (path: string) => void;
     realtimeActivityCounts: ActivityCountsReader;
+    realtimeActivityReady: boolean;
+    realtimeActivityRevision: number;
   } = $props();
 
   let user = $state<AuthUser | null>(null);
@@ -72,7 +77,6 @@
   let myIssues = $state<Issue[]>([]);
   let allPages = $state<Page[]>([]);
   let activityItems = $state<Activity[]>([]);
-  let activityNow = $state(Date.now());
   let recents = $state<RecentEntry[]>([]);
   let loading = $state(true);
   let error = $state("");
@@ -81,16 +85,6 @@
   // reused as the destination for the "New issue" quick action so it lands
   // wherever the user has been most active rather than an arbitrary project.
   let digestProjectIds = $state<number[]>([]);
-
-  // Cadence uses a one-second window, so it needs a finer-grained clock than
-  // the shared 30-second relative-time heartbeat. Keep this timer local to
-  // Home so other timestamp displays do not rerender every second.
-  $effect(() => {
-    const interval = setInterval(() => {
-      activityNow = Date.now();
-    }, 1_000);
-    return () => clearInterval(interval);
-  });
 
   $effect(() => {
     loadData();
@@ -265,7 +259,11 @@
     return a.actor_display_name || a.actor_username || "system";
   }
 
-  let activityRate = $derived(selectActivityRate(realtimeActivityCounts(activityNow)));
+  let activityRate = $derived.by(() => {
+    const current = now();
+    realtimeActivityRevision;
+    return selectActivityRate(realtimeActivityCounts(current));
+  });
 
   function activityDest(a: Activity): string | null {
     const ident = projectIdent(a.project_id);
@@ -645,12 +643,14 @@
                       Recent activity
                     </h2>
                   </div>
-                  <span
-                    class="text-micro text-[var(--text-faint)] tabular-nums text-right"
-                    title="Live websocket activity observed this session; counts use 1-second, 1-minute, 1-hour, or 1-day windows"
-                  >
-                    {activityRate.value} {activityRate.unit}
-                  </span>
+                  {#if realtimeActivityReady}
+                    <span
+                      class="text-micro text-[var(--text-faint)] tabular-nums text-right"
+                      title="Websocket activity rate; the day fallback includes the last 24 hours"
+                    >
+                      {activityRate.value} {activityRate.unit}
+                    </span>
+                  {/if}
                 </div>
                 <div class="flex flex-col gap-0.5">
                   {#each activityItems as a (a.id)}


### PR DESCRIPTION
## Summary

Adds a websocket-backed activity rate to the existing Recent activity pane on the home screen.

The indicator chooses the shortest meaningful cadence:

- updates/s when at least two events arrive within a second
- updates/min when activity is minute-scale
- updates/hr when activity is hour-scale
- updates/day as the final fallback, seeded from the trailing 24-hour activity count

## Maintainer notes

- Reuses the existing realtime connection and requests the 24-hour baseline over that connection.
- Applies the current project visibility rules when calculating the baseline.
- Keeps the indicator hidden until the websocket baseline is available.
- Resets the rate on disconnect or resynchronization.
- Keeps rate calculation separate from websocket lifecycle handling and Home pane rendering.