### PR TITLE
Keep deeply nested plan steps readable

### DIFF
--- a/web/src/routes/PlanDetail.svelte
+++ b/web/src/routes/PlanDetail.svelte
@@ -429,7 +429,7 @@
   {@const expanded = isExpanded(step)}
   {@const hasBody = step.description.trim().length > 0}
   <div class="flex flex-col">
-    <div class="group flex items-start gap-2 py-1 rounded-md hover:bg-[var(--bg-subtle)]" style="padding-left: {depth * 1.5}rem">
+    <div class="group flex items-start gap-2 py-1 rounded-md hover:bg-[var(--bg-subtle)]" style="padding-left: min({depth * 1.5}rem, 25%)">
       <!-- caret -->
       <button
         class="mt-0.5 size-4 shrink-0 flex items-center justify-center text-[var(--text-faint)] hover:text-[var(--text)]"


### PR DESCRIPTION
## Summary

Deeply nested plan steps applied `1.5rem` of left padding for every level. At depth 56, that consumed `84rem` before the step content and controls were laid out, collapsing text to roughly one word per line.

This caps recursive indentation at 25% of the row while preserving the existing `1.5rem` progression for shallower levels. The remaining width stays available to the step title, issue reference, description, edit surface, and row actions.
