### PR TITLE
Support HTTP backend for CLI data commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "charset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
+dependencies = [
+ "base64",
+ "encoding_rs",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +673,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "content_disposition"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc14a88e1463ddd193906285abe5c360c7e8564e05ccc5d501755f7fbc9ca9c"
+dependencies = [
+ "charset",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1645,6 +1664,7 @@ dependencies = [
  "clap_complete",
  "cliclack",
  "console",
+ "content_disposition",
  "crossbeam-queue",
  "dirs",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ flate2 = "1"
 
 # Encoding
 urlencoding = "2"
+content_disposition = "0.4"
 # serde_urlencoded: parse application/x-www-form-urlencoded device-authorization
 # bodies by hand (the endpoint accepts BOTH form and JSON, so we sniff the
 # content-type and deserialize the raw bytes rather than committing to one axum

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Issues stay flat and lateral; the hierarchy lives on the plan. It's the differen
 - **Pipe-native CLI.** Output auto-upgrades to JSON when piped, so `lific issue list --project APP | jq` just works, no `--json` needed (though it's there). Prompts never hang a non-interactive caller; they fail fast and name the bypass flag.
 - **Shell completions:** `lific completion fish | source` (bash, zsh, fish, powershell, elvish).
 
-The CLI also works directly against the database, no server or auth required:
+The CLI works directly against the database, with no server or auth required. Data commands also support an HTTP backend when you want the CLI to operate on a remote Lific instance:
 
 ```bash
 lific project list
@@ -191,7 +191,13 @@ lific issue list --project APP
 lific issue create --project APP --title "Fix login bug" --priority high
 lific issue update APP-42 --status done
 lific search "authentication" --project APP
+
+# Remote mode (the same commands use the server API)
+lific --backend http --url https://lific.example.com --api-key "$LIFIC_API_KEY" issue list --project APP
+lific --backend http --url https://lific.example.com --api-key "$LIFIC_API_KEY" issue update APP-42 --status done
 ```
+
+`--backend http` can read the URL and bearer key from `LIFIC_URL` and `LIFIC_API_KEY`. The default backend remains direct SQL; HTTP mode never opens the local database for data commands.
 
 ## MCP tools
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ lific --backend http --url https://lific.example.com --api-key "$LIFIC_API_KEY" 
 lific --backend http --url https://lific.example.com --api-key "$LIFIC_API_KEY" issue update APP-42 --status done
 ```
 
-`--backend http` can read the URL and bearer key from `LIFIC_URL` and `LIFIC_API_KEY`. The default backend remains direct SQL; HTTP mode never opens the local database for data commands.
+`--backend http` can read the URL and bearer key from `LIFIC_URL` and `LIFIC_API_KEY`. If no API key is supplied, it also uses the credential from `lific login` (`LIFIC_TOKEN`, keyring, or credential file). The default backend remains direct SQL; HTTP mode never opens the local database for data commands.
 
 ## MCP tools
 

--- a/site/content/docs/cli.mdx
+++ b/site/content/docs/cli.mdx
@@ -16,7 +16,7 @@ lific [--config <PATH>] [--db <PATH>] [--json] [--backend sql|http] [--url <URL>
 - `--json` writes JSON output. Data commands also select JSON output when standard output is not a terminal.
 - `--backend sql|http` selects the direct SQLite backend (the default) or the HTTP server backend.
 - `--url <URL>` sets the HTTP server base URL. It can also be supplied as `LIFIC_URL`; when omitted, the configured `server.public_url` or local bind address is used.
-- `--api-key <KEY>` sends a bearer API key to the HTTP server. It can also be supplied as `LIFIC_API_KEY`.
+- `--api-key <KEY>` sends a bearer API key to the HTTP server. It can also be supplied as `LIFIC_API_KEY`. When omitted, HTTP mode uses the credential from `lific login` (`LIFIC_TOKEN`, keyring, or credential file).
 
 For example, run the same command against a remote server with:
 

--- a/site/content/docs/cli.mdx
+++ b/site/content/docs/cli.mdx
@@ -3,17 +3,29 @@ title: CLI reference
 description: Commands, arguments, flags, and behavior for the Lific command line interface.
 ---
 
-The CLI reads the configured SQLite database. Commands for issues, projects, pages, exports, search, comments, modules, labels, and folders do not require a running HTTP server.
+The CLI uses the configured SQLite database by default. Data commands can also use a running Lific server, so the same issue, project, page, export, search, comment, module, label, and folder commands work remotely.
 
 ## Global options
 
 ```shell
-lific [--config <PATH>] [--db <PATH>] [--json] <COMMAND>
+lific [--config <PATH>] [--db <PATH>] [--json] [--backend sql|http] [--url <URL>] [--api-key <KEY>] <COMMAND>
 ```
 
 - `--config <PATH>` selects a configuration file. It replaces automatic configuration discovery.
 - `--db <PATH>` overrides `database.path` for the command.
 - `--json` writes JSON output. Data commands also select JSON output when standard output is not a terminal.
+- `--backend sql|http` selects the direct SQLite backend (the default) or the HTTP server backend.
+- `--url <URL>` sets the HTTP server base URL. It can also be supplied as `LIFIC_URL`; when omitted, the configured `server.public_url` or local bind address is used.
+- `--api-key <KEY>` sends a bearer API key to the HTTP server. It can also be supplied as `LIFIC_API_KEY`.
+
+For example, run the same command against a remote server with:
+
+```shell
+lific --backend http --url https://lific.example.com --api-key "$LIFIC_API_KEY" issue list --project APP
+lific --backend http --url https://lific.example.com --api-key "$LIFIC_API_KEY" issue update APP-42 --status done
+```
+
+HTTP mode uses the authenticated server identity for mutations. In particular, `comment add --user` is only available with the direct SQL backend.
 
 Clap also provides `--help` and `--version`.
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -204,7 +204,8 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
         )
         .route(
             "/api/folders/{id}",
-            delete(resources::delete_folder_handler),
+            put(resources::update_folder)
+                .delete(resources::delete_folder_handler),
         )
         // Users (for dropdowns)
         .route("/api/users", get(auth::list_users))

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -227,6 +227,24 @@ pub(super) async fn delete_folder_handler(
     Ok(Json(serde_json::json!({"deleted": true})))
 }
 
+pub(super) async fn update_folder(
+    State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
+    Path(id): Path<i64>,
+    Extension(auth_user): Extension<Option<AuthUser>>,
+    Json(input): Json<UpdateFolder>,
+) -> Result<Json<Folder>, LificError> {
+    let project_id = with_read(&db, |conn| {
+        crate::db::queries::get_resource_project_id(conn, "folders", id)
+    })?;
+    require_structure_role(&db, &auth_user, project_id)?;
+    let folder = with_write(&db, |conn| {
+        crate::db::queries::update_folder(conn, id, &input)
+    })?;
+    realtime.send(RealtimeEvent::ProjectUpdated { project_id });
+    Ok(Json(folder))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::api::test_helpers::*;
@@ -319,6 +337,42 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn lead_can_update_folder_and_regular_cannot() {
+        let (db, _, lead, regular, project_id) = setup_lead_test();
+        let lead_app = app_as_user(db.clone(), &lead);
+        let created = parse_json(
+            json_post(
+                &lead_app,
+                "/api/folders",
+                serde_json::json!({ "project_id": project_id, "name": "Docs" }),
+            )
+            .await,
+        )
+        .await;
+        let folder_id = created["id"].as_i64().unwrap();
+
+        let updated = parse_json(
+            json_put(
+                &lead_app,
+                &format!("/api/folders/{folder_id}"),
+                serde_json::json!({ "name": "Documentation" }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(updated["name"], "Documentation");
+
+        let regular_app = app_as_user(db, &regular);
+        let response = json_put(
+            &regular_app,
+            &format!("/api/folders/{folder_id}"),
+            serde_json::json!({ "name": "Nope" }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -376,6 +376,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn regular_cannot_create_folder() {
+        let (db, _, _lead, regular, project_id) = setup_lead_test();
+        let regular_app = app_as_user(db, &regular);
+        let response = json_post(
+            &regular_app,
+            "/api/folders",
+            serde_json::json!({ "project_id": project_id, "name": "Docs" }),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
     async fn lead_can_merge_labels_and_regular_cannot() {
         let (db, _, lead, regular, project_id) = setup_lead_test();
         let lead_app = app_as_user(db.clone(), &lead);

--- a/src/authz_coverage_tests.rs
+++ b/src/authz_coverage_tests.rs
@@ -311,6 +311,7 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
         (("POST", "/api/labels/{id}/merge"), Gated(StructureRole)),
         (("GET", "/api/folders"), Gated(Viewer)),
         (("POST", "/api/folders"), Gated(StructureRole)),
+        (("PUT", "/api/folders/{id}"), Gated(StructureRole)),
         (("DELETE", "/api/folders/{id}"), Gated(StructureRole)),
         // ── Pages ──
         (("GET", "/api/pages"), Filtered),

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,6 +1,6 @@
+use crate::db::DbPool;
 use crate::db::models::*;
 use crate::db::queries;
-use crate::db::DbPool;
 use crate::error::LificError;
 
 use super::*;
@@ -62,6 +62,22 @@ fn print_json<T: serde::Serialize>(val: &T) {
     println!("{}", serde_json::to_string_pretty(val).unwrap());
 }
 
+fn owned_labels(value: Option<&str>) -> Option<Vec<String>> {
+    value.map(|value| super::split_csv(value).map(str::to_owned).collect())
+}
+
+fn page_folder_id(
+    conn: &rusqlite::Connection,
+    page_id: i64,
+    name: &str,
+) -> Result<i64, Box<dyn std::error::Error>> {
+    let page = queries::get_page(conn, page_id)?;
+    page.project_id
+        .map(|project_id| queries::resolve_folder_name(conn, project_id, name))
+        .transpose()?
+        .ok_or_else(|| "cannot set folder on workspace page".into())
+}
+
 /// Format a priority with visual indicator for human output.
 fn fmt_priority(p: &str) -> &str {
     match p {
@@ -105,11 +121,10 @@ fn issue(
             let conn = pool.read()?;
             let project_id = queries::resolve_project_identifier(&conn, project)?;
 
-            let module_id = if let Some(name) = module {
-                Some(queries::resolve_module_name(&conn, project_id, name)?)
-            } else {
-                None
-            };
+            let module_id = module
+                .as_deref()
+                .map(|name| queries::resolve_module_name(&conn, project_id, name))
+                .transpose()?;
 
             let issues = queries::list_issues(
                 &conn,
@@ -173,9 +188,10 @@ fn issue(
                     println!("  Labels:   {}", issue.labels.join(", "));
                 }
                 if let Some(mid) = issue.module_id
-                    && let Ok(name) = queries::get_module_name(&conn, mid) {
-                        println!("  Module:   {name}");
-                    }
+                    && let Ok(name) = queries::get_module_name(&conn, mid)
+                {
+                    println!("  Module:   {name}");
+                }
                 if !issue.blocks.is_empty() {
                     println!("  Blocks:   {}", issue.blocks.join(", "));
                 }
@@ -210,21 +226,12 @@ fn issue(
             let conn = pool.write()?;
             let project_id = queries::resolve_project_identifier(&conn, project)?;
 
-            let module_id = if let Some(name) = module {
-                Some(queries::resolve_module_name(&conn, project_id, name)?)
-            } else {
-                None
-            };
-
-            let label_list: Vec<String> = labels
+            let module_id = module
                 .as_deref()
-                .map(|s| {
-                    s.split(',')
-                        .map(|l| l.trim().to_string())
-                        .filter(|l| !l.is_empty())
-                        .collect()
-                })
-                .unwrap_or_default();
+                .map(|name| queries::resolve_module_name(&conn, project_id, name))
+                .transpose()?;
+
+            let label_list = owned_labels(labels.as_deref()).unwrap_or_default();
 
             let issue = queries::create_issue(
                 &conn,
@@ -269,12 +276,7 @@ fn issue(
                 None
             };
 
-            let label_list = labels.as_deref().map(|s| {
-                s.split(',')
-                    .map(|l| l.trim().to_string())
-                    .filter(|l| !l.is_empty())
-                    .collect()
-            });
+            let label_list = owned_labels(labels.as_deref());
 
             let issue = queries::update_issue(
                 &conn,
@@ -414,20 +416,27 @@ fn page(pool: &DbPool, action: &PageAction, json: bool) -> Result<(), Box<dyn st
             label,
         } => {
             let conn = pool.read()?;
-            let project_id = if let Some(ident) = project {
-                Some(queries::resolve_project_identifier(&conn, ident)?)
-            } else {
-                None
-            };
+            let project_id = project
+                .as_deref()
+                .map(|ident| queries::resolve_project_identifier(&conn, ident))
+                .transpose()?;
 
-            let folder_id = if let (Some(pid), Some(fname)) = (project_id, folder) {
-                Some(queries::resolve_folder_name(&conn, pid, fname)?)
-            } else {
-                None
-            };
+            let folder_id = project_id
+                .zip(folder.as_deref())
+                .map(|(project_id, name)| queries::resolve_folder_name(&conn, project_id, name))
+                .transpose()?;
 
-            let pages =
-                queries::list_pages(&conn, project_id, folder_id, label.as_deref(), None, None, None, None, None)?;
+            let pages = queries::list_pages(
+                &conn,
+                project_id,
+                folder_id,
+                label.as_deref(),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )?;
 
             if json {
                 print_json(&pages);
@@ -451,10 +460,7 @@ fn page(pool: &DbPool, action: &PageAction, json: bool) -> Result<(), Box<dyn st
                     } else {
                         format!(" [{}]", p.labels.join(", "))
                     };
-                    println!(
-                        "  {:<12} {} - {}{}",
-                        p.identifier, p.title, preview, labels
-                    );
+                    println!("  {:<12} {} - {}{}", p.identifier, p.title, preview, labels);
                 }
             }
         }
@@ -486,29 +492,19 @@ fn page(pool: &DbPool, action: &PageAction, json: bool) -> Result<(), Box<dyn st
             labels,
         } => {
             let conn = pool.write()?;
-            let project_id = if let Some(ident) = project {
-                Some(queries::resolve_project_identifier(&conn, ident)?)
-            } else {
-                None
-            };
+            let project_id = project
+                .as_deref()
+                .map(|ident| queries::resolve_project_identifier(&conn, ident))
+                .transpose()?;
 
-            let folder_id = if let (Some(pid), Some(fname)) = (project_id, folder) {
-                Some(queries::resolve_folder_name(&conn, pid, fname)?)
-            } else {
-                None
-            };
+            let folder_id = project_id
+                .zip(folder.as_deref())
+                .map(|(project_id, name)| queries::resolve_folder_name(&conn, project_id, name))
+                .transpose()?;
 
             // Same comma-split shape `issue create` uses, so users get
             // one mental model across both CLIs.
-            let label_list: Vec<String> = labels
-                .as_deref()
-                .map(|s| {
-                    s.split(',')
-                        .map(|l| l.trim().to_string())
-                        .filter(|l| !l.is_empty())
-                        .collect()
-                })
-                .unwrap_or_default();
+            let label_list = owned_labels(labels.as_deref()).unwrap_or_default();
 
             let page = queries::create_page(
                 &conn,
@@ -539,23 +535,13 @@ fn page(pool: &DbPool, action: &PageAction, json: bool) -> Result<(), Box<dyn st
             let conn = pool.write()?;
             let id = queries::resolve_page_identifier(&conn, identifier)?;
 
-            let folder_id = if let Some(fname) = folder {
-                let page = queries::get_page(&conn, id)?;
-                if let Some(pid) = page.project_id {
-                    Some(Some(queries::resolve_folder_name(&conn, pid, fname)?))
-                } else {
-                    return Err("cannot set folder on workspace page".into());
-                }
-            } else {
-                None
-            };
+            let folder_id = folder
+                .as_deref()
+                .map(|name| page_folder_id(&conn, id, name))
+                .transpose()?
+                .map(Some);
 
-            let label_list = labels.as_deref().map(|s| {
-                s.split(',')
-                    .map(|l| l.trim().to_string())
-                    .filter(|l| !l.is_empty())
-                    .collect()
-            });
+            let label_list = owned_labels(labels.as_deref());
 
             let page = queries::update_page(
                 &conn,
@@ -591,11 +577,9 @@ fn search(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let conn = pool.read()?;
-    let project_id = if let Some(ident) = project {
-        Some(queries::resolve_project_identifier(&conn, ident)?)
-    } else {
-        None
-    };
+    let project_id = project
+        .map(|ident| queries::resolve_project_identifier(&conn, ident))
+        .transpose()?;
 
     let results = queries::search(
         &conn,
@@ -1069,6 +1053,15 @@ mod tests {
     }
 
     #[test]
+    fn shared_label_parser_trims_and_discards_empty_values() {
+        assert_eq!(
+            owned_labels(Some(" bug, ,urgent ,")),
+            Some(vec!["bug".to_owned(), "urgent".to_owned()])
+        );
+        assert_eq!(owned_labels(None), None);
+    }
+
+    #[test]
     fn exec_project_list_json() {
         let pool = test_pool();
         seed_project(&pool, "LIF");
@@ -1223,6 +1216,42 @@ mod tests {
             },
         };
         run(&pool, &cmd, false).unwrap();
+    }
+
+    #[test]
+    fn exec_workspace_page_folder_update_returns_clear_error() {
+        let pool = test_pool();
+        run(
+            &pool,
+            &Command::Page {
+                action: PageAction::Create {
+                    title: "Workspace doc".into(),
+                    project: None,
+                    folder: None,
+                    content: String::new(),
+                    labels: None,
+                },
+            },
+            true,
+        )
+        .unwrap();
+
+        let error = run(
+            &pool,
+            &Command::Page {
+                action: PageAction::Update {
+                    identifier: "DOC-1".into(),
+                    title: None,
+                    content: None,
+                    folder: Some("folder".into()),
+                    labels: None,
+                },
+            },
+            true,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "cannot set folder on workspace page");
     }
 
     #[test]

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -1,0 +1,1162 @@
+//! HTTP transport for data-oriented CLI commands.
+//!
+//! The SQL executor and this module intentionally share the `Command` enum:
+//! command parsing and output selection stay transport-independent while each
+//! backend owns only identifier resolution and I/O.
+
+use std::{borrow::Cow, fs, path::Path, time::Duration};
+
+use anyhow::{Result, anyhow, bail};
+use reqwest::{
+    Client, Method, RequestBuilder, StatusCode,
+    header::{CONTENT_DISPOSITION, HeaderMap},
+};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use super::{
+    Command, CommentAction, ExportAction, FolderAction, IssueAction, LabelAction, ModuleAction,
+    PageAction, ProjectAction, borrowed_labels,
+};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+type QueryParam<'a> = (&'a str, Cow<'a, str>);
+
+#[derive(Serialize)]
+struct IssueCreate<'a> {
+    project_id: i64,
+    title: &'a str,
+    description: &'a str,
+    status: &'a str,
+    priority: &'a str,
+    module_id: Option<i64>,
+    start_date: Option<&'a str>,
+    target_date: Option<&'a str>,
+    labels: &'a [&'a str],
+    source: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct IssueUpdate<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    priority: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    module_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    labels: Option<&'a [&'a str]>,
+}
+
+#[derive(Serialize)]
+struct ProjectCreate<'a> {
+    name: &'a str,
+    identifier: &'a str,
+    description: &'a str,
+    emoji: Option<&'a str>,
+    lead_user_id: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct ProjectUpdate<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct PageCreate<'a> {
+    project_id: Option<i64>,
+    folder_id: Option<i64>,
+    title: &'a str,
+    content: &'a str,
+    status: &'static str,
+    labels: &'a [&'a str],
+}
+
+#[derive(Serialize)]
+struct PageUpdate<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    folder_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    labels: Option<&'a [&'a str]>,
+}
+
+#[derive(Serialize)]
+struct CommentCreate<'a> {
+    content: &'a str,
+}
+
+#[derive(Serialize)]
+struct ModuleCreate<'a> {
+    project_id: i64,
+    name: &'a str,
+    description: &'a str,
+    status: &'a str,
+    emoji: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct ModuleUpdate<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct LabelCreate<'a> {
+    project_id: i64,
+    name: &'a str,
+    color: &'a str,
+}
+
+#[derive(Serialize)]
+struct LabelUpdate<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct FolderCreate<'a> {
+    project_id: i64,
+    parent_id: Option<i64>,
+    name: &'a str,
+}
+
+#[derive(Serialize)]
+struct FolderUpdate<'a> {
+    name: &'a str,
+}
+
+pub async fn run(
+    command: &Command,
+    base_url: &str,
+    api_key: Option<&str>,
+    json_output: bool,
+) -> Result<()> {
+    let backend = HttpBackend::new(base_url, api_key)?;
+    let output = backend.execute(command).await?;
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_human(&output);
+    }
+    Ok(())
+}
+
+struct HttpBackend {
+    client: Client,
+    base_url: String,
+    api_key: Option<String>,
+}
+
+impl HttpBackend {
+    fn new(base_url: &str, api_key: Option<&str>) -> Result<Self> {
+        let base_url = base_url.trim_end_matches('/');
+        if base_url.is_empty() {
+            bail!("HTTP backend requires a non-empty server URL (use --url or LIFIC_URL)");
+        }
+        let parsed = reqwest::Url::parse(base_url)
+            .map_err(|error| anyhow!("invalid HTTP backend URL '{base_url}': {error}"))?;
+        if parsed.scheme() != "http" && parsed.scheme() != "https" {
+            bail!("HTTP backend URL must use http:// or https://");
+        }
+        Ok(Self {
+            client: Client::builder().timeout(REQUEST_TIMEOUT).build()?,
+            base_url: base_url.to_owned(),
+            api_key: api_key.map(str::to_owned),
+        })
+    }
+
+    async fn execute(&self, command: &Command) -> Result<Value> {
+        match command {
+            Command::Issue { action } => self.issue(action).await,
+            Command::Project { action } => self.project(action).await,
+            Command::Page { action } => self.page(action).await,
+            Command::Export { action } => self.export(action).await,
+            Command::Search {
+                query,
+                project,
+                limit,
+            } => {
+                let project_id = match project {
+                    Some(project) => Some(self.project_id(project).await?),
+                    None => None,
+                };
+                let params = [
+                    Some(("query", Cow::Borrowed(query.as_str()))),
+                    project_id.map(|id| ("project_id", Cow::Owned(id.to_string()))),
+                    limit.map(|value| ("limit", Cow::Owned(value.to_string()))),
+                ]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+                self.get_json("/api/search", &params).await
+            }
+            Command::Comment { action } => self.comment(action).await,
+            Command::Module { action } => self.module(action).await,
+            Command::Label { action } => self.label(action).await,
+            Command::Folder { action } => self.folder(action).await,
+            _ => bail!("the HTTP backend does not support this command yet"),
+        }
+    }
+
+    async fn issue(&self, action: &IssueAction) -> Result<Value> {
+        match action {
+            IssueAction::List {
+                project,
+                status,
+                priority,
+                module,
+                label,
+                workable,
+                limit,
+            } => {
+                let project_id = self.project_id(project).await?;
+                let module_id = match module {
+                    Some(module) => Some(self.module_id(project_id, module).await?),
+                    None => None,
+                };
+                let params = [
+                    Some(("project_id", Cow::Owned(project_id.to_string()))),
+                    status
+                        .as_deref()
+                        .map(|value| ("status", Cow::Borrowed(value))),
+                    priority
+                        .as_deref()
+                        .map(|value| ("priority", Cow::Borrowed(value))),
+                    module_id.map(|id| ("module_id", Cow::Owned(id.to_string()))),
+                    label
+                        .as_deref()
+                        .map(|value| ("label", Cow::Borrowed(value))),
+                    workable.then_some(("workable", Cow::Borrowed("true"))),
+                    limit.map(|value| ("limit", Cow::Owned(value.to_string()))),
+                ]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+                self.get_json("/api/issues", &params).await
+            }
+            IssueAction::Get { identifier } => {
+                self.get_json(&format!("/api/issues/resolve/{}", segment(identifier)), &[])
+                    .await
+            }
+            IssueAction::Create {
+                project,
+                title,
+                description,
+                status,
+                priority,
+                module,
+                labels,
+            } => {
+                let project_id = self.project_id(project).await?;
+                let module_id = match module {
+                    Some(module) => Some(self.module_id(project_id, module).await?),
+                    None => None,
+                };
+                let labels = borrowed_labels(labels.as_deref()).unwrap_or_default();
+                let body = IssueCreate {
+                    project_id,
+                    title,
+                    description,
+                    status,
+                    priority,
+                    module_id,
+                    start_date: None,
+                    target_date: None,
+                    labels: &labels,
+                    source: None,
+                };
+                self.send_json(Method::POST, "/api/issues", &body).await
+            }
+            IssueAction::Update {
+                identifier,
+                title,
+                description,
+                status,
+                priority,
+                module,
+                labels,
+            } => {
+                let id = self.issue_id(identifier).await?;
+                let module_id = match module {
+                    Some(module) => {
+                        let project_id = self.issue_project_id(id).await?;
+                        Some(self.module_id(project_id, module).await?)
+                    }
+                    None => None,
+                };
+                let labels = borrowed_labels(labels.as_deref());
+                let body = IssueUpdate {
+                    title: title.as_deref(),
+                    description: description.as_deref(),
+                    status: status.as_deref(),
+                    priority: priority.as_deref(),
+                    module_id,
+                    labels: labels.as_deref(),
+                };
+                self.send_json(Method::PUT, &format!("/api/issues/{id}"), &body)
+                    .await
+            }
+        }
+    }
+
+    async fn project(&self, action: &ProjectAction) -> Result<Value> {
+        match action {
+            ProjectAction::List => self.get_json("/api/projects", &[]).await,
+            ProjectAction::Get { identifier } => {
+                let id = self.project_id(identifier).await?;
+                self.get_json(&format!("/api/projects/{id}"), &[]).await
+            }
+            ProjectAction::Create {
+                name,
+                identifier,
+                description,
+            } => {
+                self.send_json(
+                    Method::POST,
+                    "/api/projects",
+                    &ProjectCreate {
+                        name,
+                        identifier,
+                        description,
+                        emoji: None,
+                        lead_user_id: None,
+                    },
+                )
+                .await
+            }
+            ProjectAction::Update {
+                identifier,
+                name,
+                description,
+            } => {
+                let id = self.project_id(identifier).await?;
+                let body = ProjectUpdate {
+                    name: name.as_deref(),
+                    description: description.as_deref(),
+                };
+                self.send_json(Method::PUT, &format!("/api/projects/{id}"), &body)
+                    .await
+            }
+        }
+    }
+
+    async fn page(&self, action: &PageAction) -> Result<Value> {
+        match action {
+            PageAction::List {
+                project,
+                folder,
+                label,
+            } => {
+                let project_id = match project {
+                    Some(project) => Some(self.project_id(project).await?),
+                    None => None,
+                };
+                let folder_id = match (project_id, folder) {
+                    (Some(project_id), Some(folder)) => {
+                        Some(self.folder_id(project_id, folder).await?)
+                    }
+                    _ => None,
+                };
+                let params = [
+                    project_id.map(|id| ("project_id", Cow::Owned(id.to_string()))),
+                    folder_id.map(|id| ("folder_id", Cow::Owned(id.to_string()))),
+                    label
+                        .as_deref()
+                        .map(|value| ("label", Cow::Borrowed(value))),
+                ]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+                self.get_json("/api/pages", &params).await
+            }
+            PageAction::Get { identifier } => {
+                let id = self.page_id(identifier).await?;
+                self.get_json(&format!("/api/pages/{id}"), &[]).await
+            }
+            PageAction::Create {
+                title,
+                project,
+                folder,
+                content,
+                labels,
+            } => {
+                let project_id = match project {
+                    Some(project) => Some(self.project_id(project).await?),
+                    None => None,
+                };
+                let folder_id = match (project_id, folder) {
+                    (Some(project_id), Some(folder)) => {
+                        Some(self.folder_id(project_id, folder).await?)
+                    }
+                    _ => None,
+                };
+                let labels = borrowed_labels(labels.as_deref()).unwrap_or_default();
+                self.send_json(
+                    Method::POST,
+                    "/api/pages",
+                    &PageCreate {
+                        project_id,
+                        folder_id,
+                        title,
+                        content,
+                        status: "draft",
+                        labels: &labels,
+                    },
+                )
+                .await
+            }
+            PageAction::Update {
+                identifier,
+                title,
+                content,
+                folder,
+                labels,
+            } => {
+                let id = self.page_id(identifier).await?;
+                let folder_id = match folder {
+                    Some(folder) => {
+                        let page = self.get_json(&format!("/api/pages/{id}"), &[]).await?;
+                        let project_id = page["project_id"]
+                            .as_i64()
+                            .ok_or_else(|| anyhow!("cannot set folder on workspace page"))?;
+                        Some(self.folder_id(project_id, folder).await?)
+                    }
+                    None => None,
+                };
+                let labels = borrowed_labels(labels.as_deref());
+                let body = PageUpdate {
+                    title: title.as_deref(),
+                    content: content.as_deref(),
+                    folder_id,
+                    labels: labels.as_deref(),
+                };
+                self.send_json(Method::PUT, &format!("/api/pages/{id}"), &body)
+                    .await
+            }
+        }
+    }
+
+    async fn comment(&self, action: &CommentAction) -> Result<Value> {
+        match action {
+            CommentAction::List { identifier } => {
+                let id = self.issue_id(identifier).await?;
+                self.get_json(&format!("/api/issues/{id}/comments"), &[])
+                    .await
+            }
+            CommentAction::Add {
+                identifier,
+                content,
+                user,
+            } => {
+                if user.is_some() {
+                    bail!(
+                        "--user cannot be used with the HTTP backend; the server uses the API credential's user"
+                    );
+                }
+                let id = self.issue_id(identifier).await?;
+                self.send_json(
+                    Method::POST,
+                    &format!("/api/issues/{id}/comments"),
+                    &CommentCreate { content },
+                )
+                .await
+            }
+        }
+    }
+
+    async fn module(&self, action: &ModuleAction) -> Result<Value> {
+        match action {
+            ModuleAction::List { project } => {
+                let id = self.project_id(project).await?;
+                self.get_json(
+                    "/api/modules",
+                    &[("project_id", Cow::Owned(id.to_string()))],
+                )
+                .await
+            }
+            ModuleAction::Create {
+                project,
+                name,
+                description,
+                status,
+            } => {
+                let project_id = self.project_id(project).await?;
+                self.send_json(
+                    Method::POST,
+                    "/api/modules",
+                    &ModuleCreate {
+                        project_id,
+                        name,
+                        description,
+                        status,
+                        emoji: None,
+                    },
+                )
+                .await
+            }
+            ModuleAction::Update {
+                project,
+                name,
+                new_name,
+                description,
+                status,
+            } => {
+                let project_id = self.project_id(project).await?;
+                let id = self.module_id(project_id, name).await?;
+                let body = ModuleUpdate {
+                    name: new_name.as_deref(),
+                    description: description.as_deref(),
+                    status: status.as_deref(),
+                };
+                self.send_json(Method::PUT, &format!("/api/modules/{id}"), &body)
+                    .await
+            }
+            ModuleAction::Delete { project, name } => {
+                let id = self
+                    .module_id(self.project_id(project).await?, name)
+                    .await?;
+                self.send_empty(Method::DELETE, &format!("/api/modules/{id}"))
+                    .await
+            }
+        }
+    }
+
+    async fn label(&self, action: &LabelAction) -> Result<Value> {
+        match action {
+            LabelAction::List { project } => {
+                let id = self.project_id(project).await?;
+                self.get_json("/api/labels", &[("project_id", Cow::Owned(id.to_string()))])
+                    .await
+            }
+            LabelAction::Create {
+                project,
+                name,
+                color,
+            } => {
+                let project_id = self.project_id(project).await?;
+                self.send_json(
+                    Method::POST,
+                    "/api/labels",
+                    &LabelCreate {
+                        project_id,
+                        name,
+                        color,
+                    },
+                )
+                .await
+            }
+            LabelAction::Update {
+                project,
+                name,
+                new_name,
+                color,
+            } => {
+                let id = self.label_id(self.project_id(project).await?, name).await?;
+                let body = LabelUpdate {
+                    name: new_name.as_deref(),
+                    color: color.as_deref(),
+                };
+                self.send_json(Method::PUT, &format!("/api/labels/{id}"), &body)
+                    .await
+            }
+            LabelAction::Delete { project, name } => {
+                let id = self.label_id(self.project_id(project).await?, name).await?;
+                self.send_empty(Method::DELETE, &format!("/api/labels/{id}"))
+                    .await
+            }
+        }
+    }
+
+    async fn folder(&self, action: &FolderAction) -> Result<Value> {
+        match action {
+            FolderAction::List { project } => {
+                let id = self.project_id(project).await?;
+                self.get_json(
+                    "/api/folders",
+                    &[("project_id", Cow::Owned(id.to_string()))],
+                )
+                .await
+            }
+            FolderAction::Create { project, name } => {
+                let project_id = self.project_id(project).await?;
+                self.send_json(
+                    Method::POST,
+                    "/api/folders",
+                    &FolderCreate {
+                        project_id,
+                        parent_id: None,
+                        name,
+                    },
+                )
+                .await
+            }
+            FolderAction::Update {
+                project,
+                name,
+                new_name,
+            } => {
+                let id = self
+                    .folder_id(self.project_id(project).await?, name)
+                    .await?;
+                self.send_json(
+                    Method::PUT,
+                    &format!("/api/folders/{id}"),
+                    &FolderUpdate { name: new_name },
+                )
+                .await
+            }
+            FolderAction::Delete { project, name } => {
+                let id = self
+                    .folder_id(self.project_id(project).await?, name)
+                    .await?;
+                self.send_empty(Method::DELETE, &format!("/api/folders/{id}"))
+                    .await
+            }
+        }
+    }
+
+    async fn export(&self, action: &ExportAction) -> Result<Value> {
+        let (path, output) = match action {
+            ExportAction::Issue { identifier, output } => (
+                format!("/api/export/issues/{}", segment(identifier)),
+                output,
+            ),
+            ExportAction::Page { identifier, output } => {
+                (format!("/api/export/pages/{}", segment(identifier)), output)
+            }
+            ExportAction::Project { project, output } => {
+                (format!("/api/export/projects/{}", segment(project)), output)
+            }
+        };
+        let response = self.send(self.request_builder(Method::GET, &path)).await?;
+        let filename = export_filename(response.headers()).unwrap_or_else(|| "export.bin".into());
+        fs::create_dir_all(output)?;
+        let path = output.join(&filename);
+        fs::write(&path, response.bytes().await?)?;
+        Ok(json!({"files": [path.display().to_string()]}))
+    }
+
+    async fn project_id(&self, identifier: &str) -> Result<i64> {
+        self.resolve_id("/api/projects", "identifier", identifier, "project", &[])
+            .await
+    }
+
+    async fn issue_id(&self, identifier: &str) -> Result<i64> {
+        self.get_json(&format!("/api/issues/resolve/{}", segment(identifier)), &[])
+            .await?["id"]
+            .as_i64()
+            .ok_or_else(|| anyhow!("issue '{identifier}' response had no id"))
+    }
+
+    async fn issue_project_id(&self, id: i64) -> Result<i64> {
+        self.get_json(&format!("/api/issues/{id}"), &[]).await?["project_id"]
+            .as_i64()
+            .ok_or_else(|| anyhow!("issue {id} response had no project id"))
+    }
+
+    async fn page_id(&self, identifier: &str) -> Result<i64> {
+        self.resolve_id("/api/pages", "identifier", identifier, "page", &[])
+            .await
+    }
+
+    async fn module_id(&self, project_id: i64, name: &str) -> Result<i64> {
+        self.project_resource_id("/api/modules", project_id, name, "module")
+            .await
+    }
+
+    async fn label_id(&self, project_id: i64, name: &str) -> Result<i64> {
+        self.project_resource_id("/api/labels", project_id, name, "label")
+            .await
+    }
+
+    async fn folder_id(&self, project_id: i64, name: &str) -> Result<i64> {
+        self.project_resource_id("/api/folders", project_id, name, "folder")
+            .await
+    }
+
+    async fn project_resource_id(
+        &self,
+        path: &str,
+        project_id: i64,
+        name: &str,
+        kind: &str,
+    ) -> Result<i64> {
+        let params = [("project_id", Cow::Owned(project_id.to_string()))];
+        self.resolve_id(path, "name", name, kind, &params).await
+    }
+
+    async fn resolve_id(
+        &self,
+        path: &str,
+        key: &str,
+        expected: &str,
+        kind: &str,
+        params: &[QueryParam<'_>],
+    ) -> Result<i64> {
+        find_resource(self.get_json(path, params).await?, key, expected, kind)
+    }
+
+    async fn get_json(&self, path: &str, params: &[QueryParam<'_>]) -> Result<Value> {
+        let response = self
+            .send(self.request_builder(Method::GET, path).query(params))
+            .await?;
+        Ok(response.json().await?)
+    }
+
+    async fn send_json<T: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        path: &str,
+        body: &T,
+    ) -> Result<Value> {
+        Ok(self
+            .send(self.request_builder(method, path).json(body))
+            .await?
+            .json()
+            .await?)
+    }
+
+    async fn send_empty(&self, method: Method, path: &str) -> Result<Value> {
+        let response = self.send(self.request_builder(method, path)).await?;
+        if response.status() == StatusCode::NO_CONTENT {
+            Ok(json!({"deleted": true}))
+        } else {
+            Ok(response.json().await?)
+        }
+    }
+
+    async fn send(&self, request: RequestBuilder) -> Result<reqwest::Response> {
+        let response = request.send().await?;
+        if response.status().is_success() {
+            return Ok(response);
+        }
+        let status = response.status();
+        let message = response.text().await.unwrap_or_default();
+        bail!(
+            "HTTP backend request failed ({status}): {}",
+            error_detail(&message)
+        );
+    }
+
+    fn request_builder(&self, method: Method, path: &str) -> RequestBuilder {
+        let url = format!("{}{}", self.base_url, path);
+        let request = self.client.request(method, url);
+        match self.api_key.as_deref() {
+            Some(key) => request.bearer_auth(key),
+            None => request,
+        }
+    }
+}
+
+fn find_resource(value: Value, key: &str, expected: &str, kind: &str) -> Result<i64> {
+    value
+        .as_array()
+        .and_then(|items| {
+            items.iter().find(|item| {
+                item[key]
+                    .as_str()
+                    .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+            })
+        })
+        .and_then(|item| item["id"].as_i64())
+        .ok_or_else(|| anyhow!("{kind} '{expected}' not found"))
+}
+
+fn segment(value: &str) -> String {
+    urlencoding::encode(value).into_owned()
+}
+
+#[must_use]
+fn safe_filename(value: &str) -> Option<String> {
+    Path::new(value)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| *name != "." && *name != "..")
+        .map(str::to_owned)
+}
+
+fn export_filename(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(CONTENT_DISPOSITION)
+        .and_then(|value| value.to_str().ok())
+        .map(content_disposition::parse_content_disposition)
+        .and_then(|header| header.params.get("filename").cloned())
+        .and_then(|filename| safe_filename(&filename))
+}
+
+fn error_detail(message: &str) -> String {
+    serde_json::from_str::<Value>(message)
+        .ok()
+        .and_then(|value| value["error"].as_str().map(str::to_owned))
+        .unwrap_or_else(|| message.to_owned())
+}
+
+fn print_human(value: &Value) {
+    match value {
+        Value::Array(items) => println!("{} item(s):\n{}", items.len(), pretty(value)),
+        _ => println!("{}", pretty(value)),
+    }
+}
+
+fn pretty(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::{
+        Method,
+        header::{CONTENT_DISPOSITION, HeaderMap},
+    };
+    use serde_json::json;
+
+    use crate::cli::{Command, split_csv};
+
+    use super::{
+        HttpBackend, IssueCreate, IssueUpdate, PageCreate, ProjectCreate, error_detail,
+        export_filename, find_resource, safe_filename, segment,
+    };
+
+    #[test]
+    fn rejects_non_http_backend_urls() {
+        let error = match HttpBackend::new("file://invalid", None) {
+            Ok(_) => panic!("file URL should be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("must use http:// or https://"));
+    }
+
+    #[test]
+    fn rejects_empty_backend_urls() {
+        let error = match HttpBackend::new("///", None) {
+            Ok(_) => panic!("an empty URL should be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("non-empty server URL"));
+    }
+
+    #[test]
+    fn rejects_malformed_backend_urls() {
+        let error = match HttpBackend::new("not a URL", None) {
+            Ok(_) => panic!("a malformed URL should be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("invalid HTTP backend URL"));
+    }
+
+    #[test]
+    fn trims_trailing_backend_url_slashes() {
+        let backend = HttpBackend::new("https://tracker.invalid///", None).unwrap();
+        assert_eq!(backend.base_url, "https://tracker.invalid");
+    }
+
+    #[test]
+    fn builds_authenticated_json_request() {
+        let backend = HttpBackend::new("https://tracker.invalid", Some("key-value")).unwrap();
+        let body = json!({"title": "A test"});
+        let request = backend
+            .request_builder(Method::POST, "/api/issues")
+            .json(&body)
+            .build()
+            .unwrap();
+
+        assert_eq!(request.url().as_str(), "https://tracker.invalid/api/issues");
+        assert_eq!(
+            request.headers().get("authorization").unwrap(),
+            "Bearer key-value"
+        );
+        assert_eq!(
+            request.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+        let body = request.body().and_then(reqwest::Body::as_bytes).unwrap();
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(body).unwrap()["title"],
+            "A test"
+        );
+    }
+
+    #[test]
+    fn builds_request_without_auth_when_key_is_absent() {
+        let backend = HttpBackend::new("https://tracker.invalid", None).unwrap();
+        let request = backend
+            .request_builder(Method::GET, "/api/projects")
+            .build()
+            .unwrap();
+
+        assert!(request.headers().get("authorization").is_none());
+        assert!(request.headers().get("content-type").is_none());
+        assert_eq!(request.url().path(), "/api/projects");
+    }
+
+    #[test]
+    fn encodes_query_parameters_in_request_builder() {
+        let backend = HttpBackend::new("https://tracker.invalid", None).unwrap();
+        let params = [("search term", "a/b".to_owned())];
+        let request = backend
+            .request_builder(Method::GET, "/api/search")
+            .query(&params)
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.url().query_pairs().collect::<Vec<_>>(),
+            vec![("search term".into(), "a/b".into())]
+        );
+    }
+
+    #[test]
+    fn preserves_request_methods_and_paths() {
+        let backend = HttpBackend::new("https://tracker.invalid", None).unwrap();
+        let request = backend
+            .request_builder(Method::DELETE, "/api/labels/4")
+            .build()
+            .unwrap();
+
+        assert_eq!(request.method(), Method::DELETE);
+        assert_eq!(request.url().path(), "/api/labels/4");
+    }
+
+    #[test]
+    fn encodes_identifier_path_segments() {
+        assert_eq!(segment("DOC 1/2"), "DOC%201%2F2");
+    }
+
+    #[test]
+    fn reduces_export_paths_to_safe_basenames() {
+        assert_eq!(
+            safe_filename("../outside/report.txt"),
+            Some("report.txt".to_owned())
+        );
+        assert_eq!(
+            safe_filename("/absolute/report.txt"),
+            Some("report.txt".to_owned())
+        );
+        assert_eq!(safe_filename(".."), None);
+    }
+
+    #[test]
+    fn parses_content_disposition_filenames() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_DISPOSITION,
+            "attachment; filename=\"report.zip\"".parse().unwrap(),
+        );
+        assert_eq!(export_filename(&headers), Some("report.zip".to_owned()));
+    }
+
+    #[test]
+    fn parses_encoded_content_disposition_filenames() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_DISPOSITION,
+            "attachment; filename*=UTF-8''report%20final.zip"
+                .parse()
+                .unwrap(),
+        );
+
+        assert_eq!(
+            export_filename(&headers),
+            Some("report final.zip".to_owned())
+        );
+    }
+
+    #[test]
+    fn splits_csv_values_and_discards_empty_items() {
+        assert_eq!(
+            split_csv(" bug, ,urgent ,").collect::<Vec<_>>(),
+            vec!["bug", "urgent"]
+        );
+        assert!(split_csv("").next().is_none());
+    }
+
+    #[test]
+    fn resolves_resources_case_insensitively() {
+        let resources = json!([
+            {"id": 4, "name": "Backend"},
+            {"id": 9, "name": "Docs"}
+        ]);
+        assert_eq!(
+            find_resource(resources, "name", "backend", "module").unwrap(),
+            4
+        );
+    }
+
+    #[test]
+    fn ignores_resources_with_missing_ids() {
+        let resources = json!([
+            {"name": "Backend"},
+            {"id": 9, "name": "Docs"}
+        ]);
+        let error = find_resource(resources, "name", "backend", "module").unwrap_err();
+        assert_eq!(error.to_string(), "module 'backend' not found");
+    }
+
+    #[test]
+    fn reports_missing_resource_name() {
+        let error = find_resource(json!([]), "name", "missing", "folder").unwrap_err();
+        assert_eq!(error.to_string(), "folder 'missing' not found");
+    }
+
+    #[test]
+    fn reports_missing_resource_key() {
+        let error = find_resource(
+            json!([{"id": 2, "title": "Docs"}]),
+            "name",
+            "Docs",
+            "folder",
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "folder 'Docs' not found");
+    }
+
+    #[test]
+    fn preserves_optional_json_fields_only_when_set() {
+        let body = serde_json::to_value(IssueUpdate {
+            title: Some("Updated"),
+            description: None,
+            status: None,
+            priority: None,
+            module_id: None,
+            labels: None,
+        })
+        .unwrap();
+        assert_eq!(body["title"], "Updated");
+        assert!(body.get("description").is_none());
+    }
+
+    #[test]
+    fn preserves_empty_optional_json_values() {
+        let body = serde_json::to_value(IssueUpdate {
+            title: None,
+            description: Some(""),
+            status: None,
+            priority: None,
+            module_id: None,
+            labels: None,
+        })
+        .unwrap();
+        assert_eq!(body["description"], "");
+    }
+
+    #[test]
+    fn extracts_structured_server_error_messages() {
+        assert_eq!(
+            error_detail(r#"{"error":"access denied"}"#),
+            "access denied"
+        );
+        assert_eq!(error_detail("connection refused"), "connection refused");
+        assert_eq!(
+            error_detail(r#"{"message":"access denied"}"#),
+            r#"{"message":"access denied"}"#
+        );
+    }
+
+    #[test]
+    fn builds_issue_create_payload_with_nullable_fields() {
+        let labels = vec!["bug"];
+        let payload = serde_json::to_value(IssueCreate {
+            project_id: 7,
+            title: "Broken link",
+            description: "Details",
+            status: "backlog",
+            priority: "high",
+            module_id: None,
+            start_date: None,
+            target_date: None,
+            labels: &labels,
+            source: None,
+        })
+        .unwrap();
+        assert_eq!(payload["project_id"], 7);
+        assert_eq!(payload["title"], "Broken link");
+        assert_eq!(payload["labels"], json!(["bug"]));
+        assert!(payload["module_id"].is_null());
+        assert!(payload["source"].is_null());
+    }
+
+    #[test]
+    fn builds_project_create_payload_with_server_defaults() {
+        let payload = serde_json::to_value(ProjectCreate {
+            name: "Docs",
+            identifier: "DOC",
+            description: "Reference material",
+            emoji: None,
+            lead_user_id: None,
+        })
+        .unwrap();
+        assert_eq!(payload["name"], "Docs");
+        assert_eq!(payload["identifier"], "DOC");
+        assert_eq!(payload["description"], "Reference material");
+        assert!(payload["emoji"].is_null());
+        assert!(payload["lead_user_id"].is_null());
+    }
+
+    #[test]
+    fn builds_page_create_payload_for_workspace_pages() {
+        let labels = Vec::new();
+        let payload = serde_json::to_value(PageCreate {
+            project_id: None,
+            folder_id: None,
+            title: "Runbook",
+            content: "# Steps",
+            status: "draft",
+            labels: &labels,
+        })
+        .unwrap();
+        assert!(payload["project_id"].is_null());
+        assert!(payload["folder_id"].is_null());
+        assert_eq!(payload["status"], "draft");
+        assert_eq!(payload["labels"], json!([]));
+    }
+
+    #[test]
+    fn builds_page_create_payload_with_project_folder_and_labels() {
+        let labels = vec!["ops", "ship"];
+        let payload = serde_json::to_value(PageCreate {
+            project_id: Some(3),
+            folder_id: Some(8),
+            title: "Release",
+            content: "Notes",
+            status: "draft",
+            labels: &labels,
+        })
+        .unwrap();
+        assert_eq!(payload["project_id"], 3);
+        assert_eq!(payload["folder_id"], 8);
+        assert_eq!(payload["labels"], json!(["ops", "ship"]));
+    }
+
+    #[tokio::test]
+    async fn rejects_commands_outside_http_data_scope() {
+        let backend = HttpBackend::new("https://tracker.invalid", None).unwrap();
+        let error = backend
+            .execute(&Command::Start {
+                port: None,
+                host: None,
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "the HTTP backend does not support this command yet"
+        );
+    }
+}

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -166,7 +166,7 @@ struct HttpBackend {
 
 impl HttpBackend {
     fn new(base_url: &str, api_key: Option<&str>) -> Result<Self> {
-        let base_url = base_url.trim_end_matches('/');
+        let base_url = base_url.trim().trim_end_matches('/');
         if base_url.is_empty() {
             bail!("HTTP backend requires a non-empty server URL (use --url or LIFIC_URL)");
         }
@@ -927,6 +927,12 @@ mod tests {
     #[test]
     fn trims_trailing_backend_url_slashes() {
         let backend = HttpBackend::new("https://tracker.invalid///", None).unwrap();
+        assert_eq!(backend.base_url, "https://tracker.invalid");
+    }
+
+    #[test]
+    fn trims_backend_url_whitespace_before_trailing_slashes() {
+        let backend = HttpBackend::new("  https://tracker.invalid///  ", None).unwrap();
         assert_eq!(backend.base_url, "https://tracker.invalid");
     }
 

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -364,16 +364,9 @@ impl HttpBackend {
                 folder,
                 label,
             } => {
-                let project_id = match project {
-                    Some(project) => Some(self.project_id(project).await?),
-                    None => None,
-                };
-                let folder_id = match (project_id, folder) {
-                    (Some(project_id), Some(folder)) => {
-                        Some(self.folder_id(project_id, folder).await?)
-                    }
-                    _ => None,
-                };
+                let (project_id, folder_id) = self
+                    .page_scope(project.as_deref(), folder.as_deref())
+                    .await?;
                 let params = [
                     project_id.map(|id| ("project_id", Cow::Owned(id.to_string()))),
                     folder_id.map(|id| ("folder_id", Cow::Owned(id.to_string()))),
@@ -397,16 +390,9 @@ impl HttpBackend {
                 content,
                 labels,
             } => {
-                let project_id = match project {
-                    Some(project) => Some(self.project_id(project).await?),
-                    None => None,
-                };
-                let folder_id = match (project_id, folder) {
-                    (Some(project_id), Some(folder)) => {
-                        Some(self.folder_id(project_id, folder).await?)
-                    }
-                    _ => None,
-                };
+                let (project_id, folder_id) = self
+                    .page_scope(project.as_deref(), folder.as_deref())
+                    .await?;
                 let labels = borrowed_labels(labels.as_deref()).unwrap_or_default();
                 self.send_json(
                     Method::POST,
@@ -658,6 +644,22 @@ impl HttpBackend {
             .await
     }
 
+    async fn page_scope(
+        &self,
+        project: Option<&str>,
+        folder: Option<&str>,
+    ) -> Result<(Option<i64>, Option<i64>)> {
+        let project_id = match project {
+            Some(project) => Some(self.project_id(project).await?),
+            None => None,
+        };
+        let folder_id = match project_id.zip(folder) {
+            Some((project_id, folder)) => Some(self.folder_id(project_id, folder).await?),
+            None => None,
+        };
+        Ok((project_id, folder_id))
+    }
+
     async fn issue_id(&self, identifier: &str) -> Result<i64> {
         self.get_json(&format!("/api/issues/resolve/{}", segment(identifier)), &[])
             .await?["id"]
@@ -821,18 +823,79 @@ fn pretty(value: &Value) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::{path::PathBuf, sync::Arc};
+
+    use axum::{
+        Json, Router,
+        body::Body,
+        extract::{Request, State},
+        http::{HeaderValue, StatusCode},
+        response::Response,
+        routing::{any, get},
+    };
     use reqwest::{
         Method,
         header::{CONTENT_DISPOSITION, HeaderMap},
     };
     use serde_json::json;
+    use tokio::{net::TcpListener, sync::Mutex, task::JoinHandle};
 
-    use crate::cli::{Command, split_csv};
+    use crate::cli::{Command, ExportAction, PageAction, ProjectAction, split_csv};
 
     use super::{
         HttpBackend, IssueCreate, IssueUpdate, PageCreate, ProjectCreate, error_detail,
         export_filename, find_resource, safe_filename, segment,
     };
+
+    type CapturedRequest = Arc<Mutex<Option<(String, Option<String>)>>>;
+
+    async fn spawn_server(router: Router) -> (String, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        (format!("http://{address}"), task)
+    }
+
+    async fn capture_request(
+        State(captured): State<CapturedRequest>,
+        request: Request,
+    ) -> Json<serde_json::Value> {
+        let authorization = request
+            .headers()
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        *captured.lock().await = Some((request.uri().to_string(), authorization));
+        Json(json!([{"id": 1}]))
+    }
+
+    async fn failed_request() -> (StatusCode, Json<serde_json::Value>) {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "request rejected"})),
+        )
+    }
+
+    async fn export_response() -> Response {
+        let mut response = Response::new(Body::from("export contents"));
+        response.headers_mut().insert(
+            CONTENT_DISPOSITION,
+            HeaderValue::from_static("attachment; filename=report.txt"),
+        );
+        response
+    }
+
+    async fn page_scope_request(request: Request) -> Json<serde_json::Value> {
+        let value = match request.uri().path() {
+            "/api/projects" => json!([{"id": 3, "identifier": "LIF"}]),
+            "/api/folders" => json!([{"id": 8, "name": "Docs"}]),
+            "/api/pages" => json!([{"id": 9, "title": "Release notes"}]),
+            _ => json!([]),
+        };
+        Json(value)
+    }
 
     #[test]
     fn rejects_non_http_backend_urls() {
@@ -932,6 +995,107 @@ mod tests {
 
         assert_eq!(request.method(), Method::DELETE);
         assert_eq!(request.url().path(), "/api/labels/4");
+    }
+
+    #[tokio::test]
+    async fn executes_search_over_http_with_auth_and_query() {
+        let captured = Arc::new(Mutex::new(None));
+        let router = Router::new()
+            .route("/api/search", any(capture_request))
+            .with_state(captured.clone());
+        let (url, server) = spawn_server(router).await;
+        let backend = HttpBackend::new(&url, Some("test-key")).unwrap();
+
+        let output = backend
+            .execute(&Command::Search {
+                query: "term".into(),
+                project: None,
+                limit: Some(7),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(output, json!([{"id": 1}]));
+        assert_eq!(
+            captured.lock().await.as_ref(),
+            Some(&(
+                "/api/search?query=term&limit=7".into(),
+                Some("Bearer test-key".into())
+            ))
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn executes_page_list_with_project_and_folder_resolution() {
+        let router = Router::new().route("/api/{*path}", any(page_scope_request));
+        let (url, server) = spawn_server(router).await;
+        let backend = HttpBackend::new(&url, None).unwrap();
+
+        let output = backend
+            .execute(&Command::Page {
+                action: PageAction::List {
+                    project: Some("LIF".into()),
+                    folder: Some("Docs".into()),
+                    label: None,
+                },
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(output, json!([{"id": 9, "title": "Release notes"}]));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn reports_http_error_details_from_server_responses() {
+        let router = Router::new().route("/api/projects", get(failed_request));
+        let (url, server) = spawn_server(router).await;
+        let backend = HttpBackend::new(&url, None).unwrap();
+
+        let error = backend
+            .execute(&Command::Project {
+                action: ProjectAction::List,
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "HTTP backend request failed (400 Bad Request): request rejected"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn writes_http_export_response_using_server_filename() {
+        let router = Router::new().route("/api/export/issues/{identifier}", get(export_response));
+        let (url, server) = spawn_server(router).await;
+        let backend = HttpBackend::new(&url, None).unwrap();
+        let output_dir =
+            std::env::temp_dir().join(format!("lific-http-export-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&output_dir);
+
+        let output = backend
+            .execute(&Command::Export {
+                action: ExportAction::Issue {
+                    identifier: "LIF-1".into(),
+                    output: PathBuf::from(&output_dir),
+                },
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(output_dir.join("report.txt")).unwrap(),
+            "export contents"
+        );
+        assert_eq!(
+            output["files"][0],
+            output_dir.join("report.txt").display().to_string()
+        );
+        std::fs::remove_dir_all(output_dir).unwrap();
+        server.abort();
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,14 +3,50 @@ pub mod connect;
 pub mod credentials;
 pub mod doctor;
 pub mod exec;
+pub mod http;
 pub mod import;
 pub mod login;
 pub mod service;
 pub mod term;
 pub mod ui;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
+
+#[must_use = "iterate over the non-empty CSV values"]
+pub(super) fn split_csv(value: &str) -> impl Iterator<Item = &str> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+#[must_use = "use the parsed label values"]
+pub(super) fn borrowed_labels(value: Option<&str>) -> Option<Vec<&str>> {
+    value.map(|value| split_csv(value).collect())
+}
+
+#[must_use = "use the resolved HTTP credential"]
+pub(super) fn resolve_http_credential(
+    explicit: Option<&str>,
+    stored: impl FnOnce() -> Option<String>,
+) -> Option<String> {
+    explicit
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .or_else(stored)
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum BackendKind {
+    /// Execute commands against the configured SQLite database.
+    Sql,
+    /// Execute commands against a Lific HTTP server.
+    Http,
+}
 
 #[derive(Parser)]
 #[command(
@@ -30,6 +66,19 @@ pub struct Cli {
     /// Output as JSON (for scripting/agent consumption)
     #[arg(long, global = true)]
     pub json: bool,
+
+    /// Backend for data commands (defaults to the local SQLite database).
+    #[arg(long, global = true, value_enum, default_value_t = BackendKind::Sql)]
+    pub backend: BackendKind,
+
+    /// Base URL for the HTTP backend (also read from LIFIC_URL).
+    #[arg(long, global = true, env = "LIFIC_URL")]
+    pub url: Option<String>,
+
+    /// API key for the HTTP backend (also read from LIFIC_API_KEY; login
+    /// credentials are used when this is omitted).
+    #[arg(long = "api-key", global = true, env = "LIFIC_API_KEY")]
+    pub api_key: Option<String>,
 
     #[command(subcommand)]
     pub command: Command,
@@ -1148,6 +1197,95 @@ pub enum UserAction {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    #[test]
+    fn borrowed_labels_preserve_values_without_owning_strings() {
+        assert_eq!(
+            borrowed_labels(Some(" bug, ,urgent ")),
+            Some(vec!["bug", "urgent"])
+        );
+        assert_eq!(borrowed_labels(None), None);
+    }
+
+    #[test]
+    fn http_credential_prefers_explicit_and_ignores_blank_values() {
+        assert_eq!(
+            resolve_http_credential(Some(" explicit "), || Some("stored".into())),
+            Some("explicit".into())
+        );
+        assert_eq!(
+            resolve_http_credential(Some("  "), || Some(" stored ".into())),
+            Some("stored".into())
+        );
+        assert_eq!(resolve_http_credential(None, || Some("  ".into())), None);
+    }
+
+    #[test]
+    fn http_credential_skips_stored_lookup_when_explicit_is_present() {
+        let mut loaded = false;
+        let credential = resolve_http_credential(Some("explicit"), || {
+            loaded = true;
+            Some("stored".into())
+        });
+
+        assert_eq!(credential, Some("explicit".into()));
+        assert!(!loaded);
+    }
+
+    #[test]
+    fn parses_http_backend_connection_options() {
+        let cli = Cli::try_parse_from([
+            "lific",
+            "--backend",
+            "http",
+            "--url",
+            "https://tracker.example.test",
+            "--api-key",
+            "key-123",
+            "issue",
+            "list",
+            "--project",
+            "LIF",
+        ])
+        .expect("HTTP backend options should parse");
+
+        assert_eq!(cli.backend, BackendKind::Http);
+        assert_eq!(cli.url.as_deref(), Some("https://tracker.example.test"));
+        assert_eq!(cli.api_key.as_deref(), Some("key-123"));
+    }
+
+    #[test]
+    fn defaults_to_sql_backend_without_remote_options() {
+        let cli = Cli::try_parse_from(["lific", "project", "list"])
+            .expect("default backend options should parse");
+
+        assert_eq!(cli.backend, BackendKind::Sql);
+        assert!(cli.url.is_none());
+        assert!(cli.api_key.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_backend_values() {
+        assert!(
+            Cli::try_parse_from(["lific", "--backend", "remote", "project", "list"]).is_err()
+        );
+    }
+
+    #[test]
+    fn parses_json_output_alongside_http_backend() {
+        let cli = Cli::try_parse_from([
+            "lific",
+            "--backend",
+            "http",
+            "--json",
+            "project",
+            "list",
+        ])
+        .expect("JSON output should be transport independent");
+
+        assert_eq!(cli.backend, BackendKind::Http);
+        assert!(cli.json);
+    }
 
     #[test]
     fn parse_start_defaults() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,9 @@ use axum::{
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
 use clap::{CommandFactory, Parser};
-use cli::{Cli, Command, InstanceAction, KeyAction, MemberAction, ServiceAction, UserAction};
+use cli::{
+    BackendKind, Cli, Command, InstanceAction, KeyAction, MemberAction, ServiceAction, UserAction,
+};
 use config::Config;
 
 // Commands that operate directly on the database (no server required)
@@ -140,6 +142,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // CLI overrides
     if let Some(ref db) = cli.db {
         cfg.database.path = db.clone();
+    }
+
+    if cli.backend == BackendKind::Http {
+        if !is_crud_command(&cli.command) {
+            return Err(
+                "the HTTP backend currently supports data commands: issue, project, page, export, search, comment, module, label, and folder"
+                    .into(),
+            );
+        }
+        let url = http_backend_url(
+            cli.url.as_deref(),
+            cfg.server.public_url.as_deref(),
+            &cfg,
+        );
+        let api_key = cli::resolve_http_credential(
+            cli.api_key.as_deref(),
+            || cli::credentials::load(&url),
+        );
+        let json = cli::term::wants_json(cli.json);
+        return cli::http::run(&cli.command, &url, api_key.as_deref(), json)
+            .await
+            .map_err(Into::into);
     }
 
     // Handle CRUD commands (direct database access, no server needed)
@@ -1308,6 +1332,13 @@ fn local_url(cfg: &Config) -> String {
     format!("http://{}:{}", host, cfg.server.port)
 }
 
+fn http_backend_url(cli_url: Option<&str>, public_url: Option<&str>, cfg: &Config) -> String {
+    cli_url
+        .or(public_url)
+        .map(str::to_owned)
+        .unwrap_or_else(|| local_url(cfg))
+}
+
 /// Print the one-time initial API key. No box-drawing: keys are longer than
 /// any fixed-width frame (the old box rendered broken), and plain lines are
 /// easier to copy.
@@ -1939,6 +1970,40 @@ mod init_target_tests {
         .await
         .unwrap_err();
         assert!(err.to_string().contains("--here conflicts with --config"));
+    }
+}
+
+#[cfg(test)]
+mod http_backend_url_tests {
+    use super::{http_backend_url, Config};
+
+    #[test]
+    fn maps_bind_any_hosts_to_loopback() {
+        let cfg = Config::default();
+
+        assert_eq!(
+            http_backend_url(None, None, &cfg),
+            "http://127.0.0.1:3456"
+        );
+    }
+
+    #[test]
+    fn preserves_explicit_cli_and_public_urls() {
+        let mut cfg = Config::default();
+        cfg.server.public_url = Some("https://public.example.test".into());
+
+        assert_eq!(
+            http_backend_url(None, cfg.server.public_url.as_deref(), &cfg),
+            "https://public.example.test"
+        );
+        assert_eq!(
+            http_backend_url(
+                Some("https://cli.example.test"),
+                cfg.server.public_url.as_deref(),
+                &cfg,
+            ),
+            "https://cli.example.test"
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1979,11 +1979,13 @@ mod http_backend_url_tests {
 
     #[test]
     fn maps_bind_any_hosts_to_loopback() {
-        let cfg = Config::default();
+        let mut cfg = Config::default();
+        cfg.server.host = "0.0.0.0".into();
+        cfg.server.port = 4567;
 
         assert_eq!(
             http_backend_url(None, None, &cfg),
-            "http://127.0.0.1:3456"
+            "http://127.0.0.1:4567"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `--backend sql|http`, keeping SQLite as the default while allowing data commands to execute through a Lific HTTP server.
- Support authenticated HTTP execution for issue, project, page, search, export, comment, module, label, and folder commands, including identifier lookups, query parameters, JSON and human output, and server-provided export filenames.
- Resolve HTTP connection settings from CLI flags and `LIFIC_URL`, `LIFIC_API_KEY`, `LIFIC_TOKEN`, and stored login credentials, with explicit values taking precedence.
- Add the folder update API route with project authorization and update-event parity.
- Share label and optional-resource handling between SQL and HTTP execution paths.
- Document remote CLI usage and credential fallback behavior.

## Maintainer notes

- Existing SQL behavior remains the default.
- HTTP mode is intentionally limited to data-oriented commands; server administration and setup commands stay outside this backend.
- The HTTP backend uses the existing command model and API resource semantics so the two execution paths remain aligned.