### PR TITLE
Per-user project groups in the sidebar

### DIFF
--- a/migrations/035_project_groups.sql
+++ b/migrations/035_project_groups.sql
@@ -1,0 +1,35 @@
+-- Per-user grouping of projects in the sidebar.
+--
+-- Deliberately not called a folder: `folders` (001_initial.sql) is a
+-- project-scoped, nestable container for pages. Two concepts sharing that
+-- word would make every `grep folder` return unrelated hits.
+--
+-- Per-user rather than instance-wide because project visibility is per-user
+-- through project_members once authz_enforced is on (authz::can_view_project),
+-- so a shared group would render as an empty group for anyone without access
+-- to the projects inside it.
+
+CREATE TABLE IF NOT EXISTS project_groups (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       TEXT    NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT    NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (user_id, name)
+);
+
+-- A project belongs to at most one group per user. That invariant spans rows
+-- in different groups, so it lives in the query layer (assign_project clears
+-- any existing membership inside one SAVEPOINT) rather than in a constraint,
+-- matching this codebase's preference for query-layer invariants over exotic
+-- constraints (see the 029_saved_views.sql header).
+CREATE TABLE IF NOT EXISTS project_group_items (
+    group_id   INTEGER NOT NULL REFERENCES project_groups(id) ON DELETE CASCADE,
+    project_id INTEGER NOT NULL REFERENCES projects(id)       ON DELETE CASCADE,
+    PRIMARY KEY (group_id, project_id)
+);
+
+-- assign_project deletes by project_id across all of one user's groups.
+CREATE INDEX IF NOT EXISTS idx_project_group_items_project
+    ON project_group_items(project_id);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,7 @@ mod issues;
 mod members;
 mod pages;
 mod plans;
+mod project_groups;
 mod projects;
 mod resources;
 mod views;
@@ -103,6 +104,21 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
             get(projects::get_project)
                 .put(projects::update_project)
                 .delete(projects::delete_project_handler),
+        )
+        // Per-user sidebar project groups. Identity-scoped, no project role
+        // for CRUD — see src/api/project_groups.rs's doc comment. `assign`
+        // sits before `{id}` for the same reason as `projects/reorder`.
+        .route(
+            "/api/project-groups",
+            get(project_groups::list_groups).post(project_groups::create_group),
+        )
+        .route(
+            "/api/project-groups/assign",
+            put(project_groups::assign_project),
+        )
+        .route(
+            "/api/project-groups/{id}",
+            patch(project_groups::update_group).delete(project_groups::delete_group),
         )
         // Issues
         .route(

--- a/src/api/project_groups.rs
+++ b/src/api/project_groups.rs
@@ -1,0 +1,253 @@
+//! Per-user project groups for the sidebar.
+//!
+//! Authorization here is identity-only: any authenticated user manages their
+//! own groups, and every query is scoped by `user_id` in the query layer, so
+//! group CRUD has no project role to check. Assignment is the exception — its
+//! body names a project id, so it takes the normal Viewer gate. Without that,
+//! a user could file a project they can't see into a group and learn the id
+//! exists.
+
+use axum::{
+    Extension,
+    extract::{Json, Path, State},
+};
+
+use crate::authz;
+use crate::db::queries::project_groups;
+use crate::db::{DbPool, models::*};
+use crate::error::LificError;
+use crate::realtime::{RealtimeEvent, RealtimeHub};
+
+use super::{with_read, with_write};
+
+/// `LificError` has no Unauthorized variant — Forbidden is what the codebase
+/// uses for "no authenticated caller", same as `views::require_user`.
+fn require_user(auth_user: Option<AuthUser>) -> Result<AuthUser, LificError> {
+    auth_user.ok_or_else(|| {
+        LificError::Forbidden("authentication required to manage project groups".into())
+    })
+}
+
+pub(super) async fn list_groups(
+    State(db): State<DbPool>,
+    Extension(auth_user): Extension<Option<AuthUser>>,
+) -> Result<Json<Vec<ProjectGroup>>, LificError> {
+    let visible = authz::visible_project_ids(&db, &auth_user)?;
+    let user = require_user(auth_user)?;
+    let mut groups = with_read(&db, |conn| project_groups::list_groups(conn, user.id))?;
+    // A membership outlives the caller's access to that project when a
+    // project_members row is revoked. Drop those ids rather than render a
+    // sidebar entry that 403s the moment it's clicked.
+    if let Some(ids) = &visible {
+        for group in &mut groups {
+            group.project_ids.retain(|id| ids.contains(id));
+        }
+    }
+    Ok(Json(groups))
+}
+
+pub(super) async fn create_group(
+    State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
+    Extension(auth_user): Extension<Option<AuthUser>>,
+    Json(input): Json<CreateProjectGroup>,
+) -> Result<Json<ProjectGroup>, LificError> {
+    let user = require_user(auth_user)?;
+    let group = with_write(&db, |conn| {
+        project_groups::create_group(conn, user.id, &input)
+    })?;
+    realtime.send_to_users(RealtimeEvent::ProjectGroupsChanged, vec![user.id]);
+    Ok(Json(group))
+}
+
+pub(super) async fn update_group(
+    State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
+    Extension(auth_user): Extension<Option<AuthUser>>,
+    Path(id): Path<i64>,
+    Json(input): Json<UpdateProjectGroup>,
+) -> Result<Json<ProjectGroup>, LificError> {
+    let user = require_user(auth_user)?;
+    let group = with_write(&db, |conn| {
+        project_groups::update_group(conn, id, user.id, &input)
+    })?;
+    realtime.send_to_users(RealtimeEvent::ProjectGroupsChanged, vec![user.id]);
+    Ok(Json(group))
+}
+
+pub(super) async fn delete_group(
+    State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
+    Extension(auth_user): Extension<Option<AuthUser>>,
+    Path(id): Path<i64>,
+) -> Result<Json<serde_json::Value>, LificError> {
+    let user = require_user(auth_user)?;
+    let deleted = with_write(&db, |conn| project_groups::delete_group(conn, id, user.id))?;
+    realtime.send_to_users(RealtimeEvent::ProjectGroupsChanged, vec![user.id]);
+    Ok(Json(serde_json::json!({ "deleted": deleted })))
+}
+
+pub(super) async fn assign_project(
+    State(db): State<DbPool>,
+    Extension(realtime): Extension<RealtimeHub>,
+    Extension(auth_user): Extension<Option<AuthUser>>,
+    Json(input): Json<AssignProjectGroup>,
+) -> Result<Json<serde_json::Value>, LificError> {
+    authz::require_role(&db, &auth_user, input.project_id, Role::Viewer)?;
+    let user = require_user(auth_user)?;
+    with_write(&db, |conn| {
+        project_groups::assign_project(conn, user.id, input.project_id, input.group_id)
+    })?;
+    realtime.send_to_users(RealtimeEvent::ProjectGroupsChanged, vec![user.id]);
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::test_helpers::*;
+    use axum::http::StatusCode;
+
+    #[tokio::test]
+    async fn a_user_can_create_list_rename_and_delete_their_own_group() {
+        let (db, _admin, _lead, _maintainer, viewer, _non_member, _project_id) =
+            setup_membership_test();
+        let app = app_as_user(db, &viewer);
+
+        let resp = json_post(
+            &app,
+            "/api/project-groups",
+            serde_json::json!({ "name": "Work" }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let created = parse_json(resp).await;
+        let group_id = created["id"].as_i64().unwrap();
+        assert_eq!(created["name"], "Work");
+        assert_eq!(created["project_ids"].as_array().unwrap().len(), 0);
+
+        let resp = json_get(&app, "/api/project-groups").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(parse_json(resp).await.as_array().unwrap().len(), 1);
+
+        let resp = json_patch(
+            &app,
+            &format!("/api/project-groups/{group_id}"),
+            serde_json::json!({ "name": "Day job" }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(parse_json(resp).await["name"], "Day job");
+
+        let resp = json_delete(&app, &format!("/api/project-groups/{group_id}")).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(parse_json(resp).await["deleted"], true);
+    }
+
+    #[tokio::test]
+    async fn duplicate_group_name_conflicts() {
+        let (db, _admin, _lead, _maintainer, viewer, _non_member, _project_id) =
+            setup_membership_test();
+        let app = app_as_user(db, &viewer);
+
+        json_post(
+            &app,
+            "/api/project-groups",
+            serde_json::json!({ "name": "Work" }),
+        )
+        .await;
+        let resp = json_post(
+            &app,
+            "/api/project-groups",
+            serde_json::json!({ "name": "Work" }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn another_users_group_is_not_found_rather_than_forbidden() {
+        let (db, _admin, _lead, _maintainer, viewer, non_member, _project_id) =
+            setup_membership_test();
+        let owner_app = app_as_user(db.clone(), &viewer);
+        let other_app = app_as_user(db, &non_member);
+
+        let created = parse_json(
+            json_post(
+                &owner_app,
+                "/api/project-groups",
+                serde_json::json!({ "name": "Work" }),
+            )
+            .await,
+        )
+        .await;
+        let group_id = created["id"].as_i64().unwrap();
+
+        let resp = json_patch(
+            &other_app,
+            &format!("/api/project-groups/{group_id}"),
+            serde_json::json!({ "name": "Stolen" }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        // And it must not appear in their own list either.
+        let resp = json_get(&other_app, "/api/project-groups").await;
+        assert_eq!(parse_json(resp).await.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn assigning_a_project_the_caller_cannot_view_is_refused() {
+        let (db, _admin, _lead, _maintainer, _viewer, non_member, project_id) =
+            setup_membership_test();
+        let app = app_as_user(db, &non_member);
+
+        let created = parse_json(
+            json_post(
+                &app,
+                "/api/project-groups",
+                serde_json::json!({ "name": "Mine" }),
+            )
+            .await,
+        )
+        .await;
+        let group_id = created["id"].as_i64().unwrap();
+
+        let resp = json_put(
+            &app,
+            "/api/project-groups/assign",
+            serde_json::json!({ "project_id": project_id, "group_id": group_id }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn assigned_project_appears_in_the_group_listing() {
+        let (db, _admin, _lead, _maintainer, viewer, _non_member, project_id) =
+            setup_membership_test();
+        let app = app_as_user(db, &viewer);
+
+        let created = parse_json(
+            json_post(
+                &app,
+                "/api/project-groups",
+                serde_json::json!({ "name": "Work" }),
+            )
+            .await,
+        )
+        .await;
+        let group_id = created["id"].as_i64().unwrap();
+
+        let resp = json_put(
+            &app,
+            "/api/project-groups/assign",
+            serde_json::json!({ "project_id": project_id, "group_id": group_id }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = json_get(&app, "/api/project-groups").await;
+        let groups = parse_json(resp).await;
+        assert_eq!(groups[0]["project_ids"][0].as_i64().unwrap(), project_id);
+    }
+}

--- a/src/api/project_groups.rs
+++ b/src/api/project_groups.rs
@@ -6,6 +6,10 @@
 //! body names a project id, so it takes the normal Viewer gate. Without that,
 //! a user could file a project they can't see into a group and learn the id
 //! exists.
+//!
+//! The `ProjectGroupsChanged` events below are addressed to the owning user,
+//! which in this codebase still means admins receive them — see that
+//! variant's doc comment for what that does and doesn't expose.
 
 use axum::{
     Extension,

--- a/src/authz_coverage_tests.rs
+++ b/src/authz_coverage_tests.rs
@@ -239,6 +239,28 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
         (("GET", "/api/projects/{id}"), Gated(Viewer)),
         (("PUT", "/api/projects/{id}"), Gated(Lead)),
         (("DELETE", "/api/projects/{id}"), Gated(ProjectDelete)),
+        // ── Sidebar project groups (per-user) ──
+        // CRUD is identity-scoped, not project-scoped: every query filters on
+        // the caller's user_id and an id belonging to someone else 404s, so
+        // there is no project role to gate on. `assign` is the exception —
+        // its body names a project, so it takes the Viewer gate.
+        (
+            ("GET", "/api/project-groups"),
+            Exempt("per-user groups; ownership enforced in the query layer by user_id"),
+        ),
+        (
+            ("POST", "/api/project-groups"),
+            Exempt("per-user groups; creates only for the caller"),
+        ),
+        (
+            ("PATCH", "/api/project-groups/{id}"),
+            Exempt("per-user groups; another user's id is NotFound, never Forbidden"),
+        ),
+        (
+            ("DELETE", "/api/project-groups/{id}"),
+            Exempt("per-user groups; another user's id is NotFound, never Forbidden"),
+        ),
+        (("PUT", "/api/project-groups/assign"), Gated(Viewer)),
         (("GET", "/api/projects/{id}/board"), Gated(Viewer)),
         (("GET", "/api/projects/{id}/issue-counts"), Gated(Viewer)),
         (("POST", "/api/projects/{id}/import/github"), Gated(Lead)),

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -165,6 +165,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "comment search",
         include_str!("../../migrations/034_comment_search.sql"),
     ),
+    (
+        35,
+        "project groups",
+        include_str!("../../migrations/035_project_groups.sql"),
+    ),
 ];
 
 /// Highest migration version this binary knows how to apply. Used by

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -49,6 +49,37 @@ pub struct UpdateProject {
     pub lead_user_id: Option<Option<i64>>,
 }
 
+/// A user's named group of projects in the sidebar. `project_ids` is derived,
+/// populated by `queries::project_groups::list_groups`; it is not a column.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectGroup {
+    pub id: i64,
+    pub user_id: i64,
+    pub name: String,
+    pub sort_order: i64,
+    pub project_ids: Vec<i64>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateProjectGroup {
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateProjectGroup {
+    pub name: Option<String>,
+}
+
+/// `PUT /api/project-groups/assign` body. `group_id: None` takes the project
+/// out of every one of the caller's groups.
+#[derive(Debug, Deserialize)]
+pub struct AssignProjectGroup {
+    pub project_id: i64,
+    pub group_id: Option<i64>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Issue {
     pub id: i64,

--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -6,6 +6,7 @@ mod issues;
 pub(crate) mod members;
 mod pages;
 pub(crate) mod plans;
+pub(crate) mod project_groups;
 mod projects;
 mod resources;
 mod search;

--- a/src/db/queries/project_groups.rs
+++ b/src/db/queries/project_groups.rs
@@ -109,6 +109,64 @@ pub fn create_group(
     get_owned_group(conn, conn.last_insert_rowid(), user_id)
 }
 
+/// Rename a group. Ownership is re-checked here, so callers may pass an id
+/// straight from a request body.
+pub fn update_group(
+    conn: &Connection,
+    id: i64,
+    user_id: i64,
+    input: &UpdateProjectGroup,
+) -> Result<ProjectGroup, LificError> {
+    get_owned_group(conn, id, user_id)?;
+    if let Some(name) = &input.name {
+        validate_name(name)?;
+        let name = name.trim();
+        conn.execute(
+            "UPDATE project_groups SET name = ?1, updated_at = datetime('now') WHERE id = ?2",
+            params![name, id],
+        )
+        .map_err(constraint_err(name))?;
+    }
+    get_owned_group(conn, id, user_id)
+}
+
+/// Delete a group. Its memberships go with it through `ON DELETE CASCADE`;
+/// the projects themselves are untouched and become ungrouped.
+pub fn delete_group(conn: &Connection, id: i64, user_id: i64) -> Result<bool, LificError> {
+    get_owned_group(conn, id, user_id)?;
+    let changed = conn.execute("DELETE FROM project_groups WHERE id = ?1", params![id])?;
+    Ok(changed > 0)
+}
+
+/// Move `project_id` into `group_id`, or out of every one of the caller's
+/// groups when `group_id` is `None`. Both halves run in one SAVEPOINT, which
+/// is what keeps a project from ever sitting in two of the same user's groups.
+pub fn assign_project(
+    conn: &Connection,
+    user_id: i64,
+    project_id: i64,
+    group_id: Option<i64>,
+) -> Result<(), LificError> {
+    let target = group_id
+        .map(|id| get_owned_group(conn, id, user_id))
+        .transpose()?;
+    super::savepoint(conn, "assign_project_group", || {
+        conn.execute(
+            "DELETE FROM project_group_items
+             WHERE project_id = ?1
+               AND group_id IN (SELECT id FROM project_groups WHERE user_id = ?2)",
+            params![project_id, user_id],
+        )?;
+        if let Some(group) = &target {
+            conn.execute(
+                "INSERT INTO project_group_items (group_id, project_id) VALUES (?1, ?2)",
+                params![group.id, project_id],
+            )?;
+        }
+        Ok(())
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,6 +187,21 @@ mod tests {
                 display_name: None,
                 is_admin: false,
                 is_bot: false,
+            },
+        )
+        .unwrap()
+        .id
+    }
+
+    fn seed_project(conn: &Connection, ident: &str) -> i64 {
+        queries::create_project(
+            conn,
+            &crate::db::models::CreateProject {
+                name: format!("Project {ident}"),
+                identifier: ident.into(),
+                description: String::new(),
+                emoji: None,
+                lead_user_id: None,
             },
         )
         .unwrap()
@@ -189,5 +262,194 @@ mod tests {
         let err =
             create_group(&conn, alice, &CreateProjectGroup { name: "   ".into() }).unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got {err:?}");
+    }
+
+    // ── assignment ──────────────────────────────────────────────
+
+    #[test]
+    fn assigning_a_project_twice_moves_it_instead_of_duplicating_it() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let project = seed_project(&conn, "APP");
+        let work =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let personal =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+
+        assign_project(&conn, alice, project, Some(work.id)).unwrap();
+        assign_project(&conn, alice, project, Some(personal.id)).unwrap();
+
+        let groups = list_groups(&conn, alice).unwrap();
+        let work_now = groups.iter().find(|g| g.id == work.id).unwrap();
+        let personal_now = groups.iter().find(|g| g.id == personal.id).unwrap();
+        assert!(
+            work_now.project_ids.is_empty(),
+            "project should have moved out of Work"
+        );
+        assert_eq!(personal_now.project_ids, vec![project]);
+    }
+
+    #[test]
+    fn assigning_none_ungroups_the_project() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let project = seed_project(&conn, "APP");
+        let work =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+
+        assign_project(&conn, alice, project, Some(work.id)).unwrap();
+        assign_project(&conn, alice, project, None).unwrap();
+
+        let groups = list_groups(&conn, alice).unwrap();
+        assert!(groups[0].project_ids.is_empty());
+    }
+
+    #[test]
+    fn two_users_may_file_the_same_project_differently() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let bob = seed_user(&conn, "bob");
+        let project = seed_project(&conn, "APP");
+        let alice_work =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let bob_side =
+            create_group(&conn, bob, &CreateProjectGroup { name: "Side".into() }).unwrap();
+
+        assign_project(&conn, alice, project, Some(alice_work.id)).unwrap();
+        assign_project(&conn, bob, project, Some(bob_side.id)).unwrap();
+
+        assert_eq!(
+            list_groups(&conn, alice).unwrap()[0].project_ids,
+            vec![project]
+        );
+        assert_eq!(
+            list_groups(&conn, bob).unwrap()[0].project_ids,
+            vec![project]
+        );
+    }
+
+    #[test]
+    fn assigning_into_another_users_group_is_not_found() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let bob = seed_user(&conn, "bob");
+        let project = seed_project(&conn, "APP");
+        let alice_work =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+
+        let err = assign_project(&conn, bob, project, Some(alice_work.id)).unwrap_err();
+        assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
+    }
+
+    // ── delete and cascades ─────────────────────────────────────
+
+    #[test]
+    fn deleting_a_group_leaves_its_projects_intact_and_ungrouped() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let project = seed_project(&conn, "APP");
+        let work =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        assign_project(&conn, alice, project, Some(work.id)).unwrap();
+
+        assert!(delete_group(&conn, work.id, alice).unwrap());
+
+        assert!(list_groups(&conn, alice).unwrap().is_empty());
+        queries::get_project(&conn, project).expect("project must survive its group");
+    }
+
+    #[test]
+    fn deleting_another_users_group_is_not_found() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let bob = seed_user(&conn, "bob");
+        let work =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+
+        let err = delete_group(&conn, work.id, bob).unwrap_err();
+        assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn deleting_a_project_drops_its_memberships() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let project = seed_project(&conn, "APP");
+        let work =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        assign_project(&conn, alice, project, Some(work.id)).unwrap();
+
+        queries::delete_project(&conn, project).unwrap();
+
+        assert!(list_groups(&conn, alice).unwrap()[0].project_ids.is_empty());
+    }
+
+    #[test]
+    fn deleting_a_user_cascades_their_groups_away() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+
+        conn.execute("DELETE FROM users WHERE id = ?1", params![alice])
+            .unwrap();
+
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM project_groups", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    // ── rename ──────────────────────────────────────────────────
+
+    #[test]
+    fn renaming_onto_an_existing_name_conflicts() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let personal =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+
+        let err = update_group(
+            &conn,
+            personal.id,
+            alice,
+            &UpdateProjectGroup {
+                name: Some("Work".into()),
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn renaming_keeps_the_groups_membership() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let project = seed_project(&conn, "APP");
+        let work =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        assign_project(&conn, alice, project, Some(work.id)).unwrap();
+
+        let renamed = update_group(
+            &conn,
+            work.id,
+            alice,
+            &UpdateProjectGroup {
+                name: Some("Day job".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(renamed.name, "Day job");
+        assert_eq!(list_groups(&conn, alice).unwrap()[0].project_ids, vec![project]);
     }
 }

--- a/src/db/queries/project_groups.rs
+++ b/src/db/queries/project_groups.rs
@@ -1,0 +1,193 @@
+//! Per-user project groups for the sidebar.
+//!
+//! Ownership mirrors `queries::views`: every function targeting an existing
+//! row resolves it through [`get_owned_group`], which folds "no such group"
+//! and "someone else's group" into the same `NotFound`, so a group id can't
+//! be used to probe another user's sidebar.
+
+use std::collections::HashMap;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::db::models::{CreateProjectGroup, ProjectGroup, UpdateProjectGroup};
+use crate::error::LificError;
+
+fn validate_name(name: &str) -> Result<(), LificError> {
+    if name.trim().is_empty() {
+        return Err(LificError::BadRequest("name must not be empty".into()));
+    }
+    Ok(())
+}
+
+/// Map the `UNIQUE (user_id, name)` violation onto a 409 the client can show
+/// verbatim. Mirrors `views::constraint_err`.
+fn constraint_err(name: &str) -> impl Fn(rusqlite::Error) -> LificError + '_ {
+    move |e| match e {
+        rusqlite::Error::SqliteFailure(err, _)
+            if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+        {
+            LificError::Conflict(format!("a group named '{name}' already exists"))
+        }
+        other => other.into(),
+    }
+}
+
+fn row_to_group(row: &rusqlite::Row) -> rusqlite::Result<ProjectGroup> {
+    Ok(ProjectGroup {
+        id: row.get(0)?,
+        user_id: row.get(1)?,
+        name: row.get(2)?,
+        sort_order: row.get(3)?,
+        // Filled in by list_groups; a bare row carries no membership.
+        project_ids: Vec::new(),
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+fn get_owned_group(conn: &Connection, id: i64, user_id: i64) -> Result<ProjectGroup, LificError> {
+    conn.query_row(
+        "SELECT id, user_id, name, sort_order, created_at, updated_at
+         FROM project_groups WHERE id = ?1 AND user_id = ?2",
+        params![id, user_id],
+        row_to_group,
+    )
+    .optional()?
+    .ok_or_else(|| LificError::NotFound(format!("project group {id} not found")))
+}
+
+/// The caller's groups with their member project ids. Memberships come back
+/// in one extra statement and are bucketed in memory, not one query per group.
+pub fn list_groups(conn: &Connection, user_id: i64) -> Result<Vec<ProjectGroup>, LificError> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT id, user_id, name, sort_order, created_at, updated_at
+         FROM project_groups WHERE user_id = ?1
+         ORDER BY sort_order, name COLLATE NOCASE",
+    )?;
+    let mut groups: Vec<ProjectGroup> = stmt
+        .query_map(params![user_id], row_to_group)?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut stmt = conn.prepare_cached(
+        "SELECT i.group_id, i.project_id
+         FROM project_group_items i
+         JOIN project_groups g ON g.id = i.group_id
+         WHERE g.user_id = ?1",
+    )?;
+    let mut by_group: HashMap<i64, Vec<i64>> = HashMap::new();
+    let rows = stmt.query_map(params![user_id], |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    for row in rows {
+        let (group_id, project_id) = row?;
+        by_group.entry(group_id).or_default().push(project_id);
+    }
+    for group in &mut groups {
+        group.project_ids = by_group.remove(&group.id).unwrap_or_default();
+    }
+    Ok(groups)
+}
+
+/// Create a group, appended after the caller's existing ones.
+pub fn create_group(
+    conn: &Connection,
+    user_id: i64,
+    input: &CreateProjectGroup,
+) -> Result<ProjectGroup, LificError> {
+    validate_name(&input.name)?;
+    let name = input.name.trim();
+    let next_order: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(sort_order) + 1, 0) FROM project_groups WHERE user_id = ?1",
+        params![user_id],
+        |row| row.get(0),
+    )?;
+    conn.execute(
+        "INSERT INTO project_groups (user_id, name, sort_order) VALUES (?1, ?2, ?3)",
+        params![user_id, name, next_order],
+    )
+    .map_err(constraint_err(name))?;
+    get_owned_group(conn, conn.last_insert_rowid(), user_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::CreateUser;
+    use crate::db::{self, queries};
+
+    fn test_db() -> db::DbPool {
+        db::open_memory().expect("test db")
+    }
+
+    fn seed_user(conn: &Connection, username: &str) -> i64 {
+        queries::users::create_user(
+            conn,
+            &CreateUser {
+                username: username.into(),
+                email: format!("{username}@test.local"),
+                password: "testpassword1".into(),
+                display_name: None,
+                is_admin: false,
+                is_bot: false,
+            },
+        )
+        .unwrap()
+        .id
+    }
+
+    #[test]
+    fn created_group_comes_back_empty_and_named() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+
+        let created =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        assert_eq!(created.name, "Work");
+        assert!(created.project_ids.is_empty());
+
+        let listed = list_groups(&conn, alice).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, created.id);
+    }
+
+    #[test]
+    fn duplicate_name_for_same_user_conflicts_but_another_user_may_reuse_it() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let bob = seed_user(&conn, "bob");
+
+        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+
+        let err =
+            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap_err();
+        assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
+
+        create_group(&conn, bob, &CreateProjectGroup { name: "Work".into() })
+            .expect("a different user may reuse the name");
+    }
+
+    #[test]
+    fn one_users_groups_are_invisible_to_another() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+        let bob = seed_user(&conn, "bob");
+
+        create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+
+        assert!(list_groups(&conn, bob).unwrap().is_empty());
+    }
+
+    #[test]
+    fn blank_name_is_rejected() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let alice = seed_user(&conn, "alice");
+
+        let err =
+            create_group(&conn, alice, &CreateProjectGroup { name: "   ".into() }).unwrap_err();
+        assert!(matches!(err, LificError::BadRequest(_)), "got {err:?}");
+    }
+}

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -128,9 +128,15 @@ pub enum RealtimeEvent {
     ProjectDeleted { project_id: i64 },
     #[serde(rename = "projects.reordered")]
     ProjectsReordered,
-    /// Only ever delivered through `send_to_users`. Groups are per-user, so
-    /// broadcasting this would tell every connected client that someone
-    /// reorganized their own sidebar.
+    /// Addressed to the owning user through `send_to_users` rather than
+    /// broadcast, since groups are per-user and every other client would only
+    /// be told that someone reorganized their own sidebar.
+    ///
+    /// That is an audience, not a secret: `visible_to` lets any admin see
+    /// every `Users(..)`-addressed event, the same superuser rule
+    /// `can_view_project` and `visible_project_ids` follow. The payload
+    /// carries no group data, and an admin's client refetches only its own
+    /// groups, so what leaks is the bare fact that a user changed theirs.
     #[serde(rename = "project_groups.changed")]
     ProjectGroupsChanged,
     #[serde(rename = "issue.created")]

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -128,6 +128,11 @@ pub enum RealtimeEvent {
     ProjectDeleted { project_id: i64 },
     #[serde(rename = "projects.reordered")]
     ProjectsReordered,
+    /// Only ever delivered through `send_to_users`. Groups are per-user, so
+    /// broadcasting this would tell every connected client that someone
+    /// reorganized their own sidebar.
+    #[serde(rename = "project_groups.changed")]
+    ProjectGroupsChanged,
     #[serde(rename = "issue.created")]
     IssueCreated { project_id: i64, issue_id: i64 },
     #[serde(rename = "issue.updated")]
@@ -395,7 +400,7 @@ impl RealtimeEvent {
             | Self::IssueDeleted { project_id, .. }
             | Self::IssueLinked { project_id, .. }
             | Self::IssueUnlinked { project_id, .. } => Some(*project_id),
-            Self::ResyncRequired | Self::ProjectsReordered => None,
+            Self::ResyncRequired | Self::ProjectsReordered | Self::ProjectGroupsChanged => None,
         }
     }
 }

--- a/web/src/lib/Layout.svelte
+++ b/web/src/lib/Layout.svelte
@@ -8,20 +8,23 @@
     listModules,
     listPages,
     listPlans,
+    listProjectGroups,
     type AuthUser,
     type Project,
+    type ProjectGroup,
     type Issue,
     type Module,
     type Page,
     type Plan,
   } from "./api";
+  import { loadCollapsedGroups, saveCollapsedGroups } from "./projectGroups";
   import ProjectIcon from "./ProjectIcon.svelte";
   import CommandPalette from "./CommandPalette.svelte";
   import ShortcutHelp from "./ShortcutHelp.svelte";
   import { dndzone, type DndEvent } from "svelte-dnd-action";
   import { flip } from "svelte/animate";
   import { getPreference, setPreference, resolveTheme, motionReduced, type ThemePreference } from "./theme";
-  import { Settings, List, LayoutGrid, FileText, Plus, Layers, History, ListChecks, LayoutDashboard, Search, ChevronRight, Sun, Moon, Monitor, Menu, X, Home, TrendingUp, HelpCircle } from "lucide-svelte";
+  import { Settings, List, LayoutGrid, FileText, Plus, Layers, History, ListChecks, LayoutDashboard, Search, ChevronRight, Sun, Moon, Monitor, Menu, X, Home, TrendingUp, HelpCircle, Folder } from "lucide-svelte";
   import { onDestroy, setContext } from "svelte";
   import { peekState } from "./issues/peek.svelte";
   import PeekPanel from "./issues/PeekPanel.svelte"; // LIF-248: hoisted here so it's available on every route
@@ -232,6 +235,28 @@
   let projects = $state<Project[]>([]);
   let loading = $state(true);
 
+  // ── Per-user sidebar project groups ────────────────────────
+  let groups = $state<ProjectGroup[]>([]);
+  let collapsedGroups = $state<Set<number>>(loadCollapsedGroups());
+
+  // Membership is the server's answer, so a project missing from every group
+  // is ungrouped by definition — there's no "ungrouped" row to keep in sync.
+  let groupedIds = $derived(new Set(groups.flatMap((g) => g.project_ids)));
+  let ungrouped = $derived(projects.filter((p) => !groupedIds.has(p.id)));
+
+  // `projects` is already in sidebar order, so filtering preserves it inside
+  // a group too.
+  function projectsIn(group: ProjectGroup): Project[] {
+    return projects.filter((p) => group.project_ids.includes(p.id));
+  }
+
+  function toggleGroup(id: number) {
+    const next = new Set(collapsedGroups);
+    if (!next.delete(id)) next.add(id);
+    collapsedGroups = next;
+    saveCollapsedGroups(next);
+  }
+
   // Load user once on mount
   $effect(() => {
     loadUser();
@@ -250,9 +275,12 @@
     startAutoRefresh({
       refresh: refreshProjects,
       isBusy: () => dragActive,
+      // `project_groups.changed` uses an underscore, so the `project.` prefix
+      // test below does not cover it — it needs its own clause.
       shouldRefresh: (event) =>
         event.type === "resync.required" ||
         event.type === "projects.reordered" ||
+        event.type === "project_groups.changed" ||
         event.type.startsWith("project."),
     }),
   );
@@ -276,9 +304,15 @@
     // route-change refresh landing mid-drag would corrupt the zone. The
     // finalize handler re-syncs from the server response once the drop settles.
     if (dragActive) return;
-    const res = await listProjects();
-    if (res.ok) {
-      projects = res.data;
+    const [projectsRes, groupsRes] = await Promise.all([
+      listProjects(),
+      listProjectGroups(),
+    ]);
+    if (projectsRes.ok) {
+      projects = projectsRes.data;
+    }
+    if (groupsRes.ok) {
+      groups = groupsRes.data;
     }
   }
 
@@ -593,45 +627,12 @@
           Home
         </button>
 
-        {#if projects.length > 0}
-          <div class="flex items-center justify-between px-2 pt-1.5 pb-1">
-            <span class="text-micro font-semibold uppercase tracking-widest text-[var(--text-faint)]">
-              Projects
-            </span>
-            <button
-              class="size-5 flex items-center justify-center rounded
-                     text-[var(--text-faint)] hover:text-[var(--accent)]
-                     hover:bg-[var(--bg-subtle)] transition-colors"
-              title="New project"
-              onclick={() => navigate("/projects/new")}
-            >
-              <Plus size={13} />
-            </button>
-          </div>
-
-          <!-- LIF-233: drag-to-reorder zone. Each project is a SINGLE direct
-               child of the zone (pill + its sub-nav wrapped together), so
-               svelte-dnd-action's one-item-per-child model stays 1:1 — the
-               active project's expanded sub-nav must NOT become its own
-               draggable item. The header/+button above sit OUTSIDE the zone. -->
-          <div
-            use:dndzone={{
-              items: projects,
-              flipDurationMs: flipMs(),
-              type: "lific-projects",
-              dropTargetStyle: {},
-              dragDisabled: projects.length < 2,
-            }}
-            onconsider={handleProjectConsider}
-            onfinalize={handleProjectFinalize}
-          >
-          {#each projects as project (project.id)}
+        <!-- One project entry: the pill plus its sub-nav. Shared verbatim by
+             the grouped lists and the ungrouped drag zone below, so a project
+             looks and behaves identically wherever it is filed. -->
+        {#snippet projectEntry(project: Project)}
             {@const isProjectActive = activeProject === project.identifier}
             {@const open = subnavOpen(project)}
-            <!-- One draggable item per project. animate:flip gives the reorder
-                 its slide; the wrapper holds both the pill and (when open)
-                 the sub-nav so they move as a unit. -->
-            <div animate:flip={{ duration: flipMs() }}>
             <!-- Project pill. Clicking the active project toggles its sub-nav
                  (the chevron is a real disclosure control); clicking any other
                  project navigates in and opens it. The chevron rotates with the
@@ -746,6 +747,79 @@
                 {@render subItem(`/${project.identifier}/insights`, "Insights", TrendingUp)}
               </div>
             {/if}
+        {/snippet}
+
+        <!-- Groups render above the ungrouped list. The guard covers groups
+             too: without it an instance with no projects offers no way to
+             create a group, and a group whose last project left would vanish
+             instead of staying around to be renamed or deleted. -->
+        {#if projects.length > 0 || groups.length > 0}
+          <div class="flex items-center justify-between px-2 pt-1.5 pb-1">
+            <span class="text-micro font-semibold uppercase tracking-widest text-[var(--text-faint)]">
+              Projects
+            </span>
+            <button
+              class="size-5 flex items-center justify-center rounded
+                     text-[var(--text-faint)] hover:text-[var(--accent)]
+                     hover:bg-[var(--bg-subtle)] transition-colors"
+              title="New project"
+              onclick={() => navigate("/projects/new")}
+            >
+              <Plus size={13} />
+            </button>
+          </div>
+
+          {#each groups as group (group.id)}
+            {@const collapsed = collapsedGroups.has(group.id)}
+            <button
+              class="group w-full flex items-center gap-1.5 pl-1.5 pr-2 py-1.5 rounded-md
+                     text-left text-body-sm transition text-[var(--text-muted)]
+                     hover:text-[var(--text)] hover:bg-[var(--bg-subtle)]"
+              aria-expanded={!collapsed}
+              onclick={() => toggleGroup(group.id)}
+            >
+              <ChevronRight
+                size={13}
+                class="shrink-0 transition-transform {collapsed ? '' : 'rotate-90'}
+                       text-[var(--text-faint)] group-hover:text-[var(--text-muted)]"
+              />
+              <Folder size={14} class="shrink-0 text-[var(--text-faint)]" />
+              <span class="truncate flex-1">{group.name}</span>
+            </button>
+            {#if !collapsed}
+              <!-- Same indent and guide line as a project's sub-nav, so the
+                   sidebar reads as one tree rather than two conventions. -->
+              <div class="ml-[1.125rem] pl-2.5 border-l border-[var(--border)]">
+                {#each projectsIn(group) as project (project.id)}
+                  {@render projectEntry(project)}
+                {/each}
+              </div>
+            {/if}
+          {/each}
+
+          <!-- LIF-233: drag-to-reorder zone, now holding only the ungrouped
+               projects. Each is a SINGLE direct child of the zone (pill + its
+               sub-nav wrapped together), so svelte-dnd-action's
+               one-item-per-child model stays 1:1 — the active project's
+               expanded sub-nav must NOT become its own draggable item. The
+               header/+button and the groups above sit OUTSIDE the zone. -->
+          <div
+            use:dndzone={{
+              items: ungrouped,
+              flipDurationMs: flipMs(),
+              type: "lific-projects",
+              dropTargetStyle: {},
+              dragDisabled: ungrouped.length < 2,
+            }}
+            onconsider={handleProjectConsider}
+            onfinalize={handleProjectFinalize}
+          >
+          {#each ungrouped as project (project.id)}
+            <!-- animate:flip gives the reorder its slide; the wrapper holds
+                 both the pill and (when open) the sub-nav so they move as a
+                 unit. -->
+            <div animate:flip={{ duration: flipMs() }}>
+              {@render projectEntry(project)}
             </div>
           {/each}
           </div>

--- a/web/src/lib/Layout.svelte
+++ b/web/src/lib/Layout.svelte
@@ -244,6 +244,11 @@
   let groupedIds = $derived(new Set(groups.flatMap((g) => g.project_ids)));
   let ungrouped = $derived(projects.filter((p) => !groupedIds.has(p.id)));
 
+  // `ungrouped` is derived, so svelte-dnd-action can't own it during a drag.
+  // The in-flight order lives here and wins while the drag is live.
+  let ungroupedDuringDrag = $state<Project[] | null>(null);
+  let ungroupedItems = $derived(ungroupedDuringDrag ?? ungrouped);
+
   // `projects` is already in sidebar order, so filtering preserves it inside
   // a group too.
   function projectsIn(group: ProjectGroup): Project[] {
@@ -330,13 +335,12 @@
 
   function handleProjectConsider(e: CustomEvent<DndEvent<Project>>) {
     dragActive = true;
-    projects = e.detail.items;
+    ungroupedDuringDrag = e.detail.items;
   }
 
   async function handleProjectFinalize(e: CustomEvent<DndEvent<Project>>) {
-    projects = e.detail.items;
-    const ids = projects.map((p) => p.id);
-    const res = await reorderProjects(ids);
+    ungroupedDuringDrag = e.detail.items;
+    const res = await reorderProjects(reorderPayload(e.detail));
     if (res.ok) {
       projects = res.data;
     } else {
@@ -344,7 +348,43 @@
       const fresh = await listProjects();
       if (fresh.ok) projects = fresh.data;
     }
+    ungroupedDuringDrag = null;
     dragActive = false;
+  }
+
+  // sort_order is a single global column, but groups are per-user. So the
+  // payload must never be derived from the sidebar's grouped layout: doing
+  // that would write this user's private grouping into an order every other
+  // user reads. Sending only the dragged zone's ids is no better — the server
+  // reindexes them to 0..N and collides with the ranks held by grouped
+  // projects. Instead, take the canonical order the server last returned and
+  // move exactly one project within it: the one that was dragged. The result
+  // is always a permutation of the canonical list with a single element
+  // relocated, which carries no grouping information at all.
+  function reorderPayload(detail: DndEvent<Project>): number[] {
+    const movedId = Number(detail.info.id);
+    const moved = projects.find((p) => p.id === movedId);
+    if (!moved) return projects.map((p) => p.id);
+
+    const items = detail.items;
+    const pos = items.findIndex((p) => p.id === movedId);
+    const after = items[pos + 1];
+    const before = items[pos - 1];
+
+    const rest = projects.filter((p) => p.id !== movedId);
+    // Anchor to whichever ungrouped neighbour the drop landed against; with
+    // no neighbour on either side the zone held only this project, so its
+    // position relative to everything else is unchanged.
+    let at: number;
+    if (after) {
+      at = rest.findIndex((p) => p.id === after.id);
+    } else if (before) {
+      at = rest.findIndex((p) => p.id === before.id) + 1;
+    } else {
+      at = rest.length;
+    }
+    rest.splice(at, 0, moved);
+    return rest.map((p) => p.id);
   }
 
   function initials(name: string): string {
@@ -805,16 +845,16 @@
                header/+button and the groups above sit OUTSIDE the zone. -->
           <div
             use:dndzone={{
-              items: ungrouped,
+              items: ungroupedItems,
               flipDurationMs: flipMs(),
               type: "lific-projects",
               dropTargetStyle: {},
-              dragDisabled: ungrouped.length < 2,
+              dragDisabled: ungroupedItems.length < 2,
             }}
             onconsider={handleProjectConsider}
             onfinalize={handleProjectFinalize}
           >
-          {#each ungrouped as project (project.id)}
+          {#each ungroupedItems as project (project.id)}
             <!-- animate:flip gives the reorder its slide; the wrapper holds
                  both the pill and (when open) the sub-nav so they move as a
                  unit. -->

--- a/web/src/lib/Layout.svelte
+++ b/web/src/lib/Layout.svelte
@@ -920,45 +920,49 @@
             {/if}
         {/snippet}
 
-        <!-- Groups render above the ungrouped list. The guard covers groups
-             too: without it an instance with no projects offers no way to
-             create a group, and a group whose last project left would vanish
-             instead of staying around to be renamed or deleted. -->
+        <!-- The header renders unconditionally: it carries the only affordance
+             for creating a group, so gating it on having projects would make
+             the first group unreachable on a brand-new instance. -->
+        <div class="flex items-center justify-between px-2 pt-1.5 pb-1">
+          <span class="text-micro font-semibold uppercase tracking-widest text-[var(--text-faint)]">
+            Projects
+          </span>
+          <button
+            class="size-5 flex items-center justify-center rounded
+                   text-[var(--text-faint)] hover:text-[var(--accent)]
+                   hover:bg-[var(--bg-subtle)] transition-colors"
+            title="New project or group"
+            onclick={openCreateMenu}
+          >
+            <Plus size={13} />
+          </button>
+        </div>
+
+        <!-- Outside the guard below for the same reason as the header: on an
+             empty instance this input is the whole first-group flow. -->
+        {#snippet groupNameInput()}
+          <input
+            class="w-full h-7 px-2 mb-0.5 rounded-md text-body-sm bg-[var(--bg)]
+                   border border-[var(--border)] text-[var(--text)]"
+            placeholder="Group name"
+            bind:value={draftGroupName}
+            onblur={commitGroupName}
+            onkeydown={(e) => {
+              if (e.key === "Enter") commitGroupName();
+              if (e.key === "Escape") cancelGroupEdit();
+            }}
+            autofocus
+          />
+        {/snippet}
+
+        {#if editingGroupId === NEW_GROUP}
+          {@render groupNameInput()}
+        {/if}
+
+        <!-- Groups render above the ungrouped list. The guard covers groups as
+             well as projects so a group whose last project left stays around
+             to be renamed or deleted instead of vanishing. -->
         {#if projects.length > 0 || groups.length > 0}
-          <div class="flex items-center justify-between px-2 pt-1.5 pb-1">
-            <span class="text-micro font-semibold uppercase tracking-widest text-[var(--text-faint)]">
-              Projects
-            </span>
-            <button
-              class="size-5 flex items-center justify-center rounded
-                     text-[var(--text-faint)] hover:text-[var(--accent)]
-                     hover:bg-[var(--bg-subtle)] transition-colors"
-              title="New project or group"
-              onclick={openCreateMenu}
-            >
-              <Plus size={13} />
-            </button>
-          </div>
-
-          {#snippet groupNameInput()}
-            <input
-              class="w-full h-7 px-2 mb-0.5 rounded-md text-body-sm bg-[var(--bg)]
-                     border border-[var(--border)] text-[var(--text)]"
-              placeholder="Group name"
-              bind:value={draftGroupName}
-              onblur={commitGroupName}
-              onkeydown={(e) => {
-                if (e.key === "Enter") commitGroupName();
-                if (e.key === "Escape") cancelGroupEdit();
-              }}
-              autofocus
-            />
-          {/snippet}
-
-          {#if editingGroupId === NEW_GROUP}
-            {@render groupNameInput()}
-          {/if}
-
           {#each groups as group (group.id)}
             {@const collapsed = collapsedGroups.has(group.id)}
             {#if editingGroupId === group.id}
@@ -1018,15 +1022,23 @@
             </div>
           {/each}
           </div>
-        {:else}
+        {:else if editingGroupId !== NEW_GROUP}
           <div class="px-3 py-6">
             <p class="text-body-sm text-[var(--text-faint)] mb-2">No projects yet.</p>
-            <button
-              class="text-body-sm text-[var(--accent)] hover:underline"
-              onclick={() => navigate("/projects/new")}
-            >
-              Create a project
-            </button>
+            <div class="flex flex-col items-start gap-1">
+              <button
+                class="text-body-sm text-[var(--accent)] hover:underline"
+                onclick={() => navigate("/projects/new")}
+              >
+                Create a project
+              </button>
+              <button
+                class="text-body-sm text-[var(--accent)] hover:underline"
+                onclick={() => startCreatingGroup()}
+              >
+                Create a group
+              </button>
+            </div>
           </div>
         {/if}
       </nav>

--- a/web/src/lib/Layout.svelte
+++ b/web/src/lib/Layout.svelte
@@ -9,6 +9,10 @@
     listPages,
     listPlans,
     listProjectGroups,
+    createProjectGroup,
+    renameProjectGroup,
+    deleteProjectGroup,
+    assignProjectGroup,
     type AuthUser,
     type Project,
     type ProjectGroup,
@@ -24,11 +28,12 @@
   import { dndzone, type DndEvent } from "svelte-dnd-action";
   import { flip } from "svelte/animate";
   import { getPreference, setPreference, resolveTheme, motionReduced, type ThemePreference } from "./theme";
-  import { Settings, List, LayoutGrid, FileText, Plus, Layers, History, ListChecks, LayoutDashboard, Search, ChevronRight, Sun, Moon, Monitor, Menu, X, Home, TrendingUp, HelpCircle, Folder } from "lucide-svelte";
+  import { Settings, List, LayoutGrid, FileText, Plus, Layers, History, ListChecks, LayoutDashboard, Search, ChevronRight, Sun, Moon, Monitor, Menu, X, Home, TrendingUp, HelpCircle, Folder, FolderPlus, FolderMinus, Pencil, Trash2 } from "lucide-svelte";
   import { onDestroy, setContext } from "svelte";
   import { peekState } from "./issues/peek.svelte";
   import PeekPanel from "./issues/PeekPanel.svelte"; // LIF-248: hoisted here so it's available on every route
-  import { contextMenuState } from "./contextMenuState.svelte";
+  import { contextMenuState, openContextMenu } from "./contextMenuState.svelte";
+  import { toast } from "./toast/toast.svelte";
   import ContextMenu from "./ContextMenu.svelte"; // LIF-248
   import { commandPaletteState } from "./commandPaletteState.svelte";
   import { toggleShortcutHelp } from "./shortcutHelpState.svelte";
@@ -260,6 +265,131 @@
     if (!next.delete(id)) next.add(id);
     collapsedGroups = next;
     saveCollapsedGroups(next);
+  }
+
+  // ── Managing groups ────────────────────────────────────────
+  // The id being renamed, or NEW_GROUP while creating one.
+  const NEW_GROUP = -1;
+  let editingGroupId = $state<number | null>(null);
+  let draftGroupName = $state("");
+  // Set when "New group…" came from a project's menu: the project to file
+  // into the group as soon as it exists.
+  let pendingGroupProjectId = $state<number | null>(null);
+
+  function openProjectMenu(e: MouseEvent, project: Project) {
+    e.preventDefault();
+    e.stopPropagation();
+    const current = groups.find((g) => g.project_ids.includes(project.id));
+    openContextMenu(e.clientX, e.clientY, [
+      ...groups
+        .filter((g) => g.id !== current?.id)
+        .map((g) => ({
+          label: `Move to ${g.name}`,
+          icon: Folder,
+          action: () => void assignProject(project.id, g.id),
+        })),
+      ...(current
+        ? [
+            {
+              label: "Remove from group",
+              icon: FolderMinus,
+              action: () => void assignProject(project.id, null),
+            },
+          ]
+        : []),
+      {
+        label: "New group…",
+        icon: FolderPlus,
+        action: () => startCreatingGroup(project.id),
+      },
+    ]);
+  }
+
+  function openGroupMenu(e: MouseEvent, group: ProjectGroup) {
+    e.preventDefault();
+    e.stopPropagation();
+    openContextMenu(e.clientX, e.clientY, [
+      { label: "Rename", icon: Pencil, action: () => startRenamingGroup(group) },
+      { label: "Delete group", icon: Trash2, action: () => void removeGroup(group) },
+    ]);
+  }
+
+  function openCreateMenu(e: MouseEvent) {
+    // Without this the click keeps bubbling to ContextMenu's window listener,
+    // which closes the menu this very call just opened.
+    e.stopPropagation();
+    // Anchored to the button's own box, not the cursor, so the menu lines up
+    // under the + rather than wherever the pointer happened to be.
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    openContextMenu(rect.left, rect.bottom, [
+      { label: "New project", icon: Plus, action: () => navigate("/projects/new") },
+      { label: "New group", icon: FolderPlus, action: () => startCreatingGroup() },
+    ]);
+  }
+
+  function startRenamingGroup(group: ProjectGroup) {
+    editingGroupId = group.id;
+    draftGroupName = group.name;
+  }
+
+  function startCreatingGroup(projectId: number | null = null) {
+    editingGroupId = NEW_GROUP;
+    draftGroupName = "";
+    pendingGroupProjectId = projectId;
+  }
+
+  function cancelGroupEdit() {
+    editingGroupId = null;
+    pendingGroupProjectId = null;
+  }
+
+  async function assignProject(projectId: number, groupId: number | null) {
+    const res = await assignProjectGroup(projectId, groupId);
+    if (res.ok) {
+      await refreshProjects();
+    } else {
+      toast(res.error, { kind: "error" });
+    }
+  }
+
+  async function commitGroupName() {
+    const name = draftGroupName.trim();
+    const editing = editingGroupId;
+    const pending = pendingGroupProjectId;
+    cancelGroupEdit();
+    if (!name || editing === null) return;
+
+    const res =
+      editing === NEW_GROUP
+        ? await createProjectGroup(name)
+        : await renameProjectGroup(editing, name);
+    if (!res.ok) {
+      toast(res.error, { kind: "error" });
+      return;
+    }
+    // The group exists now even if the follow-up assignment fails, so report
+    // that separately: the user's next move is to file the project by hand,
+    // not to create the group again.
+    if (editing === NEW_GROUP && pending !== null) {
+      const assigned = await assignProjectGroup(pending, res.data.id);
+      if (!assigned.ok) {
+        toast(`Group created, but the project wasn't moved into it: ${assigned.error}`, {
+          kind: "error",
+        });
+      }
+    }
+    await refreshProjects();
+  }
+
+  // Deleting a group never touches the projects inside it — they reappear in
+  // the ungrouped list below, so there is nothing to confirm.
+  async function removeGroup(group: ProjectGroup) {
+    const res = await deleteProjectGroup(group.id);
+    if (res.ok) {
+      await refreshProjects();
+    } else {
+      toast(res.error, { kind: "error" });
+    }
   }
 
   // Load user once on mount
@@ -686,6 +816,7 @@
                 : 'text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-subtle)]'}"
               aria-expanded={drawerOpen || isProjectActive ? open : undefined}
               onclick={() => onProjectClick(project)}
+              oncontextmenu={(e) => openProjectMenu(e, project)}
             >
               <ChevronRight
                 size={13}
@@ -802,21 +933,44 @@
               class="size-5 flex items-center justify-center rounded
                      text-[var(--text-faint)] hover:text-[var(--accent)]
                      hover:bg-[var(--bg-subtle)] transition-colors"
-              title="New project"
-              onclick={() => navigate("/projects/new")}
+              title="New project or group"
+              onclick={openCreateMenu}
             >
               <Plus size={13} />
             </button>
           </div>
 
+          {#snippet groupNameInput()}
+            <input
+              class="w-full h-7 px-2 mb-0.5 rounded-md text-body-sm bg-[var(--bg)]
+                     border border-[var(--border)] text-[var(--text)]"
+              placeholder="Group name"
+              bind:value={draftGroupName}
+              onblur={commitGroupName}
+              onkeydown={(e) => {
+                if (e.key === "Enter") commitGroupName();
+                if (e.key === "Escape") cancelGroupEdit();
+              }}
+              autofocus
+            />
+          {/snippet}
+
+          {#if editingGroupId === NEW_GROUP}
+            {@render groupNameInput()}
+          {/if}
+
           {#each groups as group (group.id)}
             {@const collapsed = collapsedGroups.has(group.id)}
+            {#if editingGroupId === group.id}
+              {@render groupNameInput()}
+            {:else}
             <button
               class="group w-full flex items-center gap-1.5 pl-1.5 pr-2 py-1.5 rounded-md
                      text-left text-body-sm transition text-[var(--text-muted)]
                      hover:text-[var(--text)] hover:bg-[var(--bg-subtle)]"
               aria-expanded={!collapsed}
               onclick={() => toggleGroup(group.id)}
+              oncontextmenu={(e) => openGroupMenu(e, group)}
             >
               <ChevronRight
                 size={13}
@@ -826,6 +980,7 @@
               <Folder size={14} class="shrink-0 text-[var(--text-faint)]" />
               <span class="truncate flex-1">{group.name}</span>
             </button>
+            {/if}
             {#if !collapsed}
               <!-- Same indent and guide line as a project's sub-nav, so the
                    sidebar reads as one tree rather than two conventions. -->

--- a/web/src/lib/ProjectForm.svelte
+++ b/web/src/lib/ProjectForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { listUsers, type UserSummary } from "./api";
+  import { listUsers, listProjectGroups, type UserSummary, type ProjectGroup } from "./api";
   import IconPicker from "./IconPicker.svelte";
   import Select from "./Select.svelte";
 
@@ -9,6 +9,7 @@
     description = $bindable(""),
     emoji = $bindable(""),
     leadUserId = $bindable<number | null>(null),
+    groupId = $bindable<number | null>(null),
     mode = "create",
     identifierLocked = false,
   }: {
@@ -17,16 +18,23 @@
     description?: string;
     emoji?: string;
     leadUserId?: number | null;
+    /** Sidebar group to file the project into. The form only collects it —
+     *  persisting it is the caller's job, since it rides a separate endpoint. */
+    groupId?: number | null;
     mode?: "create" | "edit";
     identifierLocked?: boolean;
   } = $props();
 
   let users = $state<UserSummary[]>([]);
+  let groups = $state<ProjectGroup[]>([]);
   let identifierTouched = $state(false);
 
   $effect(() => {
     listUsers().then((res) => {
       if (res.ok) users = res.data;
+    });
+    listProjectGroups().then((res) => {
+      if (res.ok) groups = res.data;
     });
   });
 
@@ -58,6 +66,11 @@
   const placeholder = PLACEHOLDERS[Math.floor(Math.random() * PLACEHOLDERS.length)];
 
   let previewId = $derived((identifier.trim().toUpperCase() || "PRO") + "-1");
+
+  let groupOptions = $derived([
+    { value: null, label: "No group" },
+    ...groups.map((g) => ({ value: g.id, label: g.name })),
+  ]);
 
   let userOptions = $derived([
     { value: null, label: "No lead" },
@@ -166,6 +179,16 @@
       <IconPicker value={emoji} onchange={(v) => { emoji = v; }} />
     </div>
   </div>
+
+  {#if groups.length > 0}
+    <!-- Sidebar grouping. Personal to the signed-in user, unlike Lead. -->
+    <div class="mb-8 max-w-xs">
+      <label class="block text-body-sm font-medium text-[var(--text)] mb-2 w-fit">
+        Group
+      </label>
+      <Select options={groupOptions} bind:value={groupId} placeholder="No group" />
+    </div>
+  {/if}
 
   <!-- Description -->
   <div class="mb-8">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -456,6 +456,51 @@ export async function deleteProject(id: number) {
   });
 }
 
+/** A user's sidebar project group. `project_ids` carries only projects the
+ *  caller can see — the server drops memberships pointing at projects whose
+ *  access was revoked, so a group never renders an entry that 403s on click. */
+export interface ProjectGroup {
+  id: number;
+  user_id: number;
+  name: string;
+  sort_order: number;
+  project_ids: number[];
+  created_at: string;
+  updated_at: string;
+}
+
+export async function listProjectGroups() {
+  return request<ProjectGroup[]>("/project-groups");
+}
+
+export async function createProjectGroup(name: string) {
+  return request<ProjectGroup>("/project-groups", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function renameProjectGroup(id: number, name: string) {
+  return request<ProjectGroup>(`/project-groups/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function deleteProjectGroup(id: number) {
+  return request<{ deleted: boolean }>(`/project-groups/${id}`, {
+    method: "DELETE",
+  });
+}
+
+/** Move a project into a group, or out of every group with `groupId: null`. */
+export async function assignProjectGroup(projectId: number, groupId: number | null) {
+  return request<{ ok: boolean }>("/project-groups/assign", {
+    method: "PUT",
+    body: JSON.stringify({ project_id: projectId, group_id: groupId }),
+  });
+}
+
 export async function downloadProjectExport(identifier: string) {
   return download(`/export/projects/${identifier}`);
 }

--- a/web/src/lib/projectGroups.ts
+++ b/web/src/lib/projectGroups.ts
@@ -1,0 +1,29 @@
+// Which sidebar project groups are collapsed. Per browser, not per account:
+// the grouping itself lives in the database, but whether a group is folded
+// away is the same class of state as the sidebar width. Every accessor
+// swallows storage failures so private mode falls back to all-expanded.
+
+const storageKey = "lific:sidebar:collapsed-groups";
+
+export function loadCollapsedGroups(): Set<number> {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (raw !== null) {
+      const ids: unknown = JSON.parse(raw);
+      if (Array.isArray(ids)) {
+        return new Set(ids.filter((id): id is number => typeof id === "number"));
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return new Set();
+}
+
+export function saveCollapsedGroups(ids: Set<number>): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify([...ids]));
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/routes/ProjectNew.svelte
+++ b/web/src/routes/ProjectNew.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { createProject } from "../lib/api";
+  import { createProject, assignProjectGroup } from "../lib/api";
+  import { toast } from "../lib/toast/toast.svelte";
   import ProjectForm from "../lib/ProjectForm.svelte";
   import { ArrowLeft } from "lucide-svelte";
   import { getContext } from "svelte";
@@ -20,6 +21,7 @@
   let description = $state("");
   let emoji = $state("");
   let leadUserId = $state<number | null>(null);
+  let groupId = $state<number | null>(null);
   let saving = $state(false);
   let error = $state("");
 
@@ -39,6 +41,18 @@
     });
 
     if (res.ok) {
+      // The group rides a separate endpoint, so it can only be filed once the
+      // project has an id. If that call fails the project still exists — say
+      // so rather than landing the user on the overview with their choice
+      // silently dropped.
+      if (groupId !== null) {
+        const assigned = await assignProjectGroup(res.data.id, groupId);
+        if (!assigned.ok) {
+          toast(`Project created, but it wasn't added to the group: ${assigned.error}`, {
+            kind: "error",
+          });
+        }
+      }
       navigate(`/${res.data.identifier}/overview`);
     } else {
       error = res.error;
@@ -56,6 +70,7 @@
       bind:description
       bind:emoji
       bind:leadUserId
+      bind:groupId
       mode="create"
     />
   </div>

--- a/web/src/routes/ProjectSettings.svelte
+++ b/web/src/routes/ProjectSettings.svelte
@@ -12,7 +12,10 @@
     updateProject,
     deleteProject,
     downloadProjectExport,
+    listProjectGroups,
+    assignProjectGroup,
     type Project,
+    type ProjectGroup,
     type Issue,
     type Activity,
     type IssueStatusCounts,
@@ -122,6 +125,7 @@
     if (issuesRes.ok) issues = issuesRes.data;
     if (actRes.ok) activity = actRes.data.items;
     if (usersRes.ok) users = usersRes.data;
+    await loadGroups();
     loading = false;
   }
 
@@ -174,6 +178,42 @@
       saveField("lead_user_id", next);
     }
   });
+
+  // ── Sidebar group ────────────────────────────────────────
+  // Not a saveField: the group is per-user and rides its own endpoint, not
+  // updateProject. Unlike Lead this autosaves on change rather than through
+  // an effect, so a rejected write can put the select back where it was.
+  let groups = $state<ProjectGroup[]>([]);
+  let selectedGroupId = $state<number | null>(null);
+
+  function currentGroupId(): number | null {
+    if (!project) return null;
+    const id = project.id;
+    return groups.find((g) => g.project_ids.includes(id))?.id ?? null;
+  }
+
+  async function loadGroups() {
+    const res = await listProjectGroups();
+    if (!res.ok) return;
+    groups = res.data;
+    selectedGroupId = currentGroupId();
+  }
+
+  async function saveGroup(groupId: number | null) {
+    if (!project) return;
+    const res = await assignProjectGroup(project.id, groupId);
+    if (!res.ok) {
+      toast(`Couldn't save changes: ${res.error}`, { kind: "error" });
+      // Put the select back so it never shows a value the server rejected.
+      selectedGroupId = currentGroupId();
+      return;
+    }
+    const latest = await listProjectGroups();
+    if (latest.ok) groups = latest.data;
+    onProjectChange?.();
+    savedAt = Date.now();
+    window.setTimeout(() => { if (Date.now() - savedAt >= 1900) savedAt = 0; }, 2000);
+  }
 
   async function copyIdentifier() {
     if (!project) return;
@@ -516,6 +556,35 @@
               {/each}
             </div>
           {/if}
+        </section>
+
+        <!-- ── SIDEBAR GROUP ────────────────────────────── -->
+        <!-- Personal to the signed-in user, so it needs no role gate and
+             stays out of the danger zone: nobody else's sidebar changes. -->
+        <section class="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4">
+          <div class="flex items-center gap-3">
+            <div class="flex-1">
+              <p class="text-body-sm font-medium text-[var(--text)]">Sidebar group</p>
+              <p class="text-caption text-[var(--text-muted)]">
+                Where this project sits in your sidebar. Only you see it.
+              </p>
+            </div>
+            <select
+              value={selectedGroupId === null ? "" : String(selectedGroupId)}
+              onchange={(e) => {
+                const v = e.currentTarget.value;
+                selectedGroupId = v === "" ? null : Number(v);
+                saveGroup(selectedGroupId);
+              }}
+              class="text-body-sm rounded-md border border-[var(--border)] bg-[var(--surface)]
+                     text-[var(--text)] px-2.5 py-1.5 outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            >
+              <option value="">No group</option>
+              {#each groups as group (group.id)}
+                <option value={String(group.id)}>{group.name}</option>
+              {/each}
+            </select>
+          </div>
         </section>
 
         <!-- ── LABELS (management) ──────────────────────── -->


### PR DESCRIPTION
Adds one level of grouping to the sidebar project list, so projects can be filed into named, collapsible groups. Projects outside any group keep rendering exactly as they do today.

<img src="https://raw.githubusercontent.com/lardissone/lific/assets/sidebar-project-groups.png" alt="Sidebar showing two project groups, Personal projects and Company, each with projects nested under it" width="300">

Closes #16 — the two decisions from that thread:

**Per-user, not instance-wide.** `project_groups(id, user_id, name, sort_order)` plus `project_group_items(group_id, project_id)`. No `ALTER` on an existing table. A project belongs to at most one group per user; since that invariant spans rows in different groups, `assign_project` clears any existing membership inside the same SAVEPOINT rather than leaning on a constraint — matching what `029_saved_views.sql` says about preferring query-layer invariants.

**Menu, not drag.** "Move to…" on a project's context menu, plus a Group select on the new-project form and the project overview. No drag-into-group, for the reason `PageList.svelte:113-117` already documents for page folders.

Named *group* rather than *folder* on purpose: `folders` already exists in `001_initial.sql` for organizing pages, and a second folder concept would make every `grep folder` return two unrelated things.

**Endpoints** live under `/api/project-groups`, scoped by `user_id` in the query layer following `src/api/views.rs`. A group belonging to another user returns 404, never 403, so an id can't be used to probe someone else's sidebar. Assignment is the one endpoint that takes the Viewer gate, since its body names a project. The listing drops project ids the caller can no longer see, so a revoked membership never renders an entry that 403s on click. The five routes are classified in `authz_coverage_tests::rest_manifest`.

`project_groups.changed` is addressed to the owning user via `send_to_users`, which in this codebase still means admins receive it — the same superuser rule `can_view_project` follows. The event carries no group data and an admin's client refetches only its own groups, so what an admin learns is the bare fact that someone changed theirs. Noted in the variant's doc comment rather than worked around, but say the word if you'd rather it were a stricter audience.

**One thing worth flagging.** `projects.sort_order` is global while groups are per-user, so the reorder payload must not be derived from the sidebar's grouped layout — doing that writes one user's private grouping into an order everyone else reads. Sending only the drag zone's ids is no better: the server reindexes them to 0..N and collides with the ranks grouped projects hold. I reproduced both on a four-project instance (two grouped projects and the two ungrouped ones ended up sharing `sort_order` 0 and 1, leaving the order to name tie-breaks). The fix here keeps the payload as the canonical order with exactly one project moved, so no grouping is encoded. That leaves the pre-existing property that any user's drag reorders everyone's sidebar, which I've left alone since you mentioned wanting to re-evaluate global `sort_order` yourself.

**Tests:** 19 new (14 query-layer, 5 REST). `cargo clippy --all-targets -- -D warnings` and `cargo test --all-targets` are clean, and migration 35 applies to a fresh database. Verified end to end in the running app: create, move between groups, remove, rename, delete (projects survive), collapse persistence across reload, both save flows, an emptied group staying manageable, and creating the first group on an instance with no projects at all.

**Unrelated bug I ran into while testing**, reported here only so it isn't mistaken for something this branch introduced: the context menu doesn't unmount after an item is activated. It reproduces on `IssueRow`'s menu on `master`, untouched by this branch. `contextMenuState.open` does go false — neither an outside click nor Escape closes it afterwards, and both handlers early-return on `!open` — but the `{#if}` never tears the node down, with no `opacity` ever applied, so it isn't a half-finished transition. Removing `transition:fade={enterParams()}` (`ContextMenu.svelte:147`) makes it close correctly; splitting it into `in:`/`out:` does not. Happy to open a separate issue with the reproduction if that's useful.

AI-assisted, as the CONTRIBUTING invites.
