### PR TITLE
Add authoritative resource links to HTTP MCP and CLI output

### DIFF
--- a/site/content/docs/cli.mdx
+++ b/site/content/docs/cli.mdx
@@ -29,7 +29,7 @@ HTTP mode uses the authenticated server identity for mutations. In particular, `
 
 HTTP mode currently uses pretty-printed JSON for human-readable output. Remote project export downloads one archive file from the server into the output directory rather than writing individual Markdown files.
 
-When HTTP mode returns issue objects, JSON output includes a `web_url` built from the configured server URL. Human-readable output renders structured issue identifiers as Markdown links. Direct SQL mode cannot add these links because it has no authoritative external hostname.
+When HTTP mode returns issues, projects, pages, plans, modules, or comments, JSON output includes a `web_url` built from the configured server URL. Human-readable output renders the corresponding identifier, name, or comment handle as a Markdown link. Direct SQL mode cannot add these links because it has no authoritative external hostname.
 
 Clap also provides `--help` and `--version`.
 

--- a/site/content/docs/cli.mdx
+++ b/site/content/docs/cli.mdx
@@ -29,6 +29,8 @@ HTTP mode uses the authenticated server identity for mutations. In particular, `
 
 HTTP mode currently uses pretty-printed JSON for human-readable output. Remote project export downloads one archive file from the server into the output directory rather than writing individual Markdown files.
 
+When HTTP mode returns issue objects, JSON output includes a `web_url` built from the configured server URL. Human-readable output renders structured issue identifiers as Markdown links. Direct SQL mode cannot add these links because it has no authoritative external hostname.
+
 Clap also provides `--help` and `--version`.
 
 ## Server and setup

--- a/site/content/docs/mcp/tools.mdx
+++ b/site/content/docs/mcp/tools.mdx
@@ -5,6 +5,8 @@ description: Reference for the MCP tools exposed by Lific.
 
 Lific exposes 27 MCP tools. Required parameters use non-optional input fields. Optional parameters can be omitted.
 
+When MCP is reached over HTTP and its origin is known, structured issue identifiers are rendered as Markdown links to the canonical `/<PROJECT>/issues/<ISSUE>` route. Configure `server.public_url` for deployments behind a proxy; otherwise a direct HTTP `Host` is used only when it matches the configured allowlist. Stdio MCP and direct SQL have no authoritative external hostname, so they keep plain identifiers.
+
 ## Issues
 
 ### `list_issues`

--- a/site/content/docs/mcp/tools.mdx
+++ b/site/content/docs/mcp/tools.mdx
@@ -5,7 +5,7 @@ description: Reference for the MCP tools exposed by Lific.
 
 Lific exposes 27 MCP tools. Required parameters use non-optional input fields. Optional parameters can be omitted.
 
-When MCP is reached over HTTP and its origin is known, structured issue identifiers are rendered as Markdown links to the canonical `/<PROJECT>/issues/<ISSUE>` route. Configure `server.public_url` for deployments behind a proxy; otherwise a direct HTTP `Host` is used only when it matches the configured allowlist. Stdio MCP and direct SQL have no authoritative external hostname, so they keep plain identifiers.
+When MCP is reached over HTTP and its origin is known, issue, project, page, plan, module, and comment references are rendered as Markdown links to their canonical web routes. Comment links include an anchor that scrolls the issue or page thread to that comment. Configure `server.public_url` for deployments behind a proxy; otherwise a direct HTTP `Host` is used only when it matches the configured allowlist. Stdio MCP and direct SQL have no authoritative external hostname, so they keep plain references.
 
 ## Issues
 

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -156,12 +156,16 @@ pub async fn run(
     let issue_links = IssueLinkContext::parse(base_url);
     if json_output {
         if let Some(context) = issue_links.as_ref() {
-            decorate_issue_links(&mut output, context, IssueLinkOutput::Url);
+            decorate_resource_links(&mut output, context, IssueLinkOutput::Url);
+            decorate_comment_links(&mut output, command, context, IssueLinkOutput::Url);
+            decorate_module_links(&mut output, command, context, IssueLinkOutput::Url);
         }
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
         if let Some(context) = issue_links.as_ref() {
-            decorate_issue_links(&mut output, context, IssueLinkOutput::Markdown);
+            decorate_resource_links(&mut output, context, IssueLinkOutput::Markdown);
+            decorate_comment_links(&mut output, command, context, IssueLinkOutput::Markdown);
+            decorate_module_links(&mut output, command, context, IssueLinkOutput::Markdown);
         }
         print_human(&output);
     }
@@ -883,14 +887,14 @@ enum IssueLinkOutput {
     Markdown,
 }
 
-fn decorate_issue_links(value: &mut Value, context: &IssueLinkContext, output: IssueLinkOutput) {
+fn decorate_resource_links(value: &mut Value, context: &IssueLinkContext, output: IssueLinkOutput) {
     match value {
         Value::Array(items) => items
             .iter_mut()
-            .for_each(|item| decorate_issue_links(item, context, output)),
+            .for_each(|item| decorate_resource_links(item, context, output)),
         Value::Object(object) => {
             if let Some(identifier) = object.get("identifier").and_then(Value::as_str)
-                && let Some(url) = context.issue_url(identifier)
+                && let Some(url) = resource_url(object, context, identifier)
             {
                 match output {
                     IssueLinkOutput::Url => {
@@ -899,14 +903,137 @@ fn decorate_issue_links(value: &mut Value, context: &IssueLinkContext, output: I
                     IssueLinkOutput::Markdown => {
                         object.insert(
                             "identifier".into(),
-                            Value::String(context.issue_markdown(identifier)),
+                            Value::String(format!("[{identifier}]({url})")),
                         );
                     }
                 }
             }
             object
                 .values_mut()
-                .for_each(|item| decorate_issue_links(item, context, output));
+                .for_each(|item| decorate_resource_links(item, context, output));
+        }
+        _ => {}
+    }
+}
+
+fn resource_url(object: &serde_json::Map<String, Value>, context: &IssueLinkContext, identifier: &str) -> Option<String> {
+    if let Some(url) = context.issue_url(identifier) {
+        return Some(url);
+    }
+    let id = object.get("id").and_then(Value::as_i64)?;
+    if let Some(url) = context.page_url(identifier, id) {
+        return Some(url);
+    }
+    if let Some(url) = context.plan_url(identifier, id) {
+        return Some(url);
+    }
+    context.project_url(identifier)
+}
+
+fn decorate_comment_links(
+    value: &mut Value,
+    command: &Command,
+    context: &IssueLinkContext,
+    output: IssueLinkOutput,
+) {
+    let Some(identifier) = (match command {
+        Command::Comment { action } => match action {
+            CommentAction::List { identifier } | CommentAction::Add { identifier, .. } => {
+                Some(identifier.as_str())
+            }
+        },
+        _ => None,
+    }) else {
+        return;
+    };
+    decorate_comment_value(value, identifier, context, output);
+}
+
+fn decorate_comment_value(
+    value: &mut Value,
+    parent_identifier: &str,
+    context: &IssueLinkContext,
+    output: IssueLinkOutput,
+) {
+    match value {
+        Value::Array(items) => items.iter_mut().for_each(|item| {
+            decorate_comment_value(item, parent_identifier, context, output)
+        }),
+        Value::Object(object) => {
+            if let Some(comment_id) = object.get("id").and_then(Value::as_i64)
+                && let Some(url) = context.issue_comment_url(parent_identifier, comment_id)
+            {
+                match output {
+                    IssueLinkOutput::Url => {
+                        object.insert("web_url".into(), Value::String(url));
+                    }
+                    IssueLinkOutput::Markdown => {
+                        object.insert(
+                            "comment".into(),
+                            Value::String(format!("[comment #{comment_id}]({url})")),
+                        );
+                    }
+                }
+            }
+            object.values_mut().for_each(|item| {
+                decorate_comment_value(item, parent_identifier, context, output)
+            });
+        }
+        _ => {}
+    }
+}
+
+fn decorate_module_links(
+    value: &mut Value,
+    command: &Command,
+    context: &IssueLinkContext,
+    output: IssueLinkOutput,
+) {
+    let Some(project) = (match command {
+        Command::Module { action } => match action {
+            ModuleAction::List { project }
+            | ModuleAction::Create { project, .. }
+            | ModuleAction::Update { project, .. }
+            | ModuleAction::Delete { project, .. } => Some(project.as_str()),
+        },
+        _ => None,
+    }) else {
+        return;
+    };
+    decorate_module_value(value, &project.to_ascii_uppercase(), context, output);
+}
+
+fn decorate_module_value(
+    value: &mut Value,
+    project: &str,
+    context: &IssueLinkContext,
+    output: IssueLinkOutput,
+) {
+    match value {
+        Value::Array(items) => items
+            .iter_mut()
+            .for_each(|item| decorate_module_value(item, project, context, output)),
+        Value::Object(object) => {
+            if let Some(module_id) = object.get("id").and_then(Value::as_i64)
+                && let Some(url) = context.module_url(project, module_id)
+            {
+                match output {
+                    IssueLinkOutput::Url => {
+                        object.insert("web_url".into(), Value::String(url));
+                    }
+                    IssueLinkOutput::Markdown => {
+                        if let Some(name) = object.get("name").and_then(Value::as_str) {
+                            object.insert(
+                                "name".into(),
+                                Value::String(format!("[{name}]({url})")),
+                            );
+                        }
+                    }
+                }
+            }
+            object.values_mut().for_each(|item| {
+                decorate_module_value(item, project, context, output)
+            });
         }
         _ => {}
     }
@@ -948,7 +1075,8 @@ mod tests {
 
     use super::{
         ERROR_BODY_LIMIT, HttpBackend, IssueCreate, IssueLinkOutput, IssueUpdate, PageCreate,
-        ProjectCreate, decorate_issue_links, error_detail, export_filename, find_resource,
+        ProjectCreate, decorate_comment_links, decorate_resource_links, error_detail,
+        decorate_module_links, export_filename, find_resource, resource_url,
         is_loopback_host, safe_filename, sanitize_error_detail, segment,
     };
     use crate::links::IssueLinkContext;
@@ -1653,24 +1781,80 @@ mod tests {
     }
 
     #[test]
-    fn decorates_http_issue_results_without_touching_page_identifiers() {
+    fn decorates_http_resource_results() {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
         let mut value = json!([
             {"identifier": "LIF-42", "title": "Fix"},
-            {"identifier": "LIF-DOC-3", "title": "Page"}
+            {"identifier": "LIF-DOC-3", "id": 17, "title": "Page"},
+            {"identifier": "LIF-PLAN-4", "id": 19, "title": "Plan"},
+            {"identifier": "LIF", "id": 23, "name": "Project"}
         ]);
 
-        decorate_issue_links(&mut value, &context, IssueLinkOutput::Url);
+        decorate_resource_links(&mut value, &context, IssueLinkOutput::Url);
         assert_eq!(
             value[0]["web_url"],
             "https://tracker.example/lific/LIF/issues/LIF-42"
         );
-        assert!(value[1]["web_url"].is_null());
-        decorate_issue_links(&mut value, &context, IssueLinkOutput::Markdown);
+        assert_eq!(
+            value[1]["web_url"],
+            "https://tracker.example/lific/LIF/pages/17"
+        );
+        assert_eq!(
+            value[2]["web_url"],
+            "https://tracker.example/lific/LIF/plans/19"
+        );
+        assert_eq!(
+            value[3]["web_url"],
+            "https://tracker.example/lific/LIF/overview"
+        );
+        assert_eq!(
+            resource_url(value[1].as_object().unwrap(), &context, "LIF-DOC-3"),
+            Some("https://tracker.example/lific/LIF/pages/17".into())
+        );
+        decorate_resource_links(&mut value, &context, IssueLinkOutput::Markdown);
         assert_eq!(
             value[0]["identifier"],
             "[LIF-42](https://tracker.example/lific/LIF/issues/LIF-42)"
         );
-        assert_eq!(value[1]["identifier"], "LIF-DOC-3");
+        assert_eq!(
+            value[1]["identifier"],
+            "[LIF-DOC-3](https://tracker.example/lific/LIF/pages/17)"
+        );
+    }
+
+    #[test]
+    fn decorates_http_comment_results_with_issue_anchor() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+        let command = Command::Comment {
+            action: crate::cli::CommentAction::List {
+                identifier: "LIF-42".into(),
+            },
+        };
+        let mut value = json!([{"id": 7, "content": "Looks good"}]);
+
+        decorate_comment_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
+
+        assert_eq!(
+            value[0]["comment"],
+            "[comment #7](https://tracker.example/lific/LIF/issues/LIF-42#comment-7)"
+        );
+    }
+
+    #[test]
+    fn decorates_http_module_results_with_project_route() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+        let command = Command::Module {
+            action: crate::cli::ModuleAction::List {
+                project: "lif".into(),
+            },
+        };
+        let mut value = json!([{"id": 23, "name": "Backend"}]);
+
+        decorate_module_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
+
+        assert_eq!(
+            value[0]["name"],
+            "[Backend](https://tracker.example/lific/LIF/modules/23)"
+        );
     }
 }

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -153,20 +153,16 @@ pub async fn run(
 ) -> Result<()> {
     let backend = HttpBackend::new(base_url, api_key)?;
     let mut output = backend.execute(command).await?;
-    let issue_links = IssueLinkContext::parse(base_url);
+    let issue_links = backend.link_context();
     if json_output {
-        if let Some(context) = issue_links.as_ref() {
-            decorate_resource_links(&mut output, context, IssueLinkOutput::Url);
-            decorate_comment_links(&mut output, command, context, IssueLinkOutput::Url);
-            decorate_module_links(&mut output, command, context, IssueLinkOutput::Url);
-        }
+        decorate_resource_links(&mut output, issue_links, IssueLinkOutput::Url);
+        decorate_comment_links(&mut output, command, issue_links, IssueLinkOutput::Url);
+        decorate_module_links(&mut output, command, issue_links, IssueLinkOutput::Url);
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        if let Some(context) = issue_links.as_ref() {
-            decorate_resource_links(&mut output, context, IssueLinkOutput::Markdown);
-            decorate_comment_links(&mut output, command, context, IssueLinkOutput::Markdown);
-            decorate_module_links(&mut output, command, context, IssueLinkOutput::Markdown);
-        }
+        decorate_resource_links(&mut output, issue_links, IssueLinkOutput::Markdown);
+        decorate_comment_links(&mut output, command, issue_links, IssueLinkOutput::Markdown);
+        decorate_module_links(&mut output, command, issue_links, IssueLinkOutput::Markdown);
         print_human(&output);
     }
     Ok(())
@@ -175,6 +171,7 @@ pub async fn run(
 struct HttpBackend {
     client: Client,
     base_url: String,
+    link_context: IssueLinkContext,
     api_key: Option<String>,
 }
 
@@ -189,6 +186,9 @@ impl HttpBackend {
         if parsed.scheme() != "http" && parsed.scheme() != "https" {
             bail!("HTTP backend URL must use http:// or https://");
         }
+        let link_context = IssueLinkContext::parse(base_url).ok_or_else(|| {
+            anyhow!("HTTP backend URL must not contain credentials, a query, or a fragment")
+        })?;
         if parsed.scheme() == "http"
             && parsed
                 .host_str()
@@ -205,8 +205,13 @@ impl HttpBackend {
                 .redirect(reqwest::redirect::Policy::none())
                 .build()?,
             base_url: base_url.to_owned(),
+            link_context,
             api_key: api_key.map(str::to_owned),
         })
+    }
+
+    fn link_context(&self) -> &IssueLinkContext {
+        &self.link_context
     }
 
     async fn execute(&self, command: &Command) -> Result<Value> {
@@ -946,7 +951,19 @@ fn decorate_comment_links(
     }) else {
         return;
     };
-    decorate_comment_value(value, identifier, context, output);
+    let canonical_identifier = canonical_issue_identifier(identifier);
+    decorate_comment_value(
+        value,
+        canonical_identifier.as_deref().unwrap_or(identifier),
+        context,
+        output,
+    );
+}
+
+fn canonical_issue_identifier(identifier: &str) -> Option<String> {
+    let (project, sequence) = identifier.rsplit_once('-')?;
+    let sequence = sequence.parse::<i64>().ok()?;
+    (sequence > 0).then(|| format!("{}-{sequence}", project.to_ascii_uppercase()))
 }
 
 fn decorate_comment_value(
@@ -1025,7 +1042,7 @@ fn decorate_module_value(
                         if let Some(name) = object.get("name").and_then(Value::as_str) {
                             object.insert(
                                 "name".into(),
-                                Value::String(format!("[{name}]({url})")),
+                                Value::String(context.module_markdown(project, module_id, name)),
                             );
                         }
                     }
@@ -1138,9 +1155,10 @@ mod tests {
             .await,
         )
         .await;
-        let workspace_page =
-            parse_json(json_post(&app, "/api/pages", json!({"title": "Workspace page"})).await)
-                .await;
+        let workspace_page = parse_json(
+            json_post(&app, "/api/pages", json!({"title": "Workspace page"})).await,
+        )
+        .await;
         let issue = parse_json(
             json_post(
                 &app,
@@ -1253,6 +1271,27 @@ mod tests {
     fn trims_backend_url_whitespace_before_trailing_slashes() {
         let backend = HttpBackend::new("  https://tracker.invalid///  ", None).unwrap();
         assert_eq!(backend.base_url, "https://tracker.invalid");
+    }
+
+    #[test]
+    fn normalized_backend_url_decorates_links() {
+        let backend = HttpBackend::new("  https://tracker.invalid/lific/  ", None).unwrap();
+
+        assert_eq!(
+            backend.link_context().issue_markdown("LIF-42"),
+            "[LIF-42](https://tracker.invalid/lific/LIF/issues/LIF-42)"
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_backend_urls() {
+        for base_url in [
+            "https://user:password@tracker.invalid",
+            "https://tracker.invalid?tenant=one",
+            "https://tracker.invalid#fragment",
+        ] {
+            assert!(HttpBackend::new(base_url, None).is_err(), "{base_url}");
+        }
     }
 
     #[test]
@@ -1427,11 +1466,9 @@ mod tests {
 
         let error = backend.get_json("/api/redirect", &[]).await.unwrap_err();
 
-        assert!(
-            error
-                .to_string()
-                .starts_with("HTTP backend request failed (302 Found):")
-        );
+        assert!(error
+            .to_string()
+            .starts_with("HTTP backend request failed (302 Found):"));
         assert!(captured.lock().await.is_none());
         server.abort();
     }
@@ -1459,10 +1496,7 @@ mod tests {
             std::fs::read_to_string(output_dir.join("report.txt")).unwrap(),
             "export contents"
         );
-        assert_eq!(
-            output,
-            json!([output_dir.join("report.txt").display().to_string()])
-        );
+        assert_eq!(output, json!([output_dir.join("report.txt").display().to_string()]));
         std::fs::remove_dir_all(output_dir).unwrap();
         server.abort();
     }
@@ -1827,7 +1861,7 @@ mod tests {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
         let command = Command::Comment {
             action: crate::cli::CommentAction::List {
-                identifier: "LIF-42".into(),
+                identifier: "lif-042".into(),
             },
         };
         let mut value = json!([{"id": 7, "content": "Looks good"}]);
@@ -1848,13 +1882,13 @@ mod tests {
                 project: "lif".into(),
             },
         };
-        let mut value = json!([{"id": 23, "name": "Backend"}]);
+        let mut value = json!([{"id": 23, "name": "Backend [internal]"}]);
 
         decorate_module_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
 
         assert_eq!(
             value[0]["name"],
-            "[Backend](https://tracker.example/lific/LIF/modules/23)"
+            "[Backend \\[internal\\]](https://tracker.example/lific/LIF/modules/23)"
         );
     }
 }

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -14,7 +14,7 @@ use reqwest::{
 use serde::Serialize;
 use serde_json::{Value, json};
 
-use crate::links::IssueLinkContext;
+use crate::links::{IssueLinkContext, MarkdownReference, ResourceUrl};
 
 use super::{
     Command, CommentAction, ExportAction, FolderAction, IssueAction, LabelAction, ModuleAction,
@@ -24,6 +24,12 @@ use super::{
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const ERROR_BODY_LIMIT: usize = 64 * 1024;
 type QueryParam<'a> = (&'a str, Cow<'a, str>);
+
+#[derive(Debug)]
+struct ResolvedResource {
+    id: i64,
+    identifier: String,
+}
 
 #[derive(Serialize)]
 struct IssueCreate<'a> {
@@ -152,17 +158,15 @@ pub async fn run(
     json_output: bool,
 ) -> Result<()> {
     let backend = HttpBackend::new(base_url, api_key)?;
-    let mut output = backend.execute(command).await?;
-    let issue_links = backend.link_context();
+    let link_output = if json_output {
+        IssueLinkOutput::Url
+    } else {
+        IssueLinkOutput::Markdown
+    };
+    let output = backend.execute(command, link_output).await?;
     if json_output {
-        decorate_resource_links(&mut output, issue_links, IssueLinkOutput::Url);
-        decorate_comment_links(&mut output, command, issue_links, IssueLinkOutput::Url);
-        decorate_module_links(&mut output, command, issue_links, IssueLinkOutput::Url);
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        decorate_resource_links(&mut output, issue_links, IssueLinkOutput::Markdown);
-        decorate_comment_links(&mut output, command, issue_links, IssueLinkOutput::Markdown);
-        decorate_module_links(&mut output, command, issue_links, IssueLinkOutput::Markdown);
         print_human(&output);
     }
     Ok(())
@@ -210,15 +214,17 @@ impl HttpBackend {
         })
     }
 
-    fn link_context(&self) -> &IssueLinkContext {
-        &self.link_context
-    }
-
-    async fn execute(&self, command: &Command) -> Result<Value> {
+    async fn execute(&self, command: &Command, output: IssueLinkOutput) -> Result<Value> {
         match command {
-            Command::Issue { action } => self.issue(action).await,
-            Command::Project { action } => self.project(action).await,
-            Command::Page { action } => self.page(action).await,
+            Command::Issue { action } => self.issue(action).await.map(|value| {
+                linked_resources(value, &self.link_context, output, ResourceKind::Issue)
+            }),
+            Command::Project { action } => self.project(action).await.map(|value| {
+                linked_resources(value, &self.link_context, output, ResourceKind::Project)
+            }),
+            Command::Page { action } => self.page(action).await.map(|value| {
+                linked_resources(value, &self.link_context, output, ResourceKind::Page)
+            }),
             Command::Export { action } => self.export(action).await,
             Command::Search {
                 query,
@@ -237,10 +243,16 @@ impl HttpBackend {
                 .into_iter()
                 .flatten()
                 .collect::<Vec<_>>();
-                self.get_json("/api/search", &params).await
+                self.get_json("/api/search", &params).await.map(|value| {
+                    linked_resources(value, &self.link_context, output, ResourceKind::Search)
+                })
             }
-            Command::Comment { action } => self.comment(action).await,
-            Command::Module { action } => self.module(action).await,
+            Command::Comment { action } => self.comment(action).await.map(|(value, identifier)| {
+                linked_comments(value, &self.link_context, output, &identifier)
+            }),
+            Command::Module { action } => self.module(action).await.map(|(value, project)| {
+                linked_modules(value, &self.link_context, output, &project)
+            }),
             Command::Label { action } => self.label(action).await,
             Command::Folder { action } => self.folder(action).await,
             _ => bail!("the HTTP backend does not support this command yet"),
@@ -471,43 +483,46 @@ impl HttpBackend {
         }
     }
 
-    async fn comment(&self, action: &CommentAction) -> Result<Value> {
+    async fn comment(&self, action: &CommentAction) -> Result<(Value, String)> {
         match action {
             CommentAction::List { identifier } => {
-                let id = self.issue_id(identifier).await?;
-                self.get_json(&format!("/api/issues/{id}/comments"), &[])
+                let issue = self.issue_identity(identifier).await?;
+                self.get_json(&format!("/api/issues/{}/comments", issue.id), &[])
                     .await
+                    .map(|value| (value, issue.identifier))
             }
             CommentAction::Add {
                 identifier,
                 content,
                 user,
             } => {
-                if user.is_some() {
-                    bail!(
+                user.as_ref().map_or(Ok(()), |_| {
+                    Err(anyhow!(
                         "--user cannot be used with the HTTP backend; the server uses the API credential's user"
-                    );
-                }
-                let id = self.issue_id(identifier).await?;
+                    ))
+                })?;
+                let issue = self.issue_identity(identifier).await?;
                 self.send_json(
                     Method::POST,
-                    &format!("/api/issues/{id}/comments"),
+                    &format!("/api/issues/{}/comments", issue.id),
                     &CommentCreate { content },
                 )
                 .await
+                .map(|value| (value, issue.identifier))
             }
         }
     }
 
-    async fn module(&self, action: &ModuleAction) -> Result<Value> {
+    async fn module(&self, action: &ModuleAction) -> Result<(Value, String)> {
         match action {
             ModuleAction::List { project } => {
-                let id = self.project_id(project).await?;
+                let project = self.project_identity(project).await?;
                 self.get_json(
                     "/api/modules",
-                    &[("project_id", Cow::Owned(id.to_string()))],
+                    &[("project_id", Cow::Owned(project.id.to_string()))],
                 )
                 .await
+                .map(|value| (value, project.identifier))
             }
             ModuleAction::Create {
                 project,
@@ -515,12 +530,12 @@ impl HttpBackend {
                 description,
                 status,
             } => {
-                let project_id = self.project_id(project).await?;
+                let project = self.project_identity(project).await?;
                 self.send_json(
                     Method::POST,
                     "/api/modules",
                     &ModuleCreate {
-                        project_id,
+                        project_id: project.id,
                         name,
                         description,
                         status,
@@ -528,6 +543,7 @@ impl HttpBackend {
                     },
                 )
                 .await
+                .map(|value| (value, project.identifier))
             }
             ModuleAction::Update {
                 project,
@@ -536,8 +552,8 @@ impl HttpBackend {
                 description,
                 status,
             } => {
-                let project_id = self.project_id(project).await?;
-                let id = self.module_id(project_id, name).await?;
+                let project = self.project_identity(project).await?;
+                let id = self.module_id(project.id, name).await?;
                 let body = ModuleUpdate {
                     name: new_name.as_deref(),
                     description: description.as_deref(),
@@ -545,13 +561,14 @@ impl HttpBackend {
                 };
                 self.send_json(Method::PUT, &format!("/api/modules/{id}"), &body)
                     .await
+                    .map(|value| (value, project.identifier))
             }
             ModuleAction::Delete { project, name } => {
-                let id = self
-                    .module_id(self.project_id(project).await?, name)
-                    .await?;
+                let project = self.project_identity(project).await?;
+                let id = self.module_id(project.id, name).await?;
                 self.send_empty(Method::DELETE, &format!("/api/modules/{id}"))
                     .await
+                    .map(|value| (value, project.identifier))
             }
         }
     }
@@ -675,7 +692,13 @@ impl HttpBackend {
     }
 
     async fn project_id(&self, identifier: &str) -> Result<i64> {
-        self.resolve_id("/api/projects", "identifier", identifier, "project", &[])
+        self.project_identity(identifier)
+            .await
+            .map(|project| project.id)
+    }
+
+    async fn project_identity(&self, identifier: &str) -> Result<ResolvedResource> {
+        self.resolve_resource("/api/projects", "identifier", identifier, "project", &[])
             .await
     }
 
@@ -696,10 +719,14 @@ impl HttpBackend {
     }
 
     async fn issue_id(&self, identifier: &str) -> Result<i64> {
-        self.get_json(&format!("/api/issues/resolve/{}", segment(identifier)), &[])
-            .await?["id"]
-            .as_i64()
-            .ok_or_else(|| anyhow!("issue '{identifier}' response had no id"))
+        self.issue_identity(identifier).await.map(|issue| issue.id)
+    }
+
+    async fn issue_identity(&self, identifier: &str) -> Result<ResolvedResource> {
+        let value = self
+            .get_json(&format!("/api/issues/resolve/{}", segment(identifier)), &[])
+            .await?;
+        resource_from_object(value, "identifier", identifier, "issue")
     }
 
     async fn issue_project_id(&self, id: i64) -> Result<i64> {
@@ -749,6 +776,19 @@ impl HttpBackend {
         kind: &str,
         params: &[QueryParam<'_>],
     ) -> Result<i64> {
+        self.resolve_resource(path, key, expected, kind, params)
+            .await
+            .map(|resource| resource.id)
+    }
+
+    async fn resolve_resource(
+        &self,
+        path: &str,
+        key: &str,
+        expected: &str,
+        kind: &str,
+        params: &[QueryParam<'_>],
+    ) -> Result<ResolvedResource> {
         find_resource(self.get_json(path, params).await?, key, expected, kind)
     }
 
@@ -811,18 +851,51 @@ fn is_loopback_host(host: &str) -> bool {
             .is_ok_and(|address| address.is_loopback())
 }
 
-fn find_resource(value: Value, key: &str, expected: &str, kind: &str) -> Result<i64> {
-    value
-        .as_array()
-        .and_then(|items| {
-            items.iter().find(|item| {
-                item[key]
-                    .as_str()
-                    .is_some_and(|value| value.eq_ignore_ascii_case(expected))
-            })
-        })
-        .and_then(|item| item["id"].as_i64())
-        .ok_or_else(|| anyhow!("{kind} '{expected}' not found"))
+fn find_resource(value: Value, key: &str, expected: &str, kind: &str) -> Result<ResolvedResource> {
+    match value {
+        Value::Array(items) => items.into_iter().find_map(|item| match item {
+            Value::Object(object)
+                if object
+                    .get(key)
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| value.eq_ignore_ascii_case(expected)) =>
+            {
+                object.get("id").and_then(Value::as_i64).map(|_| object)
+            }
+            _ => None,
+        }),
+        _ => None,
+    }
+    .ok_or_else(|| anyhow!("{kind} '{expected}' not found"))
+    .and_then(|object| resource_from_map(object, key, expected, kind))
+}
+
+fn resource_from_object(
+    value: Value,
+    key: &str,
+    expected: &str,
+    kind: &str,
+) -> Result<ResolvedResource> {
+    match value {
+        Value::Object(object) => resource_from_map(object, key, expected, kind),
+        _ => Err(anyhow!("{kind} '{expected}' response was not an object")),
+    }
+}
+
+fn resource_from_map(
+    mut object: serde_json::Map<String, Value>,
+    key: &str,
+    expected: &str,
+    kind: &str,
+) -> Result<ResolvedResource> {
+    let id = object
+        .get("id")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow!("{kind} '{expected}' response had no id"))?;
+    match object.remove(key) {
+        Some(Value::String(identifier)) => Ok(ResolvedResource { id, identifier }),
+        _ => Err(anyhow!("{kind} '{expected}' response had no {key}")),
+    }
 }
 
 fn segment(value: &str) -> String {
@@ -892,191 +965,202 @@ enum IssueLinkOutput {
     Markdown,
 }
 
-fn decorate_resource_links(value: &mut Value, context: &IssueLinkContext, output: IssueLinkOutput) {
-    match value {
-        Value::Array(items) => items
-            .iter_mut()
-            .for_each(|item| decorate_resource_links(item, context, output)),
-        Value::Object(object) => {
-            if let Some(identifier) = object.get("identifier").and_then(Value::as_str)
-                && let Some(url) = resource_url(object, context, identifier)
-            {
-                match output {
-                    IssueLinkOutput::Url => {
-                        object.insert("web_url".into(), Value::String(url));
-                    }
-                    IssueLinkOutput::Markdown => {
-                        object.insert(
-                            "identifier".into(),
-                            Value::String(format!("[{identifier}]({url})")),
-                        );
-                    }
-                }
-            }
-            object
-                .values_mut()
-                .for_each(|item| decorate_resource_links(item, context, output));
+#[derive(Clone, Copy)]
+enum ResourceKind {
+    Issue,
+    Project,
+    Page,
+    Search,
+}
+
+#[derive(Clone, Copy)]
+enum CommentLocation {
+    Issue,
+    Page(i64),
+}
+
+impl CommentLocation {
+    fn url<'a>(
+        self,
+        context: &'a IssueLinkContext,
+        identifier: &'a str,
+        comment_id: i64,
+    ) -> Option<ResourceUrl<'a>> {
+        match self {
+            Self::Issue => context.issue_comment_url(identifier, comment_id),
+            Self::Page(page_id) => context.page_comment_url(identifier, page_id, comment_id),
         }
-        _ => {}
+    }
+
+    fn markdown<'a>(
+        self,
+        context: &'a IssueLinkContext,
+        identifier: &'a str,
+        comment_id: i64,
+    ) -> MarkdownReference<'a> {
+        match self {
+            Self::Issue => context.issue_comment_markdown(identifier, comment_id),
+            Self::Page(page_id) => context.page_comment_markdown(identifier, page_id, comment_id),
+        }
     }
 }
 
-fn resource_url(
-    object: &serde_json::Map<String, Value>,
-    context: &IssueLinkContext,
-    identifier: &str,
-) -> Option<String> {
-    let id = object.get("id").and_then(Value::as_i64);
-    if object.get("result_type").and_then(Value::as_str) == Some("comment") {
-        let comment_id = id?;
-        return object
-            .get("parent_page_id")
-            .and_then(Value::as_i64)
-            .map_or_else(
-                || context.issue_comment_url(identifier, comment_id),
-                |page_id| context.page_comment_url(identifier, page_id, comment_id),
-            );
-    }
-    if let Some(url) = context.issue_url(identifier) {
-        return Some(url);
-    }
-    if let Some(url) = context.project_url(identifier) {
-        return Some(url);
-    }
-    let id = id?;
-    if let Some(url) = context.page_url(identifier, id) {
-        return Some(url);
-    }
-    if let Some(url) = context.plan_url(identifier, id) {
-        return Some(url);
-    }
-    None
-}
-
-fn decorate_comment_links(
-    value: &mut Value,
-    command: &Command,
+fn linked_resources(
+    value: Value,
     context: &IssueLinkContext,
     output: IssueLinkOutput,
-) {
-    let Some(identifier) = (match command {
-        Command::Comment { action } => match action {
-            CommentAction::List { identifier } | CommentAction::Add { identifier, .. } => {
-                Some(identifier.as_str())
-            }
-        },
-        _ => None,
-    }) else {
-        return;
-    };
-    let canonical_identifier = canonical_issue_identifier(identifier);
-    decorate_comment_value(
-        value,
-        canonical_identifier.as_deref().unwrap_or(identifier),
-        context,
-        output,
-    );
+    kind: ResourceKind,
+) -> Value {
+    map_output_objects(value, |object| {
+        linked_resource(object, context, output, kind)
+    })
 }
 
-fn canonical_issue_identifier(identifier: &str) -> Option<String> {
-    let (project, sequence) = identifier.rsplit_once('-')?;
-    let sequence = sequence.parse::<i64>().ok()?;
-    (sequence > 0).then(|| format!("{}-{sequence}", project.to_ascii_uppercase()))
-}
+fn map_output_objects(
+    value: Value,
+    mut map: impl FnMut(serde_json::Map<String, Value>) -> serde_json::Map<String, Value>,
+) -> Value {
+    fn map_object(
+        value: Value,
+        map: &mut impl FnMut(serde_json::Map<String, Value>) -> serde_json::Map<String, Value>,
+    ) -> Value {
+        match value {
+            Value::Object(object) => Value::Object(map(object)),
+            value => value,
+        }
+    }
 
-fn decorate_comment_value(
-    value: &mut Value,
-    parent_identifier: &str,
-    context: &IssueLinkContext,
-    output: IssueLinkOutput,
-) {
     match value {
-        Value::Array(items) => items.iter_mut().for_each(|item| {
-            decorate_comment_value(item, parent_identifier, context, output)
-        }),
-        Value::Object(object) => {
-            if object.get("content").and_then(Value::as_str).is_some()
-                && let Some(comment_id) = object.get("id").and_then(Value::as_i64)
-                && let Some(url) = object
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(|value| map_object(value, &mut map))
+                .collect(),
+        ),
+        value => map_object(value, &mut map),
+    }
+}
+
+fn linked_resource(
+    object: serde_json::Map<String, Value>,
+    context: &IssueLinkContext,
+    output: IssueLinkOutput,
+    kind: ResourceKind,
+) -> serde_json::Map<String, Value> {
+    let linked_field = object
+        .get("identifier")
+        .and_then(Value::as_str)
+        .and_then(|identifier| {
+            resource_url(&object, context, identifier, kind).map(|url| match output {
+                IssueLinkOutput::Url => ("web_url", url.to_string()),
+                IssueLinkOutput::Markdown => (
+                    "identifier",
+                    MarkdownReference::linked(identifier, url).to_string(),
+                ),
+            })
+        });
+    match linked_field {
+        Some((field, value)) => with_string_field(object, field, value),
+        None => object,
+    }
+}
+
+fn resource_url<'a>(
+    object: &serde_json::Map<String, Value>,
+    context: &'a IssueLinkContext,
+    identifier: &'a str,
+    kind: ResourceKind,
+) -> Option<ResourceUrl<'a>> {
+    let id = object.get("id").and_then(Value::as_i64);
+    match kind {
+        ResourceKind::Issue => context.issue_url(identifier),
+        ResourceKind::Project => context.project_url(identifier),
+        ResourceKind::Page => context.page_url(identifier, id?),
+        ResourceKind::Search => match object.get("result_type").and_then(Value::as_str)? {
+            "issue" => context.issue_url(identifier),
+            "page" => context.page_url(identifier, id?),
+            "comment" => object
+                .get("parent_page_id")
+                .and_then(Value::as_i64)
+                .map_or(CommentLocation::Issue, CommentLocation::Page)
+                .url(context, identifier, id?),
+            _ => None,
+        },
+    }
+}
+
+fn linked_comments(
+    value: Value,
+    context: &IssueLinkContext,
+    output: IssueLinkOutput,
+    identifier: &str,
+) -> Value {
+    map_output_objects(value, |object| {
+        let linked_field = object
+            .get("id")
+            .and_then(Value::as_i64)
+            .and_then(|comment_id| {
+                let location = object
                     .get("page_id")
                     .and_then(Value::as_i64)
-                    .map_or_else(
-                        || context.issue_comment_url(parent_identifier, comment_id),
-                        |page_id| {
-                            context.page_comment_url(parent_identifier, page_id, comment_id)
-                        },
-                    )
-            {
-                match output {
-                    IssueLinkOutput::Url => {
-                        object.insert("web_url".into(), Value::String(url));
-                    }
-                    IssueLinkOutput::Markdown => {
-                        object.insert(
-                            "comment".into(),
-                            Value::String(format!("[comment #{comment_id}]({url})")),
-                        );
-                    }
-                }
-            }
+                    .map_or(CommentLocation::Issue, CommentLocation::Page);
+                location
+                    .url(context, identifier, comment_id)
+                    .map(|url| match output {
+                        IssueLinkOutput::Url => ("web_url", url.to_string()),
+                        IssueLinkOutput::Markdown => (
+                            "comment",
+                            location
+                                .markdown(context, identifier, comment_id)
+                                .to_string(),
+                        ),
+                    })
+            });
+        match linked_field {
+            Some((field, value)) => with_string_field(object, field, value),
+            None => object,
         }
-        _ => {}
-    }
+    })
 }
 
-fn decorate_module_links(
-    value: &mut Value,
-    command: &Command,
+fn linked_modules(
+    value: Value,
     context: &IssueLinkContext,
     output: IssueLinkOutput,
-) {
-    let Some(project) = (match command {
-        Command::Module { action } => match action {
-            ModuleAction::List { project }
-            | ModuleAction::Create { project, .. }
-            | ModuleAction::Update { project, .. }
-            | ModuleAction::Delete { project, .. } => Some(project.as_str()),
-        },
-        _ => None,
-    }) else {
-        return;
-    };
-    decorate_module_value(value, &project.to_ascii_uppercase(), context, output);
-}
-
-fn decorate_module_value(
-    value: &mut Value,
     project: &str,
-    context: &IssueLinkContext,
-    output: IssueLinkOutput,
-) {
-    match value {
-        Value::Array(items) => items
-            .iter_mut()
-            .for_each(|item| decorate_module_value(item, project, context, output)),
-        Value::Object(object) => {
-            if object.get("project_id").and_then(Value::as_i64).is_some()
-                && object.get("name").and_then(Value::as_str).is_some()
-                && let Some(module_id) = object.get("id").and_then(Value::as_i64)
-                && let Some(url) = context.module_url(project, module_id)
-            {
-                match output {
-                    IssueLinkOutput::Url => {
-                        object.insert("web_url".into(), Value::String(url));
-                    }
-                    IssueLinkOutput::Markdown => {
-                        if let Some(name) = object.get("name").and_then(Value::as_str) {
-                            object.insert(
-                                "name".into(),
-                                Value::String(context.module_markdown(project, module_id, name)),
-                            );
-                        }
-                    }
-                }
-            }
+) -> Value {
+    map_output_objects(value, |object| {
+        let linked_field = object
+            .get("id")
+            .and_then(Value::as_i64)
+            .zip(object.get("name").and_then(Value::as_str))
+            .and_then(|(module_id, name)| {
+                context
+                    .module_url(project, module_id)
+                    .map(|url| match output {
+                        IssueLinkOutput::Url => ("web_url", url.to_string()),
+                        IssueLinkOutput::Markdown => (
+                            "name",
+                            context
+                                .module_markdown(project, module_id, name)
+                                .to_string(),
+                        ),
+                    })
+            });
+        match linked_field {
+            Some((field, value)) => with_string_field(object, field, value),
+            None => object,
         }
-        _ => {}
-    }
+    })
+}
+
+fn with_string_field(
+    mut object: serde_json::Map<String, Value>,
+    field: &str,
+    value: String,
+) -> serde_json::Map<String, Value> {
+    object.insert(field.into(), Value::String(value));
+    object
 }
 
 fn pretty(value: &Value) -> String {
@@ -1115,9 +1199,9 @@ mod tests {
 
     use super::{
         ERROR_BODY_LIMIT, HttpBackend, IssueCreate, IssueLinkOutput, IssueUpdate, PageCreate,
-        ProjectCreate, decorate_comment_links, decorate_resource_links, error_detail,
-        decorate_module_links, export_filename, find_resource, resource_url,
-        is_loopback_host, safe_filename, sanitize_error_detail, segment,
+        ProjectCreate, ResourceKind, error_detail, export_filename, find_resource,
+        is_loopback_host, linked_comments, linked_modules, linked_resources, resource_from_object,
+        resource_url, safe_filename, sanitize_error_detail, segment,
     };
     use crate::links::IssueLinkContext;
 
@@ -1178,10 +1262,9 @@ mod tests {
             .await,
         )
         .await;
-        let workspace_page = parse_json(
-            json_post(&app, "/api/pages", json!({"title": "Workspace page"})).await,
-        )
-        .await;
+        let workspace_page =
+            parse_json(json_post(&app, "/api/pages", json!({"title": "Workspace page"})).await)
+                .await;
         let issue = parse_json(
             json_post(
                 &app,
@@ -1257,6 +1340,14 @@ mod tests {
         Json(value)
     }
 
+    async fn issue_response() -> Json<serde_json::Value> {
+        Json(json!({
+            "id": 42,
+            "identifier": "LIF-42",
+            "title": "Construct links with HTTP results"
+        }))
+    }
+
     #[test]
     fn rejects_non_http_backend_urls() {
         let error = match HttpBackend::new("file://invalid", None) {
@@ -1297,11 +1388,11 @@ mod tests {
     }
 
     #[test]
-    fn normalized_backend_url_decorates_links() {
+    fn normalized_backend_url_constructs_links() {
         let backend = HttpBackend::new("  https://tracker.invalid/lific/  ", None).unwrap();
 
         assert_eq!(
-            backend.link_context().issue_markdown("LIF-42"),
+            backend.link_context.issue_markdown("LIF-42").to_string(),
             "[LIF-42](https://tracker.invalid/lific/LIF/issues/LIF-42)"
         );
     }
@@ -1404,11 +1495,14 @@ mod tests {
         let backend = HttpBackend::new(&url, Some("test-key")).unwrap();
 
         let output = backend
-            .execute(&Command::Search {
-                query: "term".into(),
-                project: None,
-                limit: Some(7),
-            })
+            .execute(
+                &Command::Search {
+                    query: "term".into(),
+                    project: None,
+                    limit: Some(7),
+                },
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap();
 
@@ -1424,19 +1518,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_constructs_linked_issue_results() {
+        let router = Router::new().route("/api/issues/resolve/{identifier}", get(issue_response));
+        let (url, server) = spawn_server(router).await;
+        let backend = HttpBackend::new(&url, None).unwrap();
+
+        let output = backend
+            .execute(
+                &Command::Issue {
+                    action: IssueAction::Get {
+                        identifier: "LIF-42".into(),
+                    },
+                },
+                IssueLinkOutput::Url,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output["web_url"], format!("{url}/LIF/issues/LIF-42"));
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn executes_page_list_with_project_and_folder_resolution() {
         let router = Router::new().route("/api/{*path}", any(page_scope_request));
         let (url, server) = spawn_server(router).await;
         let backend = HttpBackend::new(&url, None).unwrap();
 
         let output = backend
-            .execute(&Command::Page {
-                action: PageAction::List {
-                    project: Some("LIF".into()),
-                    folder: Some("Docs".into()),
-                    label: None,
+            .execute(
+                &Command::Page {
+                    action: PageAction::List {
+                        project: Some("LIF".into()),
+                        folder: Some("Docs".into()),
+                        label: None,
+                    },
                 },
-            })
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap();
 
@@ -1451,9 +1570,12 @@ mod tests {
         let backend = HttpBackend::new(&url, None).unwrap();
 
         let error = backend
-            .execute(&Command::Project {
-                action: ProjectAction::List,
-            })
+            .execute(
+                &Command::Project {
+                    action: ProjectAction::List,
+                },
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap_err();
 
@@ -1489,9 +1611,11 @@ mod tests {
 
         let error = backend.get_json("/api/redirect", &[]).await.unwrap_err();
 
-        assert!(error
-            .to_string()
-            .starts_with("HTTP backend request failed (302 Found):"));
+        assert!(
+            error
+                .to_string()
+                .starts_with("HTTP backend request failed (302 Found):")
+        );
         assert!(captured.lock().await.is_none());
         server.abort();
     }
@@ -1506,12 +1630,15 @@ mod tests {
         let _ = std::fs::remove_dir_all(&output_dir);
 
         let output = backend
-            .execute(&Command::Export {
-                action: ExportAction::Issue {
-                    identifier: "LIF-1".into(),
-                    output: PathBuf::from(&output_dir),
+            .execute(
+                &Command::Export {
+                    action: ExportAction::Issue {
+                        identifier: "LIF-1".into(),
+                        output: PathBuf::from(&output_dir),
+                    },
                 },
-            })
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap();
 
@@ -1519,7 +1646,10 @@ mod tests {
             std::fs::read_to_string(output_dir.join("report.txt")).unwrap(),
             "export contents"
         );
-        assert_eq!(output, json!([output_dir.join("report.txt").display().to_string()]));
+        assert_eq!(
+            output,
+            json!([output_dir.join("report.txt").display().to_string()])
+        );
         std::fs::remove_dir_all(output_dir).unwrap();
         server.abort();
     }
@@ -1530,11 +1660,14 @@ mod tests {
         let backend = HttpBackend::new(&fixture.url, None).unwrap();
 
         let page = backend
-            .execute(&Command::Page {
-                action: PageAction::Get {
-                    identifier: fixture.project_page_identifier,
+            .execute(
+                &Command::Page {
+                    action: PageAction::Get {
+                        identifier: fixture.project_page_identifier,
+                    },
                 },
-            })
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap();
 
@@ -1549,11 +1682,14 @@ mod tests {
         let backend = HttpBackend::new(&fixture.url, None).unwrap();
 
         let page = backend
-            .execute(&Command::Page {
-                action: PageAction::Get {
-                    identifier: fixture.workspace_page_identifier,
+            .execute(
+                &Command::Page {
+                    action: PageAction::Get {
+                        identifier: fixture.workspace_page_identifier,
+                    },
                 },
-            })
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap();
 
@@ -1568,11 +1704,14 @@ mod tests {
         let backend = HttpBackend::new(&fixture.url, None).unwrap();
 
         let issue = backend
-            .execute(&Command::Issue {
-                action: IssueAction::Get {
-                    identifier: fixture.issue_identifier,
+            .execute(
+                &Command::Issue {
+                    action: IssueAction::Get {
+                        identifier: fixture.issue_identifier,
+                    },
                 },
-            })
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap();
 
@@ -1587,11 +1726,14 @@ mod tests {
         let backend = HttpBackend::new(&fixture.url, None).unwrap();
 
         let error = backend
-            .execute(&Command::Page {
-                action: PageAction::Get {
-                    identifier: "TST-DOC-\u{1b}[31m".into(),
+            .execute(
+                &Command::Page {
+                    action: PageAction::Get {
+                        identifier: "TST-DOC-\u{1b}[31m".into(),
+                    },
                 },
-            })
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap_err();
         let error = error.to_string();
@@ -1662,10 +1804,23 @@ mod tests {
             {"id": 4, "name": "Backend"},
             {"id": 9, "name": "Docs"}
         ]);
-        assert_eq!(
-            find_resource(resources, "name", "backend", "module").unwrap(),
-            4
-        );
+        let resource = find_resource(resources, "name", "backend", "module").unwrap();
+        assert_eq!(resource.id, 4);
+        assert_eq!(resource.identifier, "Backend");
+    }
+
+    #[test]
+    fn preserves_canonical_identity_from_resolved_object() {
+        let resource = resource_from_object(
+            json!({"id": 42, "identifier": "LIF-42"}),
+            "identifier",
+            "lif-042",
+            "issue",
+        )
+        .unwrap();
+
+        assert_eq!(resource.id, 42);
+        assert_eq!(resource.identifier, "LIF-42");
     }
 
     #[test]
@@ -1825,10 +1980,13 @@ mod tests {
     async fn rejects_commands_outside_http_data_scope() {
         let backend = HttpBackend::new("https://tracker.invalid", None).unwrap();
         let error = backend
-            .execute(&Command::Start {
-                port: None,
-                host: None,
-            })
+            .execute(
+                &Command::Start {
+                    port: None,
+                    host: None,
+                },
+                IssueLinkOutput::Url,
+            )
             .await
             .unwrap_err();
         assert_eq!(
@@ -1838,56 +1996,79 @@ mod tests {
     }
 
     #[test]
-    fn decorates_http_resource_results() {
+    fn constructs_http_resource_results_with_links() {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
-        let mut value = json!([
-            {"identifier": "LIF-42", "title": "Fix"},
-            {"identifier": "LIF-DOC-3", "id": 17, "title": "Page"},
-            {"identifier": "LIF-PLAN-4", "id": 19, "title": "Plan"},
+        let issues = linked_resources(
+            json!([{"identifier": "LIF-42", "title": "Fix"}]),
+            &context,
+            IssueLinkOutput::Url,
+            ResourceKind::Issue,
+        );
+        let pages = linked_resources(
+            json!([{"identifier": "LIF-DOC-3", "id": 17, "title": "Page"}]),
+            &context,
+            IssueLinkOutput::Url,
+            ResourceKind::Page,
+        );
+        let projects = linked_resources(
+            json!([
             {"identifier": "LIF", "id": 23, "name": "Project"},
             {"identifier": "OPS", "name": "Project without id"}
-        ]);
+            ]),
+            &context,
+            IssueLinkOutput::Url,
+            ResourceKind::Project,
+        );
 
-        decorate_resource_links(&mut value, &context, IssueLinkOutput::Url);
         assert_eq!(
-            value[0]["web_url"],
+            issues[0]["web_url"],
             "https://tracker.example/lific/LIF/issues/LIF-42"
         );
         assert_eq!(
-            value[1]["web_url"],
+            pages[0]["web_url"],
             "https://tracker.example/lific/LIF/pages/17"
         );
         assert_eq!(
-            value[2]["web_url"],
-            "https://tracker.example/lific/LIF/plans/19"
-        );
-        assert_eq!(
-            value[3]["web_url"],
+            projects[0]["web_url"],
             "https://tracker.example/lific/LIF/overview"
         );
         assert_eq!(
-            value[4]["web_url"],
+            projects[1]["web_url"],
             "https://tracker.example/lific/OPS/overview"
         );
         assert_eq!(
-            resource_url(value[1].as_object().unwrap(), &context, "LIF-DOC-3"),
+            resource_url(
+                pages[0].as_object().unwrap(),
+                &context,
+                "LIF-DOC-3",
+                ResourceKind::Page,
+            )
+            .map(|url| url.to_string()),
             Some("https://tracker.example/lific/LIF/pages/17".into())
         );
-        decorate_resource_links(&mut value, &context, IssueLinkOutput::Markdown);
+        let markdown = linked_resources(
+            json!([
+                {"identifier": "LIF-42", "title": "Fix"},
+                {"identifier": "LIF-43", "title": "Another fix"}
+            ]),
+            &context,
+            IssueLinkOutput::Markdown,
+            ResourceKind::Issue,
+        );
         assert_eq!(
-            value[0]["identifier"],
+            markdown[0]["identifier"],
             "[LIF-42](https://tracker.example/lific/LIF/issues/LIF-42)"
         );
         assert_eq!(
-            value[1]["identifier"],
-            "[LIF-DOC-3](https://tracker.example/lific/LIF/pages/17)"
+            markdown[1]["identifier"],
+            "[LIF-43](https://tracker.example/lific/LIF/issues/LIF-43)"
         );
     }
 
     #[test]
-    fn decorates_http_search_comments_with_comment_anchors() {
+    fn constructs_http_search_comments_with_comment_anchors() {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
-        let mut value = serde_json::to_value([
+        let value = serde_json::to_value([
             crate::db::models::SearchResult {
                 result_type: "comment".into(),
                 id: 7,
@@ -1908,10 +2089,13 @@ mod tests {
             },
         ])
         .unwrap();
-        let mut markdown = value.clone();
-
-        decorate_resource_links(&mut value, &context, IssueLinkOutput::Url);
-        decorate_resource_links(&mut markdown, &context, IssueLinkOutput::Markdown);
+        let markdown = linked_resources(
+            value.clone(),
+            &context,
+            IssueLinkOutput::Markdown,
+            ResourceKind::Search,
+        );
+        let value = linked_resources(value, &context, IssueLinkOutput::Url, ResourceKind::Search);
 
         assert_eq!(
             [value[0]["web_url"].as_str(), value[1]["web_url"].as_str()],
@@ -1933,20 +2117,18 @@ mod tests {
     }
 
     #[test]
-    fn decorates_http_comment_results_with_issue_anchor() {
+    fn constructs_http_comment_results_with_issue_anchor() {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
-        let command = Command::Comment {
-            action: crate::cli::CommentAction::List {
-                identifier: "lif-042".into(),
-            },
-        };
-        let mut value = json!([{
-            "id": 7,
-            "content": "Looks good",
-            "author_record": {"id": 99, "name": "Ada"}
-        }]);
-
-        decorate_comment_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
+        let value = linked_comments(
+            json!([{
+                "id": 7,
+                "content": "Looks good",
+                "author_record": {"id": 99, "name": "Ada"}
+            }]),
+            &context,
+            IssueLinkOutput::Markdown,
+            "LIF-42",
+        );
 
         assert_eq!(
             value[0]["comment"],
@@ -1956,20 +2138,18 @@ mod tests {
     }
 
     #[test]
-    fn decorates_http_comment_results_with_page_anchor() {
+    fn constructs_http_comment_results_with_page_anchor() {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
-        let command = Command::Comment {
-            action: crate::cli::CommentAction::List {
-                identifier: "lif-doc-003".into(),
-            },
-        };
-        let mut value = json!([{
-            "id": 8,
-            "page_id": 17,
-            "content": "Page comment"
-        }]);
-
-        decorate_comment_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
+        let value = linked_comments(
+            json!([{
+                "id": 8,
+                "page_id": 17,
+                "content": "Page comment"
+            }]),
+            &context,
+            IssueLinkOutput::Markdown,
+            "LIF-DOC-3",
+        );
 
         assert_eq!(
             value[0]["comment"],
@@ -1978,21 +2158,19 @@ mod tests {
     }
 
     #[test]
-    fn decorates_http_module_results_with_project_route() {
+    fn constructs_http_module_results_with_project_route() {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
-        let command = Command::Module {
-            action: crate::cli::ModuleAction::List {
-                project: "lif".into(),
-            },
-        };
-        let mut value = json!([{
-            "id": 23,
-            "project_id": 1,
-            "name": "Backend [internal]",
-            "owner": {"id": 99, "name": "Ada"}
-        }]);
-
-        decorate_module_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
+        let value = linked_modules(
+            json!([{
+                "id": 23,
+                "project_id": 1,
+                "name": "Backend [internal]",
+                "owner": {"id": 99, "name": "Ada"}
+            }]),
+            &context,
+            IssueLinkOutput::Markdown,
+            "LIF",
+        );
 
         assert_eq!(
             value[0]["name"],

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -921,18 +921,36 @@ fn decorate_resource_links(value: &mut Value, context: &IssueLinkContext, output
     }
 }
 
-fn resource_url(object: &serde_json::Map<String, Value>, context: &IssueLinkContext, identifier: &str) -> Option<String> {
+fn resource_url(
+    object: &serde_json::Map<String, Value>,
+    context: &IssueLinkContext,
+    identifier: &str,
+) -> Option<String> {
+    let id = object.get("id").and_then(Value::as_i64);
+    if object.get("result_type").and_then(Value::as_str) == Some("comment") {
+        let comment_id = id?;
+        return object
+            .get("parent_page_id")
+            .and_then(Value::as_i64)
+            .map_or_else(
+                || context.issue_comment_url(identifier, comment_id),
+                |page_id| context.page_comment_url(identifier, page_id, comment_id),
+            );
+    }
     if let Some(url) = context.issue_url(identifier) {
         return Some(url);
     }
-    let id = object.get("id").and_then(Value::as_i64)?;
+    if let Some(url) = context.project_url(identifier) {
+        return Some(url);
+    }
+    let id = id?;
     if let Some(url) = context.page_url(identifier, id) {
         return Some(url);
     }
     if let Some(url) = context.plan_url(identifier, id) {
         return Some(url);
     }
-    context.project_url(identifier)
+    None
 }
 
 fn decorate_comment_links(
@@ -977,8 +995,17 @@ fn decorate_comment_value(
             decorate_comment_value(item, parent_identifier, context, output)
         }),
         Value::Object(object) => {
-            if let Some(comment_id) = object.get("id").and_then(Value::as_i64)
-                && let Some(url) = context.issue_comment_url(parent_identifier, comment_id)
+            if object.get("content").and_then(Value::as_str).is_some()
+                && let Some(comment_id) = object.get("id").and_then(Value::as_i64)
+                && let Some(url) = object
+                    .get("page_id")
+                    .and_then(Value::as_i64)
+                    .map_or_else(
+                        || context.issue_comment_url(parent_identifier, comment_id),
+                        |page_id| {
+                            context.page_comment_url(parent_identifier, page_id, comment_id)
+                        },
+                    )
             {
                 match output {
                     IssueLinkOutput::Url => {
@@ -992,9 +1019,6 @@ fn decorate_comment_value(
                     }
                 }
             }
-            object.values_mut().for_each(|item| {
-                decorate_comment_value(item, parent_identifier, context, output)
-            });
         }
         _ => {}
     }
@@ -1031,7 +1055,9 @@ fn decorate_module_value(
             .iter_mut()
             .for_each(|item| decorate_module_value(item, project, context, output)),
         Value::Object(object) => {
-            if let Some(module_id) = object.get("id").and_then(Value::as_i64)
+            if object.get("project_id").and_then(Value::as_i64).is_some()
+                && object.get("name").and_then(Value::as_str).is_some()
+                && let Some(module_id) = object.get("id").and_then(Value::as_i64)
                 && let Some(url) = context.module_url(project, module_id)
             {
                 match output {
@@ -1048,9 +1074,6 @@ fn decorate_module_value(
                     }
                 }
             }
-            object.values_mut().for_each(|item| {
-                decorate_module_value(item, project, context, output)
-            });
         }
         _ => {}
     }
@@ -1821,7 +1844,8 @@ mod tests {
             {"identifier": "LIF-42", "title": "Fix"},
             {"identifier": "LIF-DOC-3", "id": 17, "title": "Page"},
             {"identifier": "LIF-PLAN-4", "id": 19, "title": "Plan"},
-            {"identifier": "LIF", "id": 23, "name": "Project"}
+            {"identifier": "LIF", "id": 23, "name": "Project"},
+            {"identifier": "OPS", "name": "Project without id"}
         ]);
 
         decorate_resource_links(&mut value, &context, IssueLinkOutput::Url);
@@ -1842,6 +1866,10 @@ mod tests {
             "https://tracker.example/lific/LIF/overview"
         );
         assert_eq!(
+            value[4]["web_url"],
+            "https://tracker.example/lific/OPS/overview"
+        );
+        assert_eq!(
             resource_url(value[1].as_object().unwrap(), &context, "LIF-DOC-3"),
             Some("https://tracker.example/lific/LIF/pages/17".into())
         );
@@ -1857,6 +1885,54 @@ mod tests {
     }
 
     #[test]
+    fn decorates_http_search_comments_with_comment_anchors() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+        let mut value = serde_json::to_value([
+            crate::db::models::SearchResult {
+                result_type: "comment".into(),
+                id: 7,
+                identifier: Some("LIF-42".into()),
+                title: "Fix".into(),
+                snippet: "Issue comment".into(),
+                project_id: Some(1),
+                parent_page_id: None,
+            },
+            crate::db::models::SearchResult {
+                result_type: "comment".into(),
+                id: 8,
+                identifier: Some("LIF-DOC-3".into()),
+                title: "Page".into(),
+                snippet: "Page comment".into(),
+                project_id: Some(1),
+                parent_page_id: Some(17),
+            },
+        ])
+        .unwrap();
+        let mut markdown = value.clone();
+
+        decorate_resource_links(&mut value, &context, IssueLinkOutput::Url);
+        decorate_resource_links(&mut markdown, &context, IssueLinkOutput::Markdown);
+
+        assert_eq!(
+            [value[0]["web_url"].as_str(), value[1]["web_url"].as_str()],
+            [
+                Some("https://tracker.example/lific/LIF/issues/LIF-42#comment-7"),
+                Some("https://tracker.example/lific/LIF/pages/17#comment-8")
+            ]
+        );
+        assert_eq!(
+            [
+                markdown[0]["identifier"].as_str(),
+                markdown[1]["identifier"].as_str()
+            ],
+            [
+                Some("[LIF-42](https://tracker.example/lific/LIF/issues/LIF-42#comment-7)"),
+                Some("[LIF-DOC-3](https://tracker.example/lific/LIF/pages/17#comment-8)")
+            ]
+        );
+    }
+
+    #[test]
     fn decorates_http_comment_results_with_issue_anchor() {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
         let command = Command::Comment {
@@ -1864,13 +1940,40 @@ mod tests {
                 identifier: "lif-042".into(),
             },
         };
-        let mut value = json!([{"id": 7, "content": "Looks good"}]);
+        let mut value = json!([{
+            "id": 7,
+            "content": "Looks good",
+            "author_record": {"id": 99, "name": "Ada"}
+        }]);
 
         decorate_comment_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
 
         assert_eq!(
             value[0]["comment"],
             "[comment #7](https://tracker.example/lific/LIF/issues/LIF-42#comment-7)"
+        );
+        assert!(value[0]["author_record"].get("comment").is_none());
+    }
+
+    #[test]
+    fn decorates_http_comment_results_with_page_anchor() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+        let command = Command::Comment {
+            action: crate::cli::CommentAction::List {
+                identifier: "lif-doc-003".into(),
+            },
+        };
+        let mut value = json!([{
+            "id": 8,
+            "page_id": 17,
+            "content": "Page comment"
+        }]);
+
+        decorate_comment_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
+
+        assert_eq!(
+            value[0]["comment"],
+            "[comment #8](https://tracker.example/lific/LIF/pages/17#comment-8)"
         );
     }
 
@@ -1882,7 +1985,12 @@ mod tests {
                 project: "lif".into(),
             },
         };
-        let mut value = json!([{"id": 23, "name": "Backend [internal]"}]);
+        let mut value = json!([{
+            "id": 23,
+            "project_id": 1,
+            "name": "Backend [internal]",
+            "owner": {"id": 99, "name": "Ada"}
+        }]);
 
         decorate_module_links(&mut value, &command, &context, IssueLinkOutput::Markdown);
 
@@ -1890,5 +1998,7 @@ mod tests {
             value[0]["name"],
             "[Backend \\[internal\\]](https://tracker.example/lific/LIF/modules/23)"
         );
+        assert_eq!(value[0]["owner"]["name"], "Ada");
+        assert!(value[0]["owner"].get("web_url").is_none());
     }
 }

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -14,6 +14,8 @@ use reqwest::{
 use serde::Serialize;
 use serde_json::{Value, json};
 
+use crate::links::IssueLinkContext;
+
 use super::{
     Command, CommentAction, ExportAction, FolderAction, IssueAction, LabelAction, ModuleAction,
     PageAction, ProjectAction, borrowed_labels,
@@ -150,10 +152,17 @@ pub async fn run(
     json_output: bool,
 ) -> Result<()> {
     let backend = HttpBackend::new(base_url, api_key)?;
-    let output = backend.execute(command).await?;
+    let mut output = backend.execute(command).await?;
+    let issue_links = IssueLinkContext::parse(base_url);
     if json_output {
+        if let Some(context) = issue_links.as_ref() {
+            decorate_issue_links(&mut output, context, IssueLinkOutput::Url);
+        }
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
+        if let Some(context) = issue_links.as_ref() {
+            decorate_issue_links(&mut output, context, IssueLinkOutput::Markdown);
+        }
         print_human(&output);
     }
     Ok(())
@@ -868,6 +877,41 @@ fn print_human(value: &Value) {
     }
 }
 
+#[derive(Clone, Copy)]
+enum IssueLinkOutput {
+    Url,
+    Markdown,
+}
+
+fn decorate_issue_links(value: &mut Value, context: &IssueLinkContext, output: IssueLinkOutput) {
+    match value {
+        Value::Array(items) => items
+            .iter_mut()
+            .for_each(|item| decorate_issue_links(item, context, output)),
+        Value::Object(object) => {
+            if let Some(identifier) = object.get("identifier").and_then(Value::as_str)
+                && let Some(url) = context.issue_url(identifier)
+            {
+                match output {
+                    IssueLinkOutput::Url => {
+                        object.insert("web_url".into(), Value::String(url));
+                    }
+                    IssueLinkOutput::Markdown => {
+                        object.insert(
+                            "identifier".into(),
+                            Value::String(context.issue_markdown(identifier)),
+                        );
+                    }
+                }
+            }
+            object
+                .values_mut()
+                .for_each(|item| decorate_issue_links(item, context, output));
+        }
+        _ => {}
+    }
+}
+
 fn pretty(value: &Value) -> String {
     serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
 }
@@ -903,10 +947,11 @@ mod tests {
     };
 
     use super::{
-        ERROR_BODY_LIMIT, HttpBackend, IssueCreate, IssueUpdate, PageCreate, ProjectCreate,
-        error_detail, export_filename, find_resource, is_loopback_host, safe_filename,
-        sanitize_error_detail, segment,
+        ERROR_BODY_LIMIT, HttpBackend, IssueCreate, IssueLinkOutput, IssueUpdate, PageCreate,
+        ProjectCreate, decorate_issue_links, error_detail, export_filename, find_resource,
+        is_loopback_host, safe_filename, sanitize_error_detail, segment,
     };
+    use crate::links::IssueLinkContext;
 
     type CapturedRequest = Arc<Mutex<Option<(String, Option<String>)>>>;
 
@@ -965,10 +1010,9 @@ mod tests {
             .await,
         )
         .await;
-        let workspace_page = parse_json(
-            json_post(&app, "/api/pages", json!({"title": "Workspace page"})).await,
-        )
-        .await;
+        let workspace_page =
+            parse_json(json_post(&app, "/api/pages", json!({"title": "Workspace page"})).await)
+                .await;
         let issue = parse_json(
             json_post(
                 &app,
@@ -1255,9 +1299,11 @@ mod tests {
 
         let error = backend.get_json("/api/redirect", &[]).await.unwrap_err();
 
-        assert!(error
-            .to_string()
-            .starts_with("HTTP backend request failed (302 Found):"));
+        assert!(
+            error
+                .to_string()
+                .starts_with("HTTP backend request failed (302 Found):")
+        );
         assert!(captured.lock().await.is_none());
         server.abort();
     }
@@ -1285,7 +1331,10 @@ mod tests {
             std::fs::read_to_string(output_dir.join("report.txt")).unwrap(),
             "export contents"
         );
-        assert_eq!(output, json!([output_dir.join("report.txt").display().to_string()]));
+        assert_eq!(
+            output,
+            json!([output_dir.join("report.txt").display().to_string()])
+        );
         std::fs::remove_dir_all(output_dir).unwrap();
         server.abort();
     }
@@ -1601,5 +1650,27 @@ mod tests {
             error.to_string(),
             "the HTTP backend does not support this command yet"
         );
+    }
+
+    #[test]
+    fn decorates_http_issue_results_without_touching_page_identifiers() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+        let mut value = json!([
+            {"identifier": "LIF-42", "title": "Fix"},
+            {"identifier": "LIF-DOC-3", "title": "Page"}
+        ]);
+
+        decorate_issue_links(&mut value, &context, IssueLinkOutput::Url);
+        assert_eq!(
+            value[0]["web_url"],
+            "https://tracker.example/lific/LIF/issues/LIF-42"
+        );
+        assert!(value[1]["web_url"].is_null());
+        decorate_issue_links(&mut value, &context, IssueLinkOutput::Markdown);
+        assert_eq!(
+            value[0]["identifier"],
+            "[LIF-42](https://tracker.example/lific/LIF/issues/LIF-42)"
+        );
+        assert_eq!(value[1]["identifier"], "LIF-DOC-3");
     }
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -604,6 +604,8 @@ pub struct SearchResult {
     pub title: String,
     pub snippet: String,
     pub project_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_page_id: Option<i64>,
 }
 
 // ── Audit log (LIF-155/156) ──────────────────────────────────

--- a/src/db/queries/search.rs
+++ b/src/db/queries/search.rs
@@ -166,6 +166,7 @@ fn search_fts(
             title: row.get(2)?,
             snippet: row.get(3)?,
             project_id: row.get(4)?,
+            parent_page_id: cmt_page_id,
         })
     })?;
 
@@ -247,6 +248,7 @@ fn search_literal(
                     title,
                     snippet,
                     project_id,
+                    parent_page_id: None,
                 },
             ))
         })?;
@@ -286,6 +288,7 @@ fn search_literal(
                     title,
                     snippet,
                     project_id,
+                    parent_page_id: None,
                 },
             ))
         })?;
@@ -350,6 +353,7 @@ fn search_literal(
                     title: String::new(),
                     snippet,
                     project_id,
+                    parent_page_id: cmt_page_id,
                 },
             ))
         })?;
@@ -1023,6 +1027,7 @@ mod tests {
         assert_eq!(results[0].result_type, "comment");
         // A page comment links back to its parent page's DOC identifier.
         assert_eq!(results[0].identifier, Some("TST-DOC-1".into()));
+        assert_eq!(results[0].parent_page_id, Some(page.id));
     }
 
     #[test]

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,0 +1,151 @@
+use reqwest::Url;
+
+#[derive(Debug, Clone)]
+pub(crate) struct IssueLinkContext {
+    base_url: Url,
+}
+
+impl IssueLinkContext {
+    #[must_use]
+    pub(crate) fn parse(base_url: &str) -> Option<Self> {
+        let base_url = Url::parse(base_url).ok()?;
+        valid_base_url(&base_url).then_some(Self { base_url })
+    }
+
+    #[must_use]
+    pub(crate) fn for_http_request(
+        public_url: Option<&str>,
+        host_header: Option<&str>,
+        allowed_hosts: &[String],
+    ) -> Option<Self> {
+        match public_url {
+            Some(public_url) => Self::parse(public_url),
+            None => {
+                let host_header = host_header?.trim();
+                let authority = host_header.parse::<axum::http::uri::Authority>().ok()?;
+                if authority.as_str() != host_header {
+                    return None;
+                }
+                let host = authority
+                    .host()
+                    .trim_start_matches('[')
+                    .trim_end_matches(']');
+                allowed_hosts
+                    .iter()
+                    .any(|allowed| allowed.eq_ignore_ascii_case(host))
+                    .then(|| Self::parse(&format!("http://{host_header}")))
+                    .flatten()
+            }
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn issue_markdown(&self, identifier: &str) -> String {
+        self.issue_url(identifier).map_or_else(
+            || identifier.to_owned(),
+            |url| format!("[{identifier}]({url})"),
+        )
+    }
+
+    #[must_use]
+    pub(crate) fn issue_url(&self, identifier: &str) -> Option<String> {
+        let (project, sequence) = identifier.rsplit_once('-')?;
+        if !valid_issue_identifier(project, sequence) {
+            return None;
+        }
+        let mut url = self.base_url.clone();
+        url.path_segments_mut()
+            .ok()?
+            .push(project)
+            .push("issues")
+            .push(identifier);
+        Some(url.to_string())
+    }
+}
+
+fn valid_base_url(base_url: &Url) -> bool {
+    matches!(base_url.scheme(), "http" | "https")
+        && base_url.has_authority()
+        && base_url.username().is_empty()
+        && base_url.password().is_none()
+        && base_url.query().is_none()
+        && base_url.fragment().is_none()
+}
+
+fn valid_issue_identifier(project: &str, sequence: &str) -> bool {
+    project != "DOC"
+        && project.len() <= 5
+        && project
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_uppercase())
+        && project
+            .chars()
+            .skip(1)
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+        && !sequence.is_empty()
+        && sequence.chars().all(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IssueLinkContext;
+
+    #[test]
+    fn issue_markdown_preserves_base_path() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+
+        assert_eq!(
+            context.issue_markdown("LIF-42"),
+            "[LIF-42](https://tracker.example/lific/LIF/issues/LIF-42)"
+        );
+    }
+
+    #[test]
+    fn issue_markdown_keeps_malformed_identifiers_plain() {
+        let context = IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        for identifier in ["DOC-1", "lif-1", "LIF", "LIF-nope", "TOOLONG-1"] {
+            assert_eq!(context.issue_markdown(identifier), identifier);
+        }
+    }
+
+    #[test]
+    fn parse_rejects_ambiguous_or_credential_bearing_bases() {
+        for base_url in [
+            "file:///tmp/lific",
+            "https://user:password@tracker.example",
+            "https://tracker.example?tenant=one",
+            "https://tracker.example#fragment",
+        ] {
+            assert!(IssueLinkContext::parse(base_url).is_none(), "{base_url}");
+        }
+    }
+
+    #[test]
+    fn http_request_origin_prefers_public_url_and_falls_back_to_allowlisted_host() {
+        let allowed_hosts = vec!["localhost".into(), "tracker.example".into()];
+        let public = IssueLinkContext::for_http_request(
+            Some("https://tracker.example/lific"),
+            Some("localhost:3456"),
+            &allowed_hosts,
+        )
+        .unwrap();
+        assert_eq!(
+            public.issue_markdown("LIF-1"),
+            "[LIF-1](https://tracker.example/lific/LIF/issues/LIF-1)"
+        );
+
+        let direct =
+            IssueLinkContext::for_http_request(None, Some("localhost:3456"), &allowed_hosts)
+                .unwrap();
+        assert_eq!(
+            direct.issue_markdown("LIF-1"),
+            "[LIF-1](http://localhost:3456/LIF/issues/LIF-1)"
+        );
+        assert!(
+            IssueLinkContext::for_http_request(None, Some("spoofed.example"), &allowed_hosts,)
+                .is_none()
+        );
+    }
+}

--- a/src/links.rs
+++ b/src/links.rs
@@ -61,6 +61,130 @@ impl IssueLinkContext {
             .push(identifier);
         Some(url.to_string())
     }
+
+    #[must_use]
+    pub(crate) fn project_markdown(&self, identifier: &str) -> String {
+        self.project_url(identifier).map_or_else(
+            || identifier.to_owned(),
+            |url| format!("[{identifier}]({url})"),
+        )
+    }
+
+    #[must_use]
+    pub(crate) fn project_url(&self, identifier: &str) -> Option<String> {
+        valid_project_identifier(identifier).then(|| self.path_url([identifier, "overview"]))
+    }
+
+    #[must_use]
+    pub(crate) fn page_markdown(&self, identifier: &str, page_id: i64) -> String {
+        self.page_url(identifier, page_id).map_or_else(
+            || identifier.to_owned(),
+            |url| format!("[{identifier}]({url})"),
+        )
+    }
+
+    #[must_use]
+    pub(crate) fn page_url(&self, identifier: &str, page_id: i64) -> Option<String> {
+        let (project, sequence) = identifier.split_once("-DOC-")?;
+        (valid_project_identifier(project)
+            && sequence.chars().all(|c| c.is_ascii_digit())
+            && !sequence.is_empty()
+            && page_id > 0)
+            .then(|| self.path_url([project, "pages", &page_id.to_string()]))
+    }
+
+    #[must_use]
+    pub(crate) fn plan_markdown(&self, identifier: &str, plan_id: i64) -> String {
+        self.plan_url(identifier, plan_id).map_or_else(
+            || identifier.to_owned(),
+            |url| format!("[{identifier}]({url})"),
+        )
+    }
+
+    #[must_use]
+    pub(crate) fn plan_url(&self, identifier: &str, plan_id: i64) -> Option<String> {
+        let (project, suffix) = identifier.split_once("-PLAN-")?;
+        (valid_project_identifier(project)
+            && suffix.chars().all(|c| c.is_ascii_digit())
+            && !suffix.is_empty()
+            && plan_id > 0)
+            .then(|| self.path_url([project, "plans", &plan_id.to_string()]))
+    }
+
+    #[must_use]
+    pub(crate) fn module_markdown(&self, project: &str, module_id: i64, label: &str) -> String {
+        self.module_url(project, module_id).map_or_else(
+            || label.to_owned(),
+            |url| format!("[{label}]({url})"),
+        )
+    }
+
+    #[must_use]
+    pub(crate) fn module_url(&self, project: &str, module_id: i64) -> Option<String> {
+        (valid_project_identifier(project) && module_id > 0)
+            .then(|| self.path_url([project, "modules", &module_id.to_string()]))
+    }
+
+    #[must_use]
+    pub(crate) fn issue_comment_markdown(
+        &self,
+        identifier: &str,
+        comment_id: i64,
+    ) -> String {
+        self.issue_comment_url(identifier, comment_id).map_or_else(
+            || format!("comment #{comment_id}"),
+            |url| format!("[comment #{comment_id}]({url})"),
+        )
+    }
+
+    #[must_use]
+    pub(crate) fn issue_comment_url(&self, identifier: &str, comment_id: i64) -> Option<String> {
+        if comment_id <= 0 {
+            return None;
+        }
+        Some(format!(
+            "{}#comment-{comment_id}",
+            self.issue_url(identifier)?
+        ))
+    }
+
+    #[must_use]
+    pub(crate) fn page_comment_markdown(
+        &self,
+        identifier: &str,
+        page_id: i64,
+        comment_id: i64,
+    ) -> String {
+        self.page_comment_url(identifier, page_id, comment_id)
+            .map_or_else(
+                || format!("comment #{comment_id}"),
+                |url| format!("[comment #{comment_id}]({url})"),
+            )
+    }
+
+    #[must_use]
+    pub(crate) fn page_comment_url(
+        &self,
+        identifier: &str,
+        page_id: i64,
+        comment_id: i64,
+    ) -> Option<String> {
+        if comment_id <= 0 {
+            return None;
+        }
+        Some(format!(
+            "{}#comment-{comment_id}",
+            self.page_url(identifier, page_id)?
+        ))
+    }
+
+    fn path_url<const N: usize>(&self, segments: [&str; N]) -> String {
+        let mut url = self.base_url.clone();
+        if let Ok(mut path) = url.path_segments_mut() {
+            path.extend(segments);
+        }
+        url.to_string()
+    }
 }
 
 fn valid_base_url(base_url: &Url) -> bool {
@@ -74,7 +198,13 @@ fn valid_base_url(base_url: &Url) -> bool {
 
 fn valid_issue_identifier(project: &str, sequence: &str) -> bool {
     project != "DOC"
-        && project.len() <= 5
+        && valid_project_identifier(project)
+        && !sequence.is_empty()
+        && sequence.chars().all(|c| c.is_ascii_digit())
+}
+
+fn valid_project_identifier(project: &str) -> bool {
+    project.len() <= 5
         && project
             .chars()
             .next()
@@ -83,8 +213,6 @@ fn valid_issue_identifier(project: &str, sequence: &str) -> bool {
             .chars()
             .skip(1)
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
-        && !sequence.is_empty()
-        && sequence.chars().all(|c| c.is_ascii_digit())
 }
 
 #[cfg(test)]
@@ -108,6 +236,42 @@ mod tests {
         for identifier in ["DOC-1", "lif-1", "LIF", "LIF-nope", "TOOLONG-1"] {
             assert_eq!(context.issue_markdown(identifier), identifier);
         }
+    }
+
+    #[test]
+    fn resource_markdown_uses_detail_routes() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+
+        assert_eq!(
+            context.project_markdown("LIF"),
+            "[LIF](https://tracker.example/lific/LIF/overview)"
+        );
+        assert_eq!(
+            context.page_markdown("LIF-DOC-3", 17),
+            "[LIF-DOC-3](https://tracker.example/lific/LIF/pages/17)"
+        );
+        assert_eq!(
+            context.plan_markdown("LIF-PLAN-4", 19),
+            "[LIF-PLAN-4](https://tracker.example/lific/LIF/plans/19)"
+        );
+        assert_eq!(
+            context.module_markdown("LIF", 23, "Backend"),
+            "[Backend](https://tracker.example/lific/LIF/modules/23)"
+        );
+    }
+
+    #[test]
+    fn comment_markdown_points_at_comment_anchor() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+
+        assert_eq!(
+            context.issue_comment_markdown("LIF-42", 7),
+            "[comment #7](https://tracker.example/lific/LIF/issues/LIF-42#comment-7)"
+        );
+        assert_eq!(
+            context.page_comment_markdown("LIF-DOC-3", 17, 8),
+            "[comment #8](https://tracker.example/lific/LIF/pages/17#comment-8)"
+        );
     }
 
     #[test]

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,5 +1,29 @@
 use reqwest::Url;
 
+pub(crate) fn parse_http_authority(
+    host_header: &str,
+) -> Option<axum::http::uri::Authority> {
+    let host_header = host_header.trim();
+    let authority = host_header.parse::<axum::http::uri::Authority>().ok()?;
+    if authority.as_str() != host_header {
+        return None;
+    }
+    Some(authority)
+}
+
+pub(crate) fn authority_is_allowlisted(
+    authority: &axum::http::uri::Authority,
+    allowed_hosts: &[String],
+) -> bool {
+    let host = authority
+        .host()
+        .trim_start_matches('[')
+        .trim_end_matches(']');
+    allowed_hosts
+        .iter()
+        .any(|allowed| allowed.eq_ignore_ascii_case(host))
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct IssueLinkContext {
     base_url: Url,
@@ -21,20 +45,11 @@ impl IssueLinkContext {
         match public_url {
             Some(public_url) => Self::parse(public_url),
             None => {
-                let host_header = host_header?.trim();
-                let authority = host_header.parse::<axum::http::uri::Authority>().ok()?;
-                if authority.as_str() != host_header {
+                let authority = parse_http_authority(host_header?)?;
+                if !authority_is_allowlisted(&authority, allowed_hosts) {
                     return None;
                 }
-                let host = authority
-                    .host()
-                    .trim_start_matches('[')
-                    .trim_end_matches(']');
-                allowed_hosts
-                    .iter()
-                    .any(|allowed| allowed.eq_ignore_ascii_case(host))
-                    .then(|| Self::parse(&format!("http://{host_header}")))
-                    .flatten()
+                Self::parse(&format!("http://{authority}"))
             }
         }
     }
@@ -115,7 +130,7 @@ impl IssueLinkContext {
     pub(crate) fn module_markdown(&self, project: &str, module_id: i64, label: &str) -> String {
         self.module_url(project, module_id).map_or_else(
             || label.to_owned(),
-            |url| format!("[{label}]({url})"),
+            |url| format!("[{}]({url})", escape_markdown_link_label(label)),
         )
     }
 
@@ -196,6 +211,17 @@ fn valid_base_url(base_url: &Url) -> bool {
         && base_url.fragment().is_none()
 }
 
+fn escape_markdown_link_label(label: &str) -> String {
+    let mut escaped = String::with_capacity(label.len());
+    for character in label.chars() {
+        if matches!(character, '\\' | '[' | ']') {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
 fn valid_issue_identifier(project: &str, sequence: &str) -> bool {
     project != "DOC"
         && valid_project_identifier(project)
@@ -257,6 +283,16 @@ mod tests {
         assert_eq!(
             context.module_markdown("LIF", 23, "Backend"),
             "[Backend](https://tracker.example/lific/LIF/modules/23)"
+        );
+    }
+
+    #[test]
+    fn module_markdown_escapes_link_label_delimiters() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+
+        assert_eq!(
+            context.module_markdown("LIF", 23, r"API [v2]\stable"),
+            r"[API \[v2\]\\stable](https://tracker.example/lific/LIF/modules/23)"
         );
     }
 

--- a/src/links.rs
+++ b/src/links.rs
@@ -3,9 +3,11 @@ use reqwest::Url;
 pub(crate) fn parse_http_authority(
     host_header: &str,
 ) -> Option<axum::http::uri::Authority> {
-    let host_header = host_header.trim();
     let authority = host_header.parse::<axum::http::uri::Authority>().ok()?;
     if authority.as_str() != host_header {
+        return None;
+    }
+    if authority.as_str().contains('@') {
         return None;
     }
     Some(authority)
@@ -100,8 +102,11 @@ impl IssueLinkContext {
 
     #[must_use]
     pub(crate) fn page_url(&self, identifier: &str, page_id: i64) -> Option<String> {
-        let (project, sequence) = identifier.split_once("-DOC-")?;
-        (valid_project_identifier(project)
+        let (project, sequence) = identifier
+            .strip_prefix("DOC-")
+            .map(|sequence| ("DOC", sequence))
+            .or_else(|| identifier.split_once("-DOC-"))?;
+        ((project == "DOC" || valid_project_identifier(project))
             && sequence.chars().all(|c| c.is_ascii_digit())
             && !sequence.is_empty()
             && page_id > 0)
@@ -223,14 +228,14 @@ fn escape_markdown_link_label(label: &str) -> String {
 }
 
 fn valid_issue_identifier(project: &str, sequence: &str) -> bool {
-    project != "DOC"
-        && valid_project_identifier(project)
+    valid_project_identifier(project)
         && !sequence.is_empty()
         && sequence.chars().all(|c| c.is_ascii_digit())
 }
 
 fn valid_project_identifier(project: &str) -> bool {
-    project.len() <= 5
+    project != "DOC"
+        && project.len() <= 5
         && project
             .chars()
             .next()
@@ -277,12 +282,29 @@ mod tests {
             "[LIF-DOC-3](https://tracker.example/lific/LIF/pages/17)"
         );
         assert_eq!(
+            context.page_markdown("DOC-3", 18),
+            "[DOC-3](https://tracker.example/lific/DOC/pages/18)"
+        );
+        assert_eq!(
             context.plan_markdown("LIF-PLAN-4", 19),
             "[LIF-PLAN-4](https://tracker.example/lific/LIF/plans/19)"
         );
         assert_eq!(
             context.module_markdown("LIF", 23, "Backend"),
             "[Backend](https://tracker.example/lific/LIF/modules/23)"
+        );
+    }
+
+    #[test]
+    fn reserved_doc_identifier_only_links_workspace_pages() {
+        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
+
+        assert_eq!(context.project_markdown("DOC"), "DOC");
+        assert_eq!(context.plan_markdown("DOC-PLAN-1", 19), "DOC-PLAN-1");
+        assert_eq!(context.module_markdown("DOC", 23, "Backend"), "Backend");
+        assert_eq!(
+            context.page_markdown("DOC-3", 18),
+            "[DOC-3](https://tracker.example/lific/DOC/pages/18)"
         );
     }
 
@@ -307,6 +329,10 @@ mod tests {
         assert_eq!(
             context.page_comment_markdown("LIF-DOC-3", 17, 8),
             "[comment #8](https://tracker.example/lific/LIF/pages/17#comment-8)"
+        );
+        assert_eq!(
+            context.page_comment_markdown("DOC-3", 18, 9),
+            "[comment #9](https://tracker.example/lific/DOC/pages/18#comment-9)"
         );
     }
 
@@ -346,6 +372,18 @@ mod tests {
         assert!(
             IssueLinkContext::for_http_request(None, Some("spoofed.example"), &allowed_hosts,)
                 .is_none()
+        );
+        assert!(
+            IssueLinkContext::for_http_request(None, Some(" localhost:3456 "), &allowed_hosts,)
+                .is_none()
+        );
+        assert!(
+            IssueLinkContext::for_http_request(
+                None,
+                Some("evil.example@localhost:3456"),
+                &allowed_hosts,
+            )
+            .is_none()
         );
     }
 }

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,8 +1,8 @@
+use std::fmt::{self, Display, Formatter};
+
 use reqwest::Url;
 
-pub(crate) fn parse_http_authority(
-    host_header: &str,
-) -> Option<axum::http::uri::Authority> {
+pub(crate) fn parse_http_authority(host_header: &str) -> Option<axum::http::uri::Authority> {
     let authority = host_header.parse::<axum::http::uri::Authority>().ok()?;
     if authority.as_str() != host_header {
         return None;
@@ -31,6 +31,119 @@ pub(crate) struct IssueLinkContext {
     base_url: Url,
 }
 
+#[derive(Clone, Copy)]
+enum ResourcePath<'a> {
+    Issue {
+        project: &'a str,
+        identifier: &'a str,
+    },
+    Project(&'a str),
+    Page {
+        project: &'a str,
+        id: i64,
+    },
+    Plan {
+        project: &'a str,
+        id: i64,
+    },
+    Module {
+        project: &'a str,
+        id: i64,
+    },
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ResourceUrl<'a> {
+    base_url: &'a str,
+    path: ResourcePath<'a>,
+    comment_id: Option<i64>,
+}
+
+impl Display for ResourceUrl<'_> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.base_url)?;
+        if !self.base_url.ends_with('/') {
+            formatter.write_str("/")?;
+        }
+        match self.path {
+            ResourcePath::Issue {
+                project,
+                identifier,
+            } => write!(formatter, "{project}/issues/{identifier}")?,
+            ResourcePath::Project(project) => write!(formatter, "{project}/overview")?,
+            ResourcePath::Page { project, id } => write!(formatter, "{project}/pages/{id}")?,
+            ResourcePath::Plan { project, id } => write!(formatter, "{project}/plans/{id}")?,
+            ResourcePath::Module { project, id } => write!(formatter, "{project}/modules/{id}")?,
+        }
+        if let Some(comment_id) = self.comment_id {
+            write!(formatter, "#comment-{comment_id}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum LinkLabel<'a> {
+    Text(&'a str),
+    Escaped(&'a str),
+    Comment(i64),
+}
+
+impl LinkLabel<'_> {
+    fn fmt(self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Text(label) => formatter.write_str(label),
+            Self::Escaped(label) => {
+                for character in label.chars() {
+                    if matches!(character, '\\' | '[' | ']') {
+                        formatter.write_str("\\")?;
+                    }
+                    write!(formatter, "{character}")?;
+                }
+                Ok(())
+            }
+            Self::Comment(comment_id) => write!(formatter, "comment #{comment_id}"),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct MarkdownReference<'a> {
+    label: LinkLabel<'a>,
+    url: Option<ResourceUrl<'a>>,
+}
+
+impl<'a> MarkdownReference<'a> {
+    pub(crate) fn plain(label: &'a str) -> Self {
+        Self {
+            label: LinkLabel::Text(label),
+            url: None,
+        }
+    }
+
+    pub(crate) fn linked(label: &'a str, url: ResourceUrl<'a>) -> Self {
+        Self {
+            label: LinkLabel::Text(label),
+            url: Some(url),
+        }
+    }
+}
+
+impl Display for MarkdownReference<'_> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        if let Some(url) = self.url {
+            formatter.write_str("[")?;
+            self.label.fmt(formatter)?;
+            write!(formatter, "]({url})")
+        } else {
+            match self.label {
+                LinkLabel::Escaped(label) => formatter.write_str(label),
+                label => label.fmt(formatter),
+            }
+        }
+    }
+}
+
 impl IssueLinkContext {
     #[must_use]
     pub(crate) fn parse(base_url: &str) -> Option<Self> {
@@ -57,153 +170,186 @@ impl IssueLinkContext {
     }
 
     #[must_use]
-    pub(crate) fn issue_markdown(&self, identifier: &str) -> String {
-        self.issue_url(identifier).map_or_else(
-            || identifier.to_owned(),
-            |url| format!("[{identifier}]({url})"),
-        )
+    pub(crate) fn issue_markdown<'a>(&'a self, identifier: &'a str) -> MarkdownReference<'a> {
+        MarkdownReference {
+            label: LinkLabel::Text(identifier),
+            url: self.issue_url(identifier),
+        }
     }
 
     #[must_use]
-    pub(crate) fn issue_url(&self, identifier: &str) -> Option<String> {
+    pub(crate) fn issue_url<'a>(&'a self, identifier: &'a str) -> Option<ResourceUrl<'a>> {
         let (project, sequence) = identifier.rsplit_once('-')?;
         if !valid_issue_identifier(project, sequence) {
             return None;
         }
-        let mut url = self.base_url.clone();
-        url.path_segments_mut()
-            .ok()?
-            .push(project)
-            .push("issues")
-            .push(identifier);
-        Some(url.to_string())
+        Some(self.url(ResourcePath::Issue {
+            project,
+            identifier,
+        }))
     }
 
     #[must_use]
-    pub(crate) fn project_markdown(&self, identifier: &str) -> String {
-        self.project_url(identifier).map_or_else(
-            || identifier.to_owned(),
-            |url| format!("[{identifier}]({url})"),
-        )
+    pub(crate) fn project_markdown<'a>(&'a self, identifier: &'a str) -> MarkdownReference<'a> {
+        MarkdownReference {
+            label: LinkLabel::Text(identifier),
+            url: self.project_url(identifier),
+        }
     }
 
     #[must_use]
-    pub(crate) fn project_url(&self, identifier: &str) -> Option<String> {
-        valid_project_identifier(identifier).then(|| self.path_url([identifier, "overview"]))
+    pub(crate) fn project_url<'a>(&'a self, identifier: &'a str) -> Option<ResourceUrl<'a>> {
+        valid_project_identifier(identifier).then(|| self.url(ResourcePath::Project(identifier)))
     }
 
     #[must_use]
-    pub(crate) fn page_markdown(&self, identifier: &str, page_id: i64) -> String {
-        self.page_url(identifier, page_id).map_or_else(
-            || identifier.to_owned(),
-            |url| format!("[{identifier}]({url})"),
-        )
+    pub(crate) fn page_markdown<'a>(
+        &'a self,
+        identifier: &'a str,
+        page_id: i64,
+    ) -> MarkdownReference<'a> {
+        MarkdownReference {
+            label: LinkLabel::Text(identifier),
+            url: self.page_url(identifier, page_id),
+        }
     }
 
     #[must_use]
-    pub(crate) fn page_url(&self, identifier: &str, page_id: i64) -> Option<String> {
-        let (project, sequence) = identifier
-            .strip_prefix("DOC-")
-            .map(|sequence| ("DOC", sequence))
-            .or_else(|| identifier.split_once("-DOC-"))?;
-        ((project == "DOC" || valid_project_identifier(project))
-            && sequence.chars().all(|c| c.is_ascii_digit())
-            && !sequence.is_empty()
-            && page_id > 0)
-            .then(|| self.path_url([project, "pages", &page_id.to_string()]))
+    pub(crate) fn page_url<'a>(
+        &'a self,
+        identifier: &'a str,
+        page_id: i64,
+    ) -> Option<ResourceUrl<'a>> {
+        let project = valid_page_identifier(identifier)?;
+        (page_id > 0).then(|| {
+            self.url(ResourcePath::Page {
+                project,
+                id: page_id,
+            })
+        })
     }
 
     #[must_use]
-    pub(crate) fn plan_markdown(&self, identifier: &str, plan_id: i64) -> String {
-        self.plan_url(identifier, plan_id).map_or_else(
-            || identifier.to_owned(),
-            |url| format!("[{identifier}]({url})"),
-        )
+    pub(crate) fn plan_markdown<'a>(
+        &'a self,
+        identifier: &'a str,
+        plan_id: i64,
+    ) -> MarkdownReference<'a> {
+        MarkdownReference {
+            label: LinkLabel::Text(identifier),
+            url: self.plan_url(identifier, plan_id),
+        }
     }
 
     #[must_use]
-    pub(crate) fn plan_url(&self, identifier: &str, plan_id: i64) -> Option<String> {
+    pub(crate) fn plan_url<'a>(
+        &'a self,
+        identifier: &'a str,
+        plan_id: i64,
+    ) -> Option<ResourceUrl<'a>> {
         let (project, suffix) = identifier.split_once("-PLAN-")?;
         (valid_project_identifier(project)
             && suffix.chars().all(|c| c.is_ascii_digit())
             && !suffix.is_empty()
             && plan_id > 0)
-            .then(|| self.path_url([project, "plans", &plan_id.to_string()]))
+            .then(|| {
+                self.url(ResourcePath::Plan {
+                    project,
+                    id: plan_id,
+                })
+            })
     }
 
     #[must_use]
-    pub(crate) fn module_markdown(&self, project: &str, module_id: i64, label: &str) -> String {
-        self.module_url(project, module_id).map_or_else(
-            || label.to_owned(),
-            |url| format!("[{}]({url})", escape_markdown_link_label(label)),
-        )
-    }
-
-    #[must_use]
-    pub(crate) fn module_url(&self, project: &str, module_id: i64) -> Option<String> {
-        (valid_project_identifier(project) && module_id > 0)
-            .then(|| self.path_url([project, "modules", &module_id.to_string()]))
-    }
-
-    #[must_use]
-    pub(crate) fn issue_comment_markdown(
-        &self,
-        identifier: &str,
-        comment_id: i64,
-    ) -> String {
-        self.issue_comment_url(identifier, comment_id).map_or_else(
-            || format!("comment #{comment_id}"),
-            |url| format!("[comment #{comment_id}]({url})"),
-        )
-    }
-
-    #[must_use]
-    pub(crate) fn issue_comment_url(&self, identifier: &str, comment_id: i64) -> Option<String> {
-        if comment_id <= 0 {
-            return None;
+    pub(crate) fn module_markdown<'a>(
+        &'a self,
+        project: &'a str,
+        module_id: i64,
+        label: &'a str,
+    ) -> MarkdownReference<'a> {
+        MarkdownReference {
+            label: LinkLabel::Escaped(label),
+            url: self.module_url(project, module_id),
         }
-        Some(format!(
-            "{}#comment-{comment_id}",
-            self.issue_url(identifier)?
-        ))
     }
 
     #[must_use]
-    pub(crate) fn page_comment_markdown(
-        &self,
-        identifier: &str,
+    pub(crate) fn module_url<'a>(
+        &'a self,
+        project: &'a str,
+        module_id: i64,
+    ) -> Option<ResourceUrl<'a>> {
+        (valid_project_identifier(project) && module_id > 0).then(|| {
+            self.url(ResourcePath::Module {
+                project,
+                id: module_id,
+            })
+        })
+    }
+
+    #[must_use]
+    pub(crate) fn issue_comment_markdown<'a>(
+        &'a self,
+        identifier: &'a str,
+        comment_id: i64,
+    ) -> MarkdownReference<'a> {
+        MarkdownReference {
+            label: LinkLabel::Comment(comment_id),
+            url: self.issue_comment_url(identifier, comment_id),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn issue_comment_url<'a>(
+        &'a self,
+        identifier: &'a str,
+        comment_id: i64,
+    ) -> Option<ResourceUrl<'a>> {
+        (comment_id > 0)
+            .then(|| self.issue_url(identifier))
+            .flatten()
+            .map(|url| url.with_comment(comment_id))
+    }
+
+    #[must_use]
+    pub(crate) fn page_comment_markdown<'a>(
+        &'a self,
+        identifier: &'a str,
         page_id: i64,
         comment_id: i64,
-    ) -> String {
-        self.page_comment_url(identifier, page_id, comment_id)
-            .map_or_else(
-                || format!("comment #{comment_id}"),
-                |url| format!("[comment #{comment_id}]({url})"),
-            )
+    ) -> MarkdownReference<'a> {
+        MarkdownReference {
+            label: LinkLabel::Comment(comment_id),
+            url: self.page_comment_url(identifier, page_id, comment_id),
+        }
     }
 
     #[must_use]
-    pub(crate) fn page_comment_url(
-        &self,
-        identifier: &str,
+    pub(crate) fn page_comment_url<'a>(
+        &'a self,
+        identifier: &'a str,
         page_id: i64,
         comment_id: i64,
-    ) -> Option<String> {
-        if comment_id <= 0 {
-            return None;
-        }
-        Some(format!(
-            "{}#comment-{comment_id}",
-            self.page_url(identifier, page_id)?
-        ))
+    ) -> Option<ResourceUrl<'a>> {
+        (comment_id > 0)
+            .then(|| self.page_url(identifier, page_id))
+            .flatten()
+            .map(|url| url.with_comment(comment_id))
     }
 
-    fn path_url<const N: usize>(&self, segments: [&str; N]) -> String {
-        let mut url = self.base_url.clone();
-        if let Ok(mut path) = url.path_segments_mut() {
-            path.extend(segments);
+    fn url<'a>(&'a self, path: ResourcePath<'a>) -> ResourceUrl<'a> {
+        ResourceUrl {
+            base_url: self.base_url.as_str(),
+            path,
+            comment_id: None,
         }
-        url.to_string()
+    }
+}
+
+impl ResourceUrl<'_> {
+    fn with_comment(mut self, comment_id: i64) -> Self {
+        self.comment_id = Some(comment_id);
+        self
     }
 }
 
@@ -216,21 +362,21 @@ fn valid_base_url(base_url: &Url) -> bool {
         && base_url.fragment().is_none()
 }
 
-fn escape_markdown_link_label(label: &str) -> String {
-    let mut escaped = String::with_capacity(label.len());
-    for character in label.chars() {
-        if matches!(character, '\\' | '[' | ']') {
-            escaped.push('\\');
-        }
-        escaped.push(character);
-    }
-    escaped
-}
-
 fn valid_issue_identifier(project: &str, sequence: &str) -> bool {
     valid_project_identifier(project)
         && !sequence.is_empty()
         && sequence.chars().all(|c| c.is_ascii_digit())
+}
+
+fn valid_page_identifier(identifier: &str) -> Option<&str> {
+    let (project, sequence) = identifier
+        .strip_prefix("DOC-")
+        .map(|sequence| ("DOC", sequence))
+        .or_else(|| identifier.split_once("-DOC-"))?;
+    ((project == "DOC" || valid_project_identifier(project))
+        && !sequence.is_empty()
+        && sequence.chars().all(|c| c.is_ascii_digit()))
+    .then_some(project)
 }
 
 fn valid_project_identifier(project: &str) -> bool {
@@ -252,12 +398,16 @@ mod tests {
 
     #[test]
     fn issue_markdown_preserves_base_path() {
-        let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
-
-        assert_eq!(
-            context.issue_markdown("LIF-42"),
-            "[LIF-42](https://tracker.example/lific/LIF/issues/LIF-42)"
-        );
+        for base_url in [
+            "https://tracker.example/lific",
+            "https://tracker.example/lific/",
+        ] {
+            let context = IssueLinkContext::parse(base_url).unwrap();
+            assert_eq!(
+                context.issue_markdown("LIF-42").to_string(),
+                "[LIF-42](https://tracker.example/lific/LIF/issues/LIF-42)"
+            );
+        }
     }
 
     #[test]
@@ -265,7 +415,7 @@ mod tests {
         let context = IssueLinkContext::parse("https://tracker.example").unwrap();
 
         for identifier in ["DOC-1", "lif-1", "LIF", "LIF-nope", "TOOLONG-1"] {
-            assert_eq!(context.issue_markdown(identifier), identifier);
+            assert_eq!(context.issue_markdown(identifier).to_string(), identifier);
         }
     }
 
@@ -274,23 +424,23 @@ mod tests {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
 
         assert_eq!(
-            context.project_markdown("LIF"),
+            context.project_markdown("LIF").to_string(),
             "[LIF](https://tracker.example/lific/LIF/overview)"
         );
         assert_eq!(
-            context.page_markdown("LIF-DOC-3", 17),
+            context.page_markdown("LIF-DOC-3", 17).to_string(),
             "[LIF-DOC-3](https://tracker.example/lific/LIF/pages/17)"
         );
         assert_eq!(
-            context.page_markdown("DOC-3", 18),
+            context.page_markdown("DOC-3", 18).to_string(),
             "[DOC-3](https://tracker.example/lific/DOC/pages/18)"
         );
         assert_eq!(
-            context.plan_markdown("LIF-PLAN-4", 19),
+            context.plan_markdown("LIF-PLAN-4", 19).to_string(),
             "[LIF-PLAN-4](https://tracker.example/lific/LIF/plans/19)"
         );
         assert_eq!(
-            context.module_markdown("LIF", 23, "Backend"),
+            context.module_markdown("LIF", 23, "Backend").to_string(),
             "[Backend](https://tracker.example/lific/LIF/modules/23)"
         );
     }
@@ -299,11 +449,17 @@ mod tests {
     fn reserved_doc_identifier_only_links_workspace_pages() {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
 
-        assert_eq!(context.project_markdown("DOC"), "DOC");
-        assert_eq!(context.plan_markdown("DOC-PLAN-1", 19), "DOC-PLAN-1");
-        assert_eq!(context.module_markdown("DOC", 23, "Backend"), "Backend");
+        assert_eq!(context.project_markdown("DOC").to_string(), "DOC");
         assert_eq!(
-            context.page_markdown("DOC-3", 18),
+            context.plan_markdown("DOC-PLAN-1", 19).to_string(),
+            "DOC-PLAN-1"
+        );
+        assert_eq!(
+            context.module_markdown("DOC", 23, "Backend").to_string(),
+            "Backend"
+        );
+        assert_eq!(
+            context.page_markdown("DOC-3", 18).to_string(),
             "[DOC-3](https://tracker.example/lific/DOC/pages/18)"
         );
     }
@@ -313,7 +469,9 @@ mod tests {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
 
         assert_eq!(
-            context.module_markdown("LIF", 23, r"API [v2]\stable"),
+            context
+                .module_markdown("LIF", 23, r"API [v2]\stable")
+                .to_string(),
             r"[API \[v2\]\\stable](https://tracker.example/lific/LIF/modules/23)"
         );
     }
@@ -323,15 +481,17 @@ mod tests {
         let context = IssueLinkContext::parse("https://tracker.example/lific").unwrap();
 
         assert_eq!(
-            context.issue_comment_markdown("LIF-42", 7),
+            context.issue_comment_markdown("LIF-42", 7).to_string(),
             "[comment #7](https://tracker.example/lific/LIF/issues/LIF-42#comment-7)"
         );
         assert_eq!(
-            context.page_comment_markdown("LIF-DOC-3", 17, 8),
+            context
+                .page_comment_markdown("LIF-DOC-3", 17, 8)
+                .to_string(),
             "[comment #8](https://tracker.example/lific/LIF/pages/17#comment-8)"
         );
         assert_eq!(
-            context.page_comment_markdown("DOC-3", 18, 9),
+            context.page_comment_markdown("DOC-3", 18, 9).to_string(),
             "[comment #9](https://tracker.example/lific/DOC/pages/18#comment-9)"
         );
     }
@@ -358,7 +518,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            public.issue_markdown("LIF-1"),
+            public.issue_markdown("LIF-1").to_string(),
             "[LIF-1](https://tracker.example/lific/LIF/issues/LIF-1)"
         );
 
@@ -366,7 +526,7 @@ mod tests {
             IssueLinkContext::for_http_request(None, Some("localhost:3456"), &allowed_hosts)
                 .unwrap();
         assert_eq!(
-            direct.issue_markdown("LIF-1"),
+            direct.issue_markdown("LIF-1").to_string(),
             "[LIF-1](http://localhost:3456/LIF/issues/LIF-1)"
         );
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod dump;
 mod error;
 mod export;
 mod import;
+mod links;
 mod mcp;
 mod oauth;
 mod ratelimit;
@@ -979,6 +980,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             storage::start_gc_task(pool.clone(), attachment_store.clone());
 
             // Routes behind auth: REST API + MCP
+            let mcp_public_url = cfg.server.public_url.clone();
+            let mcp_allowed_hosts_for_links = mcp_allowed_hosts.clone();
             let authed_routes = api::router(pool.clone(), &cfg.server.cors_origins)
                 .route(
                     "/mcp",
@@ -1001,7 +1004,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             .get::<auth::OperatorCredential>()
                             .is_some();
 
-                        mcp::with_request_identity(auth_user, is_operator, || async {
+                        let issue_links = links::IssueLinkContext::for_http_request(
+                            mcp_public_url.as_deref(),
+                            request
+                                .headers()
+                                .get(header::HOST)
+                                .and_then(|value| value.to_str().ok()),
+                            &mcp_allowed_hosts_for_links,
+                        );
+
+                        mcp::with_request_context(auth_user, is_operator, issue_links, || async {
                             mcp_service.handle(request).await.into_response()
                         })
                         .await
@@ -1083,6 +1095,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         &token,
                         authless_user,
                         mcp_allowed_hosts.clone(),
+                        cfg.server.public_url.clone(),
                         realtime.clone(),
                     )
                 });
@@ -1814,8 +1827,10 @@ fn build_authless_mcp_router(
     token: &str,
     user: Option<db::models::AuthUser>,
     allowed_hosts: Vec<String>,
+    public_url: Option<String>,
     realtime: realtime::RealtimeHub,
 ) -> Router {
+    let allowed_hosts_for_links = allowed_hosts.clone();
     let config = StreamableHttpServerConfig::default()
         .with_stateful_mode(false)
         .with_json_response(true)
@@ -1833,7 +1848,15 @@ fn build_authless_mcp_router(
     Router::new().route(
         &format!("/mcp/{token}"),
         any(move |request: Request<Body>| async move {
-            mcp::with_request_user(user, || async {
+            let issue_links = links::IssueLinkContext::for_http_request(
+                public_url.as_deref(),
+                request
+                    .headers()
+                    .get(header::HOST)
+                    .and_then(|value| value.to_str().ok()),
+                &allowed_hosts_for_links,
+            );
+            mcp::with_request_context(user, false, issue_links, || async {
                 service.handle(request).await.into_response()
             })
             .await
@@ -2223,6 +2246,7 @@ mod authless_mcp_tests {
             token,
             None,
             vec!["localhost".into()],
+            None,
             realtime::RealtimeHub::new(),
         );
 
@@ -2259,6 +2283,7 @@ mod authless_mcp_tests {
             "the-right-token",
             None,
             vec!["localhost".into()],
+            None,
             realtime::RealtimeHub::new(),
         );
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -58,7 +58,7 @@ thread_local! {
 /// the handler so every DB write a tool performs is attributed to this
 /// user via MCP — both the OAuth /mcp route and the authless /mcp/<token>
 /// route funnel through here.
-#[cfg(test)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub async fn with_request_user<F, Fut, R>(user: Option<AuthUser>, f: F) -> R
 where
     F: FnOnce() -> Fut,
@@ -73,7 +73,7 @@ where
 /// OAuth/session tokens), so `authz` can treat it as admin-equivalent in
 /// enforced mode. `with_request_user` keeps the old signature (operator =
 /// false) for every non-unbound-key caller.
-#[cfg(test)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub async fn with_request_identity<F, Fut, R>(user: Option<AuthUser>, is_operator: bool, f: F) -> R
 where
     F: FnOnce() -> Fut,
@@ -460,10 +460,17 @@ mod tests {
     #[tokio::test]
     async fn with_request_context_scopes_issue_link_origin() {
         let context = IssueLinkContext::parse("https://tracker.example/base");
-        let seen = with_request_context(None, false, context, || async {
-            current_issue_link_context()
+        let (seen, global_seen) = with_request_context(None, false, context, || async {
+            let scoped = current_issue_link_context()
                 .expect("request origin should be visible")
-                .issue_markdown("LIF-1")
+                .issue_markdown("LIF-1");
+            let global = MCP_REQUEST_ISSUE_LINKS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+                .expect("production request context should also be populated")
+                .issue_markdown("LIF-1");
+            (scoped, global)
         })
         .await;
 
@@ -471,7 +478,14 @@ mod tests {
             seen,
             "[LIF-1](https://tracker.example/base/LIF/issues/LIF-1)"
         );
+        assert_eq!(global_seen, seen);
         assert!(current_issue_link_context().is_none());
+        assert!(
+            MCP_REQUEST_ISSUE_LINKS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_none()
+        );
     }
 
     // End-to-end: an operator-trusted unbound API key aimed at /mcp passes an

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod schemas;
 pub(crate) mod tools;
 
+#[cfg(test)]
+use std::cell::Cell;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -12,6 +14,7 @@ use rmcp::{
 
 use crate::db::DbPool;
 use crate::db::models::AuthUser;
+use crate::links::IssueLinkContext;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 /// Serialization lock for MCP request handling.
@@ -34,6 +37,20 @@ static MCP_REQUEST_USER: Mutex<Option<AuthUser>> = Mutex::new(None);
 /// (which also resolves to `AuthUser = None`).
 static MCP_REQUEST_OPERATOR: Mutex<bool> = Mutex::new(false);
 
+/// Per-request external origin used for structured issue links.
+/// Protected by [`MCP_HANDLER_LOCK`] for the same reason as the identity state.
+static MCP_REQUEST_ISSUE_LINKS: Mutex<Option<IssueLinkContext>> = Mutex::new(None);
+
+#[cfg(test)]
+tokio::task_local! {
+    static TEST_REQUEST_ISSUE_LINKS: Option<IssueLinkContext>;
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_ISSUE_LINK_CONTEXT_READS: Cell<usize> = const { Cell::new(0) };
+}
+
 /// Acquire the MCP handler lock, set the user, run the provided future,
 /// then clean up. Guarantees no identity confusion between concurrent requests.
 ///
@@ -41,12 +58,13 @@ static MCP_REQUEST_OPERATOR: Mutex<bool> = Mutex::new(false);
 /// the handler so every DB write a tool performs is attributed to this
 /// user via MCP — both the OAuth /mcp route and the authless /mcp/<token>
 /// route funnel through here.
+#[cfg(test)]
 pub async fn with_request_user<F, Fut, R>(user: Option<AuthUser>, f: F) -> R
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = R>,
 {
-    with_request_identity(user, false, f).await
+    with_request_context(user, false, None, f).await
 }
 
 /// LIF-261: like [`with_request_user`] but also records whether the request's
@@ -55,7 +73,24 @@ where
 /// OAuth/session tokens), so `authz` can treat it as admin-equivalent in
 /// enforced mode. `with_request_user` keeps the old signature (operator =
 /// false) for every non-unbound-key caller.
+#[cfg(test)]
 pub async fn with_request_identity<F, Fut, R>(user: Option<AuthUser>, is_operator: bool, f: F) -> R
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = R>,
+{
+    with_request_context(user, is_operator, None, f).await
+}
+
+/// Run an MCP request with its authenticated identity and optional external
+/// origin. The origin is transport metadata: stdio callers pass `None`, while
+/// HTTP callers pass the validated browser-facing base URL.
+pub async fn with_request_context<F, Fut, R>(
+    user: Option<AuthUser>,
+    is_operator: bool,
+    issue_links: Option<IssueLinkContext>,
+    f: F,
+) -> R
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = R>,
@@ -71,6 +106,9 @@ where
     *MCP_REQUEST_OPERATOR
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = is_operator;
+    *MCP_REQUEST_ISSUE_LINKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = issue_links;
     let result = crate::actor::scope(actor, f()).await;
     *MCP_REQUEST_USER
         .lock()
@@ -78,6 +116,9 @@ where
     *MCP_REQUEST_OPERATOR
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = false;
+    *MCP_REQUEST_ISSUE_LINKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     result
 }
 
@@ -95,6 +136,33 @@ pub(crate) fn current_is_operator() -> bool {
     *MCP_REQUEST_OPERATOR
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Get the validated external origin for structured issue links, if this MCP
+/// request arrived through an HTTP transport that knows it.
+pub(crate) fn current_issue_link_context() -> Option<IssueLinkContext> {
+    #[cfg(test)]
+    {
+        TEST_ISSUE_LINK_CONTEXT_READS.set(TEST_ISSUE_LINK_CONTEXT_READS.get() + 1);
+        TEST_REQUEST_ISSUE_LINKS
+            .try_with(Clone::clone)
+            .unwrap_or(None)
+    }
+    #[cfg(not(test))]
+    MCP_REQUEST_ISSUE_LINKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
+#[cfg(test)]
+pub(crate) fn reset_issue_link_context_reads() {
+    TEST_ISSUE_LINK_CONTEXT_READS.set(0);
+}
+
+#[cfg(test)]
+pub(crate) fn issue_link_context_reads() -> usize {
+    TEST_ISSUE_LINK_CONTEXT_READS.get()
 }
 
 /// Per-session instructions handed to every connected MCP agent via
@@ -380,6 +448,23 @@ mod tests {
             !seen,
             "with_request_user (non-unbound-key callers) must never set the operator flag"
         );
+    }
+
+    #[tokio::test]
+    async fn with_request_context_scopes_issue_link_origin() {
+        let context = IssueLinkContext::parse("https://tracker.example/base");
+        let seen = with_request_context(None, false, context, || async {
+            current_issue_link_context()
+                .expect("request origin should be visible")
+                .issue_markdown("LIF-1")
+        })
+        .await;
+
+        assert_eq!(
+            seen,
+            "[LIF-1](https://tracker.example/base/LIF/issues/LIF-1)"
+        );
+        assert!(current_issue_link_context().is_none());
     }
 
     // End-to-end: an operator-trusted unbound API key aimed at /mcp passes an

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -39,11 +39,11 @@ static MCP_REQUEST_OPERATOR: Mutex<bool> = Mutex::new(false);
 
 /// Per-request external origin used for structured resource links.
 /// Protected by [`MCP_HANDLER_LOCK`] for the same reason as the identity state.
-static MCP_REQUEST_ISSUE_LINKS: Mutex<Option<IssueLinkContext>> = Mutex::new(None);
+static MCP_REQUEST_ISSUE_LINKS: Mutex<Option<Arc<IssueLinkContext>>> = Mutex::new(None);
 
 #[cfg(test)]
 tokio::task_local! {
-    static TEST_REQUEST_ISSUE_LINKS: Option<IssueLinkContext>;
+    static TEST_REQUEST_ISSUE_LINKS: Option<Arc<IssueLinkContext>>;
 }
 
 #[cfg(test)]
@@ -96,6 +96,7 @@ where
     Fut: std::future::Future<Output = R>,
 {
     let _guard = MCP_HANDLER_LOCK.lock().await;
+    let issue_links = issue_links.map(Arc::new);
     #[cfg(test)]
     let test_issue_links = issue_links.clone();
     let actor = crate::actor::ActorCtx {
@@ -147,7 +148,7 @@ pub(crate) fn current_is_operator() -> bool {
 
 /// Get the validated external origin for structured resource links, if this MCP
 /// request arrived through an HTTP transport that knows it.
-pub(crate) fn current_issue_link_context() -> Option<IssueLinkContext> {
+pub(crate) fn current_issue_link_context() -> Option<Arc<IssueLinkContext>> {
     #[cfg(test)]
     {
         TEST_ISSUE_LINK_CONTEXT_READS.set(TEST_ISSUE_LINK_CONTEXT_READS.get() + 1);
@@ -463,13 +464,15 @@ mod tests {
         let (seen, global_seen) = with_request_context(None, false, context, || async {
             let scoped = current_issue_link_context()
                 .expect("request origin should be visible")
-                .issue_markdown("LIF-1");
+                .issue_markdown("LIF-1")
+                .to_string();
             let global = MCP_REQUEST_ISSUE_LINKS
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .clone()
                 .expect("production request context should also be populated")
-                .issue_markdown("LIF-1");
+                .issue_markdown("LIF-1")
+                .to_string();
             (scoped, global)
         })
         .await;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -37,7 +37,7 @@ static MCP_REQUEST_USER: Mutex<Option<AuthUser>> = Mutex::new(None);
 /// (which also resolves to `AuthUser = None`).
 static MCP_REQUEST_OPERATOR: Mutex<bool> = Mutex::new(false);
 
-/// Per-request external origin used for structured issue links.
+/// Per-request external origin used for structured resource links.
 /// Protected by [`MCP_HANDLER_LOCK`] for the same reason as the identity state.
 static MCP_REQUEST_ISSUE_LINKS: Mutex<Option<IssueLinkContext>> = Mutex::new(None);
 
@@ -96,6 +96,8 @@ where
     Fut: std::future::Future<Output = R>,
 {
     let _guard = MCP_HANDLER_LOCK.lock().await;
+    #[cfg(test)]
+    let test_issue_links = issue_links.clone();
     let actor = crate::actor::ActorCtx {
         user_id: user.as_ref().map(|u| u.id),
         transport: crate::actor::Transport::Mcp,
@@ -109,6 +111,11 @@ where
     *MCP_REQUEST_ISSUE_LINKS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = issue_links;
+    #[cfg(test)]
+    let result = TEST_REQUEST_ISSUE_LINKS
+        .scope(test_issue_links, crate::actor::scope(actor, f()))
+        .await;
+    #[cfg(not(test))]
     let result = crate::actor::scope(actor, f()).await;
     *MCP_REQUEST_USER
         .lock()
@@ -138,7 +145,7 @@ pub(crate) fn current_is_operator() -> bool {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
-/// Get the validated external origin for structured issue links, if this MCP
+/// Get the validated external origin for structured resource links, if this MCP
 /// request arrived through an HTTP transport that knows it.
 pub(crate) fn current_issue_link_context() -> Option<IssueLinkContext> {
     #[cfg(test)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -5,8 +5,8 @@ use rmcp::{handler::server::wrapper::Parameters, tool, tool_router};
 
 use crate::db::{DbPool, models, queries};
 
-use super::LificMcp;
 use super::schemas::*;
+use super::{LificMcp, current_issue_link_context};
 
 /// Self-onboarding nudge (LIF-257): shown by cold read tools when the DB has
 /// **zero** projects, so the first agent connecting to a fresh install learns
@@ -22,26 +22,86 @@ impl LificMcp {
 }
 
 pub(crate) fn fmt_issue(i: &models::Issue) -> String {
+    let context = current_issue_link_context();
+    fmt_issue_with_context(i, context.as_ref())
+}
+
+fn fmt_issue_with_context(i: &models::Issue, context: Option<&IssueLinkContext>) -> String {
     let mut s = format!(
         "{} | {} | {} | {}",
-        i.identifier, i.status, i.priority, i.title
+        issue_reference_with_context(context, &i.identifier),
+        i.status,
+        i.priority,
+        i.title
     );
     if !i.labels.is_empty() {
         s.push_str(&format!(" [{}]", i.labels.join(", ")));
     }
     if !i.blocks.is_empty() {
-        s.push_str(&format!(" blocks:{}", i.blocks.join(",")));
+        s.push_str(&format!(
+            " blocks:{}",
+            i.blocks
+                .iter()
+                .map(|identifier| issue_reference_with_context(context, identifier))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
     }
     if !i.blocked_by.is_empty() {
-        s.push_str(&format!(" blocked_by:{}", i.blocked_by.join(",")));
+        s.push_str(&format!(
+            " blocked_by:{}",
+            i.blocked_by
+                .iter()
+                .map(|identifier| issue_reference_with_context(context, identifier))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
     }
     if !i.duplicates.is_empty() {
-        s.push_str(&format!(" duplicates:{}", i.duplicates.join(",")));
+        s.push_str(&format!(
+            " duplicates:{}",
+            i.duplicates
+                .iter()
+                .map(|identifier| issue_reference_with_context(context, identifier))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
     }
     if !i.duplicated_by.is_empty() {
-        s.push_str(&format!(" duplicated_by:{}", i.duplicated_by.join(",")));
+        s.push_str(&format!(
+            " duplicated_by:{}",
+            i.duplicated_by
+                .iter()
+                .map(|identifier| issue_reference_with_context(context, identifier))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
     }
     s
+}
+
+fn issue_reference(identifier: &str) -> String {
+    let context = current_issue_link_context();
+    issue_reference_with_context(context.as_ref(), identifier)
+}
+
+fn issue_reference_with_context(context: Option<&IssueLinkContext>, identifier: &str) -> String {
+    context.map_or_else(
+        || identifier.to_owned(),
+        |context| context.issue_markdown(identifier),
+    )
+}
+
+fn issue_reference_with_suffix(value: &str) -> String {
+    let Some((identifier, suffix)) = value.split_once(' ') else {
+        return issue_reference(value);
+    };
+    let rendered = issue_reference(identifier);
+    if rendered == identifier {
+        value.to_owned()
+    } else {
+        format!("{rendered} {suffix}")
+    }
 }
 
 /// Render a plan + its step tree compactly for get_plan / create_plan output.
@@ -51,7 +111,7 @@ pub(crate) fn fmt_plan(p: &models::Plan) -> String {
     let anchor = p
         .anchor_identifier
         .as_ref()
-        .map(|a| format!(" — anchor {a}"))
+        .map(|a| format!(" — anchor {}", issue_reference(a)))
         .unwrap_or_default();
     let mut out = format!(
         "{} [{}] {}{} — {}/{} done\n",
@@ -215,12 +275,14 @@ fn fmt_steps(nodes: &[models::PlanStepNode], depth: usize, out: &mut String) {
         let check = if n.done { "x" } else { " " };
         // Provenance suffix for issue-linked steps.
         let suffix = match (&n.issue_identifier, n.issue_status.as_deref()) {
-            (Some(iss), Some("done")) if n.done => format!(" (via {iss})"),
-            (Some(iss), _) if n.reopened_via_issue_at.is_some() && !n.done => {
-                format!(" (reopened — {iss} reopened)")
+            (Some(iss), Some("done")) if n.done => {
+                format!(" (via {})", issue_reference(iss))
             }
-            (Some(iss), Some(st)) => format!(" [{iss}: {st}]"),
-            (Some(iss), None) => format!(" [{iss}]"),
+            (Some(iss), _) if n.reopened_via_issue_at.is_some() && !n.done => {
+                format!(" (reopened — {} reopened)", issue_reference(iss))
+            }
+            (Some(iss), Some(st)) => format!(" [{}: {st}]", issue_reference(iss)),
+            (Some(iss), None) => format!(" [{}]", issue_reference(iss)),
             _ => String::new(),
         };
         out.push_str(&format!(
@@ -391,7 +453,12 @@ fn fmt_activity(a: &models::Activity) -> String {
         _ => "system".into(),
     };
     let agent = if a.actor_is_bot { " (agent)" } else { "" };
-    let label = a.entity_label.as_deref().unwrap_or("?");
+    let raw_label = a.entity_label.as_deref().unwrap_or("?");
+    let label = if a.entity_type == "issue" {
+        issue_reference(raw_label)
+    } else {
+        raw_label.to_owned()
+    };
 
     let detail = match a.action.as_str() {
         "create" => format!(
@@ -419,13 +486,13 @@ fn fmt_activity(a: &models::Activity) -> String {
             "{} {} → {}",
             label,
             a.field.as_deref().unwrap_or("relates_to"),
-            a.new_value.as_deref().unwrap_or("?")
+            issue_reference(a.new_value.as_deref().unwrap_or("?"))
         ),
         "unlink" => format!(
             "{} un-{} → {}",
             label,
             a.field.as_deref().unwrap_or("relates_to"),
-            a.old_value.as_deref().unwrap_or("?")
+            issue_reference(a.old_value.as_deref().unwrap_or("?"))
         ),
         other => format!("{label} {other}"),
     };
@@ -676,11 +743,22 @@ impl LificMcp {
                     // match on its parent so the reader knows to open the
                     // parent issue/page to find the thread (LIF-146).
                     if r.result_type == "comment" {
-                        out.push_str(&format!("- [comment] on {ident} — {}\n", r.snippet));
+                        out.push_str(&format!(
+                            "- [comment] on {} — {}\n",
+                            issue_reference(ident),
+                            r.snippet
+                        ));
                     } else {
                         out.push_str(&format!(
                             "- [{}] {} {} — {}\n",
-                            r.result_type, ident, r.title, r.snippet
+                            r.result_type,
+                            if r.result_type == "issue" {
+                                issue_reference(ident)
+                            } else {
+                                ident.to_owned()
+                            },
+                            r.title,
+                            r.snippet
                         ));
                     }
                 }
@@ -751,10 +829,14 @@ impl LificMcp {
             .read(|conn| queries::activity::list_activity(conn, scope, Some(limit), Some(offset)))
         {
             Ok(feed) if feed.items.is_empty() && offset == 0 => {
-                format!("No recorded activity for {ident} yet.")
+                format!("No recorded activity for {} yet.", issue_reference(ident))
             }
             Ok(feed) => {
-                let mut out = format!("{} activity entries for {ident}:\n", feed.items.len());
+                let mut out = format!(
+                    "{} activity entries for {}:\n",
+                    feed.items.len(),
+                    issue_reference(ident)
+                );
                 for a in &feed.items {
                     out.push_str(&format!("- {}\n", fmt_activity(a)));
                 }
@@ -817,9 +899,13 @@ impl LificMcp {
                 if has_more {
                     issues.truncate(limit as usize);
                 }
+                let context = current_issue_link_context();
                 let mut out = format!("{} issues:\n", issues.len());
                 for i in &issues {
-                    out.push_str(&format!("- {}\n", fmt_issue(i)));
+                    out.push_str(&format!(
+                        "- {}\n",
+                        fmt_issue_with_context(i, context.as_ref())
+                    ));
                 }
                 append_pagination_hint(&mut out, has_more, offset + limit);
                 out
@@ -879,27 +965,63 @@ impl LificMcp {
                 }
                 let mut out = format!(
                     "{} — {}\nStatus: {} | Priority: {} | Module: {}\n",
-                    issue.identifier, issue.title, issue.status, issue.priority, module_name
+                    issue_reference(&issue.identifier),
+                    issue.title,
+                    issue.status,
+                    issue.priority,
+                    module_name
                 );
                 if !issue.labels.is_empty() {
                     out.push_str(&format!("Labels: {}\n", issue.labels.join(", ")));
                 }
                 if !rels.blocks.is_empty() {
-                    out.push_str(&format!("Blocks: {}\n", rels.blocks.join(", ")));
+                    out.push_str(&format!(
+                        "Blocks: {}\n",
+                        rels.blocks
+                            .iter()
+                            .map(|r| issue_reference_with_suffix(r))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
                 }
                 if !rels.blocked_by.is_empty() {
-                    out.push_str(&format!("Blocked by: {}\n", rels.blocked_by.join(", ")));
+                    out.push_str(&format!(
+                        "Blocked by: {}\n",
+                        rels.blocked_by
+                            .iter()
+                            .map(|r| issue_reference_with_suffix(r))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
                 }
                 if !rels.relates_to.is_empty() {
-                    out.push_str(&format!("Relates to: {}\n", rels.relates_to.join(", ")));
+                    out.push_str(&format!(
+                        "Relates to: {}\n",
+                        rels.relates_to
+                            .iter()
+                            .map(|r| issue_reference_with_suffix(r))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
                 }
                 if !rels.duplicates.is_empty() {
-                    out.push_str(&format!("Duplicates: {}\n", rels.duplicates.join(", ")));
+                    out.push_str(&format!(
+                        "Duplicates: {}\n",
+                        rels.duplicates
+                            .iter()
+                            .map(|r| issue_reference_with_suffix(r))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
                 }
                 if !rels.duplicated_by.is_empty() {
                     out.push_str(&format!(
                         "Duplicated by: {}\n",
-                        rels.duplicated_by.join(", ")
+                        rels.duplicated_by
+                            .iter()
+                            .map(|r| issue_reference_with_suffix(r))
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     ));
                 }
                 if !issue.description.is_empty() {
@@ -1060,7 +1182,11 @@ impl LificMcp {
                     project_id: issue.project_id,
                     issue_id: issue.id,
                 });
-                format!("Created {}: {}", issue.identifier, issue.title)
+                format!(
+                    "Created {}: {}",
+                    issue_reference(&issue.identifier),
+                    issue.title
+                )
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1142,7 +1268,11 @@ impl LificMcp {
                     project_id: issue.project_id,
                     issue_id: issue.id,
                 });
-                let mut output = format!("Updated {}: {}", issue.identifier, fmt_issue(&issue));
+                let mut output = format!(
+                    "Updated {}: {}",
+                    issue_reference(&issue.identifier),
+                    fmt_issue(&issue)
+                );
                 if let Some(note) = cascade_action
                     .and_then(|action| fmt_issue_plan_step_cascade(action, &cascaded_steps))
                 {
@@ -1303,7 +1433,11 @@ impl LificMcp {
                     project_id: issue.project_id,
                     issue_id: issue.id,
                 });
-                format!("Edited {}: {}", issue.identifier, fmt_issue(&issue))
+                format!(
+                    "Edited {}: {}",
+                    issue_reference(&issue.identifier),
+                    fmt_issue(&issue)
+                )
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1408,6 +1542,7 @@ impl LificMcp {
                         "warning: board view capped at {BOARD_CAP} issues — older issues are not shown. Use list_issues with offset for full paging.\n\n"
                     ));
                 }
+                let context = current_issue_link_context();
                 let max_per_column = input.max_per_column.filter(|n| *n >= 0);
                 for (group, items) in ordered {
                     // Status grouping keeps closed groups as count-only stubs:
@@ -1431,7 +1566,10 @@ impl LificMcp {
                         None => items.len(),
                     };
                     for i in &items[..shown] {
-                        out.push_str(&format!("  {}\n", fmt_issue(i)));
+                        out.push_str(&format!(
+                            "  {}\n",
+                            fmt_issue_with_context(i, context.as_ref())
+                        ));
                     }
                     if shown < items.len() {
                         out.push_str(&format!(
@@ -1485,7 +1623,12 @@ impl LificMcp {
                     project_id: target.project_id,
                     issue_id: target.id,
                 });
-                format!("{} {} {}", input.source, input.relation_type, input.target)
+                format!(
+                    "{} {} {}",
+                    issue_reference(&input.source),
+                    input.relation_type,
+                    issue_reference(&input.target)
+                )
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1520,7 +1663,11 @@ impl LificMcp {
                     project_id: target.project_id,
                     issue_id: target.id,
                 });
-                format!("Unlinked {} and {}", input.source, input.target)
+                format!(
+                    "Unlinked {} and {}",
+                    issue_reference(&input.source),
+                    issue_reference(&input.target)
+                )
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1758,7 +1905,7 @@ impl LificMcp {
                             project_id: issue.project_id,
                             issue_id: issue.id,
                         });
-                        format!("Deleted issue {}", input.identifier)
+                        format!("Deleted issue {}", issue_reference(&input.identifier))
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -1915,7 +2062,7 @@ impl LificMcp {
                             let anchor = p
                                 .anchor_identifier
                                 .as_ref()
-                                .map(|a| format!(" — anchor {a}"))
+                                .map(|a| format!(" — anchor {}", issue_reference(a)))
                                 .unwrap_or_default();
                             out.push_str(&format!(
                                 "- {} | {} | {} ({}/{} done){}\n",
@@ -2002,7 +2149,9 @@ impl LificMcp {
                         for i in &issues {
                             out.push_str(&format!(
                                 "- {} | {} | {}\n",
-                                i.identifier, i.status, i.title
+                                issue_reference(&i.identifier),
+                                i.status,
+                                i.title
                             ));
                         }
                         append_pagination_hint(&mut out, has_more, offset + limit);
@@ -2574,7 +2723,10 @@ impl LificMcp {
                 }
                 format!(
                     "Comment #{} added to {} by {} at {}",
-                    c.id, input.identifier, c.author, c.created_at
+                    c.id,
+                    issue_reference(&input.identifier),
+                    c.author,
+                    c.created_at
                 )
             }
             Err(e) => format!("Error: {e}"),
@@ -2611,11 +2763,11 @@ impl LificMcp {
         }) {
             Ok((comments, total)) if comments.is_empty() => {
                 if total == 0 {
-                    format!("No comments on {}.", input.identifier)
+                    format!("No comments on {}.", issue_reference(&input.identifier))
                 } else {
                     format!(
                         "No comments in this range on {} (offset {offset}, {total} total).",
-                        input.identifier
+                        issue_reference(&input.identifier)
                     )
                 }
             }
@@ -2634,18 +2786,21 @@ impl LificMcp {
                     };
                     format!(
                         "Showing {shown} {edge} of {total} comment(s) on {}:\n",
-                        input.identifier
+                        issue_reference(&input.identifier)
                     )
                 } else if offset > 0 {
                     format!(
                         "Showing comments {}-{} of {total} on {} ({} first):\n",
                         offset + 1,
                         offset + shown,
-                        input.identifier,
+                        issue_reference(&input.identifier),
                         if order == "desc" { "newest" } else { "oldest" }
                     )
                 } else {
-                    format!("{total} comment(s) on {}:\n", input.identifier)
+                    format!(
+                        "{total} comment(s) on {}:\n",
+                        issue_reference(&input.identifier)
+                    )
                 };
                 for c in &comments {
                     out.push_str(&format!(
@@ -2724,9 +2879,7 @@ impl LificMcp {
         }
     }
 
-    #[tool(
-        description = "Delete a comment by id. Author or admin only."
-    )]
+    #[tool(description = "Delete a comment by id. Author or admin only.")]
     fn delete_comment(&self, Parameters(input): Parameters<DeleteCommentInput>) -> String {
         // Resolve the acting user the same way add_comment does.
         let (user_id, is_admin) = match self.resolve_comment_actor() {
@@ -2953,7 +3106,10 @@ impl LificMcp {
                         if let Some(ref ident) = input.attach_issue {
                             let iid = queries::resolve_identifier(conn, ident)?;
                             queries::plans::set_step_issue(conn, step_id, Some(iid))?;
-                            notes.push(format!("Attached {ident} to step #{step_id}"));
+                            notes.push(format!(
+                                "Attached {} to step #{step_id}",
+                                issue_reference(ident)
+                            ));
                         }
                         if input.detach_issue.unwrap_or(false) {
                             queries::plans::set_step_issue(conn, step_id, None)?;
@@ -2973,9 +3129,15 @@ impl LificMcp {
                                         project_id: issue.project_id,
                                         issue_id: issue.id,
                                     });
-                                    msg.push_str(&format!(" → {iss} marked done"));
+                                    msg.push_str(&format!(
+                                        " → {} marked done",
+                                        issue_reference(iss)
+                                    ));
                                 } else if done {
-                                    msg.push_str(&format!(" (linked {iss} already done)"));
+                                    msg.push_str(&format!(
+                                        " (linked {} already done)",
+                                        issue_reference(iss)
+                                    ));
                                 }
                             }
                             notes.push(msg);
@@ -3810,6 +3972,23 @@ mod tests {
         }));
         assert!(result.contains("1 issues"), "got: {result}");
         assert!(result.contains("Todo one"), "got: {result}");
+    }
+
+    #[test]
+    fn list_issues_reads_link_context_once() {
+        let m = mcp();
+        seed_project(&m, "Context", "CTX");
+        seed_issue(&m, "CTX", "First");
+        seed_issue(&m, "CTX", "Second");
+        crate::mcp::reset_issue_link_context_reads();
+
+        let result = m.list_issues(Parameters(ListIssuesInput {
+            project: "CTX".into(),
+            ..Default::default()
+        }));
+
+        assert!(result.contains("2 issues"), "got: {result}");
+        assert_eq!(crate::mcp::issue_link_context_reads(), 1);
     }
 
     #[test]
@@ -4793,7 +4972,7 @@ mod tests {
     // ── fmt_issue ──
 
     #[test]
-    fn fmt_issue_includes_relations() {
+    fn fmt_issue_formats_relations_with_one_context_read() {
         let issue = models::Issue {
             id: 1,
             project_id: 1,
@@ -4817,11 +4996,13 @@ mod tests {
             duplicates: vec!["T-3".into()],
             duplicated_by: vec!["T-4".into()],
         };
+        crate::mcp::reset_issue_link_context_reads();
         let s = fmt_issue(&issue);
         assert!(s.contains("[bug]"), "got: {s}");
         assert!(s.contains("blocks:T-2"), "got: {s}");
         assert!(s.contains("duplicates:T-3"), "got: {s}");
         assert!(s.contains("duplicated_by:T-4"), "got: {s}");
+        assert_eq!(crate::mcp::issue_link_context_reads(), 1);
     }
 
     // ── comments ──

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -473,32 +473,68 @@ fn looks_like_page_identifier(s: &str) -> bool {
 fn resolve_comment_parent(
     mcp: &LificMcp,
     identifier: &str,
-) -> Result<queries::comments::CommentParent, String> {
+) -> Result<
+    (
+        queries::comments::CommentParent,
+        String,
+        Option<i64>,
+    ),
+    String,
+> {
     if looks_like_page_identifier(identifier) {
         let conn = mcp.db.read().map_err(|e| e.to_string())?;
         let id = queries::resolve_page_identifier(&conn, identifier).map_err(|e| e.to_string())?;
-        Ok(queries::comments::CommentParent::Page(id))
+        let page = queries::get_page(&conn, id).map_err(|e| e.to_string())?;
+        Ok((
+            queries::comments::CommentParent::Page(page.id),
+            page.identifier,
+            page.project_id,
+        ))
     } else {
         let conn = mcp.db.read().map_err(|e| e.to_string())?;
         let id = queries::resolve_identifier(&conn, identifier).map_err(|e| e.to_string())?;
-        Ok(queries::comments::CommentParent::Issue(id))
+        let issue = queries::get_issue(&conn, id).map_err(|e| e.to_string())?;
+        Ok((
+            queries::comments::CommentParent::Issue(issue.id),
+            issue.identifier,
+            Some(issue.project_id),
+        ))
     }
 }
 
-/// LIF-143: resolve the project a comment belongs to, via its issue or page
-/// parent. Mirrors `api::comments::resolve_comment_project` — a page comment
-/// may have a NULL project (workspace page), which `mention_candidates`
-/// handles.
-fn resolve_comment_project(
+/// Resolve an existing comment's canonical parent and project in one read.
+/// A page comment may have a NULL project (workspace page), which
+/// `mention_candidates` handles.
+fn resolve_comment_context(
     conn: &rusqlite::Connection,
     comment: &models::Comment,
-) -> Result<Option<i64>, crate::error::LificError> {
+) -> Result<
+    (
+        Option<i64>,
+        queries::comments::CommentParent,
+        String,
+    ),
+    crate::error::LificError,
+> {
     if let Some(issue_id) = comment.issue_id {
-        Ok(Some(queries::get_issue(conn, issue_id)?.project_id))
+        let issue = queries::get_issue(conn, issue_id)?;
+        Ok((
+            Some(issue.project_id),
+            queries::comments::CommentParent::Issue(issue.id),
+            issue.identifier,
+        ))
     } else if let Some(page_id) = comment.page_id {
-        Ok(queries::get_page(conn, page_id)?.project_id)
+        let page = queries::get_page(conn, page_id)?;
+        Ok((
+            page.project_id,
+            queries::comments::CommentParent::Page(page.id),
+            page.identifier,
+        ))
     } else {
-        Ok(None)
+        Err(crate::error::LificError::Internal(format!(
+            "comment {} has no parent",
+            comment.id
+        )))
     }
 }
 
@@ -526,19 +562,50 @@ fn truncate_value(v: &str, max: usize) -> String {
 
 /// Render one audit entry as a compact line:
 /// `[ts] actor via transport — LABEL action detail`
-fn fmt_activity(a: &models::Activity) -> String {
+fn activity_reference(a: &models::Activity, project: Option<&str>) -> String {
+    let label = a.entity_label.as_deref().unwrap_or("?");
+    let Some(context) = current_issue_link_context() else {
+        return label.to_owned();
+    };
+
+    if a.action == "delete" {
+        return match a.entity_type.as_str() {
+            "comment" if a.issue_id.is_some() => context.issue_markdown(label),
+            "comment" => a
+                .page_id
+                .map_or_else(|| label.to_owned(), |id| context.page_markdown(label, id)),
+            _ => label.to_owned(),
+        };
+    }
+
+    match a.entity_type.as_str() {
+        "issue" => context.issue_markdown(label),
+        "project" => context.project_markdown(label),
+        "page" => context.page_markdown(label, a.entity_id),
+        "plan" => context.plan_markdown(label, a.entity_id),
+        "module" => project.map_or_else(
+            || label.to_owned(),
+            |project| context.module_markdown(project, a.entity_id, label),
+        ),
+        "comment" if a.issue_id.is_some() => {
+            context.issue_comment_markdown(label, a.entity_id)
+        }
+        "comment" => a.page_id.map_or_else(
+            || label.to_owned(),
+            |page_id| context.page_comment_markdown(label, page_id, a.entity_id),
+        ),
+        _ => label.to_owned(),
+    }
+}
+
+fn fmt_activity(a: &models::Activity, project: Option<&str>) -> String {
     let who = match (&a.actor_display_name, &a.actor_username) {
         (Some(d), _) if !d.is_empty() => d.clone(),
         (_, Some(u)) => u.clone(),
         _ => "system".into(),
     };
     let agent = if a.actor_is_bot { " (agent)" } else { "" };
-    let raw_label = a.entity_label.as_deref().unwrap_or("?");
-    let label = if a.entity_type == "issue" {
-        issue_reference(raw_label)
-    } else {
-        raw_label.to_owned()
-    };
+    let label = activity_reference(a, project);
 
     let detail = match a.action.as_str() {
         "create" => format!(
@@ -843,14 +910,14 @@ impl LificMcp {
                             },
                         );
                         let comment = current_issue_link_context().map_or_else(
-                            || "comment".to_owned(),
+                            || "[comment]".to_owned(),
                             |context| page_id.map_or_else(
                                 || context.issue_comment_markdown(ident, r.id),
                                 |page_id| context.page_comment_markdown(ident, page_id, r.id),
                             ),
                         );
                         out.push_str(&format!(
-                            "- [{}] on {} — {}\n",
+                            "- {} on {} — {}\n",
                             comment, parent, r.snippet
                         ));
                     } else {
@@ -894,16 +961,54 @@ impl LificMcp {
         // Resolve the identifier shape: page → issue → project. Pages are
         // unambiguous (DOC segment); issue resolution requires a numeric
         // tail, so a bare project identifier falls through cleanly.
-        let scope = if looks_like_page_identifier(ident) {
-            match self.read(|conn| queries::resolve_page_identifier(conn, ident)) {
-                Ok(id) => queries::activity::ActivityScope::Page(id),
+        let (scope, project_id, scope_reference, project_identifier) =
+            if looks_like_page_identifier(ident) {
+            match self.read(|conn| {
+                let id = queries::resolve_page_identifier(conn, ident)?;
+                queries::get_page(conn, id)
+            }) {
+                Ok(page) => {
+                    let project_identifier = page
+                        .identifier
+                        .split_once("-DOC-")
+                        .map(|(project, _)| project.to_owned());
+                    (
+                        queries::activity::ActivityScope::Page(page.id),
+                        page.project_id,
+                        page_reference(&page),
+                        project_identifier,
+                    )
+                }
                 Err(e) => return format!("Error: {e}"),
             }
-        } else if let Ok(id) = self.read(|conn| queries::resolve_identifier(conn, ident)) {
-            queries::activity::ActivityScope::Issue(id)
+        } else if let Ok(issue) = self.read(|conn| {
+            let id = queries::resolve_identifier(conn, ident)?;
+            queries::get_issue(conn, id)
+        }) {
+            let project_identifier = issue
+                .identifier
+                .rsplit_once('-')
+                .map(|(project, _)| project.to_owned());
+            (
+                queries::activity::ActivityScope::Issue(issue.id),
+                Some(issue.project_id),
+                issue_reference(&issue.identifier),
+                project_identifier,
+            )
         } else {
-            match self.read(|conn| queries::resolve_project_identifier(conn, ident)) {
-                Ok(id) => queries::activity::ActivityScope::Project(id),
+            match self.read(|conn| {
+                let id = queries::resolve_project_identifier(conn, ident)?;
+                queries::get_project(conn, id)
+            }) {
+                Ok(project) => {
+                    let project_identifier = project.identifier.clone();
+                    (
+                        queries::activity::ActivityScope::Project(project.id),
+                        Some(project.id),
+                        project_reference(&project.identifier),
+                        Some(project_identifier),
+                    )
+                }
                 Err(_) => {
                     return format!(
                         "Error: '{ident}' is not a known issue, page, or project identifier"
@@ -914,27 +1019,6 @@ impl LificMcp {
 
         // LIF-198: resolve the scope's project (Viewer gate); workspace
         // pages (project_id None) fall back to admin-only.
-        let project_id: Option<i64> = match scope {
-            queries::activity::ActivityScope::Issue(id) => {
-                match self.read(|conn| queries::get_issue(conn, id)) {
-                    Ok(issue) => Some(issue.project_id),
-                    Err(e) => return format!("Error: {e}"),
-                }
-            }
-            queries::activity::ActivityScope::Page(id) => {
-                match self.read(|conn| queries::get_page(conn, id)) {
-                    Ok(page) => page.project_id,
-                    Err(e) => return format!("Error: {e}"),
-                }
-            }
-            queries::activity::ActivityScope::Plan(id) => {
-                match self.read(|conn| queries::plans::get_plan(conn, id)) {
-                    Ok(plan) => Some(plan.project_id),
-                    Err(e) => return format!("Error: {e}"),
-                }
-            }
-            queries::activity::ActivityScope::Project(id) => Some(id),
-        };
         if let Err(e) = require_page_role_mcp(&self.db, project_id, models::Role::Viewer) {
             return format!("Error: {e}");
         }
@@ -943,16 +1027,19 @@ impl LificMcp {
             .read(|conn| queries::activity::list_activity(conn, scope, Some(limit), Some(offset)))
         {
             Ok(feed) if feed.items.is_empty() && offset == 0 => {
-                format!("No recorded activity for {} yet.", issue_reference(ident))
+                format!("No recorded activity for {scope_reference} yet.")
             }
             Ok(feed) => {
                 let mut out = format!(
                     "{} activity entries for {}:\n",
                     feed.items.len(),
-                    issue_reference(ident)
+                    scope_reference
                 );
                 for a in &feed.items {
-                    out.push_str(&format!("- {}\n", fmt_activity(a)));
+                    out.push_str(&format!(
+                        "- {}\n",
+                        fmt_activity(a, project_identifier.as_deref())
+                    ));
                 }
                 append_pagination_hint(&mut out, feed.has_more, offset + limit);
                 out
@@ -1769,9 +1856,9 @@ impl LificMcp {
                 });
                 format!(
                     "{} {} {}",
-                    issue_reference(&input.source),
+                    issue_reference(&source.identifier),
                     input.relation_type,
-                    issue_reference(&input.target)
+                    issue_reference(&target.identifier)
                 )
             }
             Err(e) => format!("Error: {e}"),
@@ -1809,8 +1896,8 @@ impl LificMcp {
                 });
                 format!(
                     "Unlinked {} and {}",
-                    issue_reference(&input.source),
-                    issue_reference(&input.target)
+                    issue_reference(&source.identifier),
+                    issue_reference(&target.identifier)
                 )
             }
             Err(e) => format!("Error: {e}"),
@@ -2049,65 +2136,55 @@ impl LificMcp {
                             project_id: issue.project_id,
                             issue_id: issue.id,
                         });
-                        format!("Deleted issue {}", issue_reference(&input.identifier))
+                        format!("Deleted issue {}", issue.identifier)
                     }
                     Err(e) => format!("Error: {e}"),
                 }
             }
             "plan" => {
-                let (id, project_id) = match self.read(|conn| {
+                let plan = match self.read(|conn| {
                     let id = queries::plans::resolve_plan_identifier(conn, &input.identifier)?;
-                    let project_id = queries::plans::get_plan(conn, id)?.project_id;
-                    Ok((id, project_id))
-                }) {
-                    Ok(v) => v,
-                    Err(e) => return format!("Error: {e}"),
-                };
-                if let Err(e) = require_role_mcp(&self.db, project_id, models::Role::Maintainer) {
-                    return format!("Error: {e}");
-                }
-                match self.write(|conn| queries::plans::delete_plan(conn, id)) {
-                    Ok(()) => {
-                        self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
-                        format!(
-                            "Deleted plan {}",
-                            current_issue_link_context().map_or_else(
-                                || input.identifier.clone(),
-                                |context| context.plan_markdown(&input.identifier, id),
-                            )
-                        )
-                    }
-                    Err(e) => format!("Error: {e}"),
-                }
-            }
-            "page" => {
-                let (id, project_id) = match self.read(|conn| {
-                    let id = queries::resolve_page_identifier(conn, &input.identifier)?;
-                    let project_id = queries::get_page(conn, id)?.project_id;
-                    Ok((id, project_id))
+                    queries::plans::get_plan(conn, id)
                 }) {
                     Ok(v) => v,
                     Err(e) => return format!("Error: {e}"),
                 };
                 if let Err(e) =
-                    require_page_role_mcp(&self.db, project_id, models::Role::Maintainer)
+                    require_role_mcp(&self.db, plan.project_id, models::Role::Maintainer)
                 {
                     return format!("Error: {e}");
                 }
-                match self.write(|conn| queries::delete_page(conn, id)) {
+                match self.write(|conn| queries::plans::delete_plan(conn, plan.id)) {
                     Ok(()) => {
-                        if let Some(project_id) = project_id {
+                        self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
+                            project_id: plan.project_id,
+                        });
+                        format!("Deleted plan {}", plan.identifier)
+                    }
+                    Err(e) => format!("Error: {e}"),
+                }
+            }
+            "page" => {
+                let page = match self.read(|conn| {
+                    let id = queries::resolve_page_identifier(conn, &input.identifier)?;
+                    queries::get_page(conn, id)
+                }) {
+                    Ok(v) => v,
+                    Err(e) => return format!("Error: {e}"),
+                };
+                if let Err(e) =
+                    require_page_role_mcp(&self.db, page.project_id, models::Role::Maintainer)
+                {
+                    return format!("Error: {e}");
+                }
+                match self.write(|conn| queries::delete_page(conn, page.id)) {
+                    Ok(()) => {
+                        if let Some(project_id) = page.project_id {
                             self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                                 project_id,
                             });
                         }
-                        format!(
-                            "Deleted page {}",
-                            current_issue_link_context().map_or_else(
-                                || input.identifier.clone(),
-                                |context| context.page_markdown(&input.identifier, id),
-                            )
-                        )
+                        format!("Deleted page {}", page.identifier)
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2131,7 +2208,7 @@ impl LificMcp {
                             Some(user_ids) => self.realtime.send_to_users(event, user_ids),
                             None => self.emit(event),
                         }
-                        format!("Deleted project {}", project_reference(&input.identifier))
+                        format!("Deleted project {}", project.identifier)
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2153,24 +2230,28 @@ impl LificMcp {
                 let result = match input.resource_type.as_str() {
                     "module" => self.write(|conn| {
                         let id = queries::resolve_module_name(conn, pid, &input.identifier)?;
-                        queries::delete_module(conn, id)
+                        let module = queries::get_module(conn, id)?;
+                        queries::delete_module(conn, id)?;
+                        Ok(module.name)
                     }),
                     "label" => self.write(|conn| {
                         let id = queries::resolve_label_name(conn, pid, &input.identifier)?;
-                        queries::delete_label(conn, id)
+                        queries::delete_label(conn, id)?;
+                        Ok(format!("'{}'", input.identifier))
                     }),
                     "folder" => self.write(|conn| {
                         let id = queries::resolve_folder_name(conn, pid, &input.identifier)?;
-                        queries::delete_folder(conn, id)
+                        queries::delete_folder(conn, id)?;
+                        Ok(format!("'{}'", input.identifier))
                     }),
                     _ => unreachable!(),
                 };
                 match result {
-                    Ok(()) => {
+                    Ok(reference) => {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: pid,
                         });
-                        format!("Deleted {} '{}'", input.resource_type, input.identifier)
+                        format!("Deleted {} {reference}", input.resource_type)
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2821,8 +2902,9 @@ impl LificMcp {
         description = "Add a comment to an issue (LIF-42) or page (LIF-DOC-3; DOC-3 for workspace pages). The author is the authenticated user."
     )]
     fn add_comment(&self, Parameters(input): Parameters<AddCommentInput>) -> String {
-        let parent = match resolve_comment_parent(self, &input.identifier) {
-            Ok(p) => p,
+        let (parent, parent_identifier, project_id) =
+            match resolve_comment_parent(self, &input.identifier) {
+            Ok(context) => context,
             Err(e) => return format!("Error: {e}"),
         };
         if let Err(e) = self.require_comment_role_mcp(parent, models::Role::Viewer) {
@@ -2846,20 +2928,6 @@ impl LificMcp {
         // front (read connections), then record @mentions in the same write
         // that creates the comment. Same visible-member rules as the REST
         // path — only tokens matching a visible member resolve.
-        let project_id: Option<i64> = match parent {
-            queries::comments::CommentParent::Issue(id) => {
-                match self.read(|conn| queries::get_issue(conn, id)) {
-                    Ok(i) => Some(i.project_id),
-                    Err(e) => return format!("Error: {e}"),
-                }
-            }
-            queries::comments::CommentParent::Page(id) => {
-                match self.read(|conn| queries::get_page(conn, id)) {
-                    Ok(p) => p.project_id,
-                    Err(e) => return format!("Error: {e}"),
-                }
-            }
-        };
         let member_scoped = match crate::authz::authz_enforced(&self.db) {
             Ok(v) => v,
             Err(e) => return format!("Error: {e}"),
@@ -2895,15 +2963,15 @@ impl LificMcp {
                 if current_issue_link_context().is_some() {
                     format!(
                         "{} added to {} by {} at {}",
-                        comment_reference(&input.identifier, parent, c.id),
-                        comment_parent_reference(&input.identifier, parent),
+                        comment_reference(&parent_identifier, parent, c.id),
+                        comment_parent_reference(&parent_identifier, parent),
                         c.author,
                         c.created_at
                     )
                 } else {
                     format!(
                         "Comment #{} added to {} by {} at {}",
-                        c.id, input.identifier, c.author, c.created_at
+                        c.id, parent_identifier, c.author, c.created_at
                     )
                 }
             }
@@ -2915,8 +2983,8 @@ impl LificMcp {
         description = "List comments on an issue (LIF-42) or page (LIF-DOC-3; DOC-3 for workspace pages)."
     )]
     fn list_comments(&self, Parameters(input): Parameters<ListCommentsInput>) -> String {
-        let parent = match resolve_comment_parent(self, &input.identifier) {
-            Ok(p) => p,
+        let (parent, parent_identifier, _) = match resolve_comment_parent(self, &input.identifier) {
+            Ok(context) => context,
             Err(e) => return format!("Error: {e}"),
         };
         if let Err(e) = self.require_comment_role_mcp(parent, models::Role::Viewer) {
@@ -2943,12 +3011,12 @@ impl LificMcp {
                 if total == 0 {
                     format!(
                         "No comments on {}.",
-                        comment_parent_reference(&input.identifier, parent)
+                        comment_parent_reference(&parent_identifier, parent)
                     )
                 } else {
                     format!(
                         "No comments in this range on {} (offset {offset}, {total} total).",
-                        comment_parent_reference(&input.identifier, parent)
+                        comment_parent_reference(&parent_identifier, parent)
                     )
                 }
             }
@@ -2967,20 +3035,20 @@ impl LificMcp {
                     };
                     format!(
                         "Showing {shown} {edge} of {total} comment(s) on {}:\n",
-                        comment_parent_reference(&input.identifier, parent)
+                        comment_parent_reference(&parent_identifier, parent)
                     )
                 } else if offset > 0 {
                     format!(
                         "Showing comments {}-{} of {total} on {} ({} first):\n",
                         offset + 1,
                         offset + shown,
-                        comment_parent_reference(&input.identifier, parent),
+                        comment_parent_reference(&parent_identifier, parent),
                         if order == "desc" { "newest" } else { "oldest" }
                     )
                 } else {
                     format!(
                         "{total} comment(s) on {}:\n",
-                        comment_parent_reference(&input.identifier, parent)
+                        comment_parent_reference(&parent_identifier, parent)
                     )
                 };
                 for c in &comments {
@@ -2990,7 +3058,7 @@ impl LificMcp {
                             c.created_at,
                             c.author,
                             c.author_display_name,
-                            comment_reference(&input.identifier, parent, c.id),
+                            comment_reference(&parent_identifier, parent, c.id),
                             c.content
                         ));
                     } else {
@@ -3038,8 +3106,9 @@ impl LificMcp {
 
         // LIF-263: recompute the mention set against the parent project's
         // visible members, resolving the project from the comment's parent.
-        let project_id = match self.read(|conn| resolve_comment_project(conn, &existing)) {
-            Ok(p) => p,
+        let (project_id, parent, parent_identifier) =
+            match self.read(|conn| resolve_comment_context(conn, &existing)) {
+            Ok(context) => context,
             Err(e) => return format!("Error: {e}"),
         };
         let member_scoped = match crate::authz::authz_enforced(&self.db) {
@@ -3065,7 +3134,15 @@ impl LificMcp {
                 } else if let Some(project_id) = project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                format!("Comment #{} edited at {}", c.id, c.updated_at)
+                if current_issue_link_context().is_some() {
+                    format!(
+                        "{} edited at {}",
+                        comment_reference(&parent_identifier, parent, c.id),
+                        c.updated_at
+                    )
+                } else {
+                    format!("Comment #{} edited at {}", c.id, c.updated_at)
+                }
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -3090,8 +3167,9 @@ impl LificMcp {
             return "Error: you can only delete your own comments".into();
         }
 
-        let project_id = match self.read(|conn| resolve_comment_project(conn, &existing)) {
-            Ok(project_id) => project_id,
+        let (project_id, parent, parent_identifier) =
+            match self.read(|conn| resolve_comment_context(conn, &existing)) {
+            Ok(context) => context,
             Err(e) => return format!("Error: {e}"),
         };
 
@@ -3105,7 +3183,15 @@ impl LificMcp {
                 } else if let Some(project_id) = project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                format!("Comment #{} deleted", input.comment_id)
+                if current_issue_link_context().is_some() {
+                    format!(
+                        "Comment #{} deleted from {}",
+                        input.comment_id,
+                        comment_parent_reference(&parent_identifier, parent)
+                    )
+                } else {
+                    format!("Comment #{} deleted", input.comment_id)
+                }
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -3297,10 +3383,11 @@ impl LificMcp {
                         }
                         if let Some(ref ident) = input.attach_issue {
                             let iid = queries::resolve_identifier(conn, ident)?;
+                            let issue = queries::get_issue(conn, iid)?;
                             queries::plans::set_step_issue(conn, step_id, Some(iid))?;
                             notes.push(format!(
                                 "Attached {} to step #{step_id}",
-                                issue_reference(ident)
+                                issue_reference(&issue.identifier)
                             ));
                         }
                         if input.detach_issue.unwrap_or(false) {
@@ -4099,10 +4186,10 @@ mod tests {
 
         let result = m.delete(Parameters(DeleteInput {
             resource_type: "issue".into(),
-            identifier: "DEL-1".into(),
+            identifier: "DEL-01".into(),
             project: None,
         }));
-        assert!(result.contains("Deleted issue"), "got: {result}");
+        assert_eq!(result, "Deleted issue DEL-1");
 
         // Verify gone
         let get = m.get_issue(Parameters(GetIssueInput {
@@ -4110,6 +4197,27 @@ mod tests {
             ..Default::default()
         }));
         assert!(get.starts_with("Error"), "got: {get}");
+    }
+
+    #[tokio::test]
+    async fn issue_delete_keeps_the_deleted_resource_reference_plain() {
+        let m = mcp();
+        seed_project(&m, "Test", "DEL");
+        seed_issue(&m, "DEL", "Doomed");
+        let context =
+            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let result =
+            crate::mcp::with_request_context(None, false, Some(context), || async {
+                m.delete(Parameters(DeleteInput {
+                    resource_type: "issue".into(),
+                    identifier: "DEL-01".into(),
+                    project: None,
+                }))
+            })
+            .await;
+
+        assert_eq!(result, "Deleted issue DEL-1");
     }
 
     #[test]
@@ -4313,11 +4421,11 @@ mod tests {
         seed_issue(&m, "LNK", "Blocked");
 
         let result = m.link_issues(Parameters(LinkIssuesInput {
-            source: "LNK-1".into(),
-            target: "LNK-2".into(),
+            source: "LNK-01".into(),
+            target: "LNK-02".into(),
             relation_type: "blocks".into(),
         }));
-        assert!(result.contains("blocks"), "got: {result}");
+        assert_eq!(result, "LNK-1 blocks LNK-2");
 
         // Verify relation shows in get_issue, now annotated with the related
         // issue's status (LIF-303). LNK-2 is a fresh issue → backlog.
@@ -4328,10 +4436,10 @@ mod tests {
         assert!(detail.contains("Blocks: LNK-2 (backlog)"), "got: {detail}");
 
         let result = m.unlink_issues(Parameters(UnlinkIssuesInput {
-            source: "LNK-1".into(),
-            target: "LNK-2".into(),
+            source: "LNK-01".into(),
+            target: "LNK-02".into(),
         }));
-        assert!(result.contains("Unlinked"), "got: {result}");
+        assert_eq!(result, "Unlinked LNK-1 and LNK-2");
     }
 
     // LIF-303: get_issue annotates relation identifiers with the related
@@ -4700,10 +4808,10 @@ mod tests {
         }));
         let result = m.delete(Parameters(DeleteInput {
             resource_type: "page".into(),
-            identifier: "PGD-DOC-1".into(),
+            identifier: "PGD-DOC-01".into(),
             project: None,
         }));
-        assert!(result.contains("Deleted page"), "got: {result}");
+        assert_eq!(result, "Deleted page PGD-DOC-1");
     }
 
     // ── search ──
@@ -4760,6 +4868,48 @@ mod tests {
             "got: {result}"
         );
         assert!(result.contains("- [comment] on FMT-1 "), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn search_renders_a_comment_as_one_direct_link() {
+        let m = mcp();
+        seed_project(&m, "Test", "SRC");
+        seed_issue(&m, "SRC", "Search comments");
+        let author = make_user(&m, "author", false);
+        let auth_user = models::AuthUser {
+            id: author.id,
+            username: author.username,
+            display_name: author.display_name,
+            is_admin: author.is_admin,
+        };
+        let context =
+            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let result = crate::mcp::with_request_context(
+            Some(auth_user),
+            false,
+            Some(context),
+            || async {
+                m.add_comment(Parameters(AddCommentInput {
+                    identifier: "SRC-1".into(),
+                    content: "Unique comment needle".into(),
+                }));
+                m.search(Parameters(SearchInput {
+                    query: "needle".into(),
+                    result_type: Some("comment".into()),
+                    ..Default::default()
+                }))
+            },
+        )
+        .await;
+
+        assert!(
+            result.contains(
+                "- [comment #1](https://tracker.example/SRC/issues/SRC-1#comment-1) on [SRC-1](https://tracker.example/SRC/issues/SRC-1)"
+            ),
+            "got: {result}"
+        );
+        assert!(!result.contains("[[comment"), "got: {result}");
     }
 
     // LIF-304: literal mode surfaces punctuation-heavy needles FTS tokenizes
@@ -5031,6 +5181,27 @@ mod tests {
             project: None,
         }));
         assert!(result.contains("project required"), "got: {result}");
+    }
+
+    #[test]
+    fn delete_module_reports_the_canonical_module_name() {
+        let m = mcp();
+        seed_project(&m, "Modules", "MOD");
+        m.manage_resource(Parameters(ManageResourceInput {
+            resource_type: "module".into(),
+            action: "create".into(),
+            project: Some("MOD".into()),
+            name: Some("Backend".into()),
+            ..Default::default()
+        }));
+
+        let result = m.delete(Parameters(DeleteInput {
+            resource_type: "module".into(),
+            identifier: "backend".into(),
+            project: Some("MOD".into()),
+        }));
+
+        assert_eq!(result, "Deleted module Backend");
     }
 
     #[test]
@@ -5698,17 +5869,21 @@ mod tests {
         let _guard = seed_user(&m);
 
         let result = m.add_comment(Parameters(AddCommentInput {
-            identifier: "PGC-DOC-1".into(),
+            identifier: "PGC-DOC-01".into(),
             content: "Comment on a page".into(),
         }));
         assert!(result.starts_with("Comment #"), "got: {result}");
         assert!(result.contains("PGC-DOC-1"), "got: {result}");
+        assert!(!result.contains("PGC-DOC-01"), "got: {result}");
 
         let listing = m.list_comments(Parameters(ListCommentsInput {
-            identifier: "PGC-DOC-1".into(),
+            identifier: "PGC-DOC-01".into(),
             ..Default::default()
         }));
-        assert!(listing.contains("1 comment(s)"), "got: {listing}");
+        assert!(
+            listing.starts_with("1 comment(s) on PGC-DOC-1:"),
+            "got: {listing}"
+        );
         assert!(listing.contains("Comment on a page"), "got: {listing}");
     }
 
@@ -7260,6 +7435,56 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn comment_mutations_link_the_live_comment_or_parent() {
+        let m = mcp();
+        seed_project(&m, "Proj", "PRJ");
+        seed_issue(&m, "PRJ", "Linked comments");
+        let author = make_user(&m, "author", false);
+        let auth_user = models::AuthUser {
+            id: author.id,
+            username: author.username,
+            display_name: author.display_name,
+            is_admin: author.is_admin,
+        };
+        let context =
+            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let (comment_id, edited, deleted) = crate::mcp::with_request_context(
+            Some(auth_user),
+            false,
+            Some(context),
+            || async {
+                let added = m.add_comment(Parameters(AddCommentInput {
+                    identifier: "PRJ-1".into(),
+                    content: "original".into(),
+                }));
+                let comment_id = comment_id_from(&added);
+                let edited = m.edit_comment(Parameters(EditCommentInput {
+                    comment_id,
+                    content: "revised".into(),
+                }));
+                let deleted =
+                    m.delete_comment(Parameters(DeleteCommentInput { comment_id }));
+                (comment_id, edited, deleted)
+            },
+        )
+        .await;
+
+        assert!(
+            edited.contains(&format!(
+                "[comment #{comment_id}](https://tracker.example/PRJ/issues/PRJ-1#comment-{comment_id}) edited"
+            )),
+            "got: {edited}"
+        );
+        assert_eq!(
+            deleted,
+            format!(
+                "Comment #{comment_id} deleted from [PRJ-1](https://tracker.example/PRJ/issues/PRJ-1)"
+            )
+        );
+    }
+
     #[test]
     fn issue_comment_edit_and_delete_emit_updates() {
         let (m, mut events) = mcp_with_realtime();
@@ -7542,6 +7767,92 @@ mod tests {
         assert!(!next.contains("offset="), "no further hint: {next}");
     }
 
+    #[tokio::test]
+    async fn get_activity_links_the_resolved_resource_type() {
+        let m = mcp();
+        seed_project(&m, "Audit", "TST");
+        seed_issue(&m, "TST", "Audit issue");
+        m.create_page(Parameters(CreatePageInput {
+            project: Some("TST".into()),
+            title: "Audit page".into(),
+            content: None,
+            folder: None,
+            status: None,
+            labels: None,
+        }));
+        m.create_plan(Parameters(CreatePlanInput {
+            project: "TST".into(),
+            title: "Audit plan".into(),
+            anchor_issue: None,
+            steps: None,
+        }));
+        m.manage_resource(Parameters(ManageResourceInput {
+            resource_type: "module".into(),
+            action: "create".into(),
+            project: Some("TST".into()),
+            name: Some("Backend".into()),
+            ..Default::default()
+        }));
+        let author = make_user(&m, "author", false);
+        let auth_user = models::AuthUser {
+            id: author.id,
+            username: author.username,
+            display_name: author.display_name,
+            is_admin: author.is_admin,
+        };
+        let context =
+            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let (project, page, issue) =
+            crate::mcp::with_request_context(Some(auth_user), false, Some(context), || async {
+                m.add_comment(Parameters(AddCommentInput {
+                    identifier: "TST-1".into(),
+                    content: "Audit comment".into(),
+                }));
+                (
+                    m.get_activity(Parameters(GetActivityInput {
+                        identifier: "TST".into(),
+                        ..Default::default()
+                    })),
+                    m.get_activity(Parameters(GetActivityInput {
+                        identifier: "TST-DOC-1".into(),
+                        ..Default::default()
+                    })),
+                    m.get_activity(Parameters(GetActivityInput {
+                        identifier: "TST-1".into(),
+                        ..Default::default()
+                    })),
+                )
+            })
+            .await;
+
+        assert!(
+            project.contains(
+                "activity entries for [TST](https://tracker.example/TST/overview):"
+            ),
+            "got: {project}"
+        );
+        assert!(
+            page.contains(
+                "activity entries for [TST-DOC-1](https://tracker.example/TST/pages/1):"
+            ),
+            "got: {page}"
+        );
+        for expected in [
+            "[TST-DOC-1](https://tracker.example/TST/pages/1)",
+            "[TST-PLAN-1](https://tracker.example/TST/plans/1)",
+            "[Backend](https://tracker.example/TST/modules/1)",
+        ] {
+            assert!(project.contains(expected), "missing {expected}: {project}");
+        }
+        assert!(
+            issue.contains(
+                "[comment #1](https://tracker.example/TST/issues/TST-1#comment-1)"
+            ),
+            "got: {issue}"
+        );
+    }
+
     #[test]
     fn get_activity_rejects_unknown_identifier() {
         let m = mcp();
@@ -7691,6 +8002,47 @@ mod tests {
             "get_plan should rehydrate tree: {got}"
         );
         assert!(got.contains("0/4 done"), "header should count steps: {got}");
+    }
+
+    #[tokio::test]
+    async fn attaching_an_issue_to_a_plan_step_links_its_canonical_identifier() {
+        let m = mcp();
+        seed_project(&m, "Plans", "PLN");
+        seed_issue(&m, "PLN", "Real work");
+        let created = m.create_plan(Parameters(CreatePlanInput {
+            project: "PLN".into(),
+            title: "Plan".into(),
+            anchor_issue: None,
+            steps: Some(vec![PlanStepInput {
+                title: "mirror".into(),
+                ..Default::default()
+            }]),
+        }));
+        let step_id = created
+            .split('#')
+            .nth(1)
+            .and_then(|value| value.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|value| value.parse().ok())
+            .expect("step id in output");
+        let context =
+            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let output =
+            crate::mcp::with_request_context(None, false, Some(context), || async {
+                m.update_plan_step(Parameters(UpdatePlanStepInput {
+                    plan: "PLN-PLAN-1".into(),
+                    step_id: Some(step_id),
+                    attach_issue: Some("PLN-01".into()),
+                    ..Default::default()
+                }))
+            })
+            .await;
+
+        assert!(
+            output.contains("[PLN-1](https://tracker.example/PLN/issues/PLN-1)"),
+            "got: {output}"
+        );
+        assert!(!output.contains("/PLN-01"), "got: {output}");
     }
 
     #[test]
@@ -8081,10 +8433,10 @@ mod tests {
         }));
         let out = m.delete(Parameters(DeleteInput {
             resource_type: "plan".into(),
-            identifier: "PLN-PLAN-1".into(),
+            identifier: "PLN-PLAN-01".into(),
             project: None,
         }));
-        assert!(out.contains("Deleted plan"), "got: {out}");
+        assert_eq!(out, "Deleted plan PLN-PLAN-1");
         let got = m.get_plan(Parameters(GetPlanInput {
             plan: "PLN-PLAN-1".into(),
         }));

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3,7 +3,10 @@ use std::{cmp::Ordering, sync::Arc};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use rmcp::{handler::server::wrapper::Parameters, tool, tool_router};
 
-use crate::db::{DbPool, models, queries};
+use crate::{
+    db::{DbPool, models, queries},
+    links::IssueLinkContext,
+};
 
 use super::schemas::*;
 use super::{LificMcp, current_issue_link_context};
@@ -434,6 +437,13 @@ fn resolve_project(db: &Arc<DbPool>, ident: &str) -> Result<i64, String> {
     queries::resolve_project_identifier(&conn, ident).map_err(|e| e.to_string())
 }
 
+fn canonical_project_identifier(db: &Arc<DbPool>, project_id: i64) -> Result<String, String> {
+    let conn = db.read().map_err(|e| e.to_string())?;
+    queries::get_project(&conn, project_id)
+        .map(|project| project.identifier)
+        .map_err(|e| e.to_string())
+}
+
 fn resolve_module(db: &Arc<DbPool>, project_id: i64, name: &str) -> Result<i64, String> {
     let conn = db.read().map_err(|e| e.to_string())?;
     queries::resolve_module_name(&conn, project_id, name).map_err(|e| e.to_string())
@@ -562,91 +572,227 @@ fn truncate_value(v: &str, max: usize) -> String {
 
 /// Render one audit entry as a compact line:
 /// `[ts] actor via transport — LABEL action detail`
-fn activity_reference(a: &models::Activity, project: Option<&str>) -> String {
-    let label = a.entity_label.as_deref().unwrap_or("?");
-    let Some(context) = current_issue_link_context() else {
-        return label.to_owned();
+fn resolves_to(result: Result<i64, crate::error::LificError>, expected: i64) -> bool {
+    result.is_ok_and(|id| id == expected)
+}
+
+fn activity_comment_reference(
+    conn: &rusqlite::Connection,
+    context: &IssueLinkContext,
+    activity: &models::Activity,
+    label: &str,
+) -> String {
+    let (issue_id, page_id) = if activity.action == "delete" {
+        (activity.issue_id, activity.page_id)
+    } else {
+        let Ok(comment) = queries::comments::get_comment(conn, activity.entity_id) else {
+            return label.to_owned();
+        };
+        if comment.issue_id != activity.issue_id || comment.page_id != activity.page_id {
+            return label.to_owned();
+        }
+        (comment.issue_id, comment.page_id)
     };
 
-    if a.action == "delete" {
-        return match a.entity_type.as_str() {
-            "comment" if a.issue_id.is_some() => context.issue_markdown(label),
-            "comment" => a
-                .page_id
-                .map_or_else(|| label.to_owned(), |id| context.page_markdown(label, id)),
-            _ => label.to_owned(),
-        };
-    }
-
-    match a.entity_type.as_str() {
-        "issue" => context.issue_markdown(label),
-        "project" => context.project_markdown(label),
-        "page" => context.page_markdown(label, a.entity_id),
-        "plan" => context.plan_markdown(label, a.entity_id),
-        "module" => project.map_or_else(
-            || label.to_owned(),
-            |project| context.module_markdown(project, a.entity_id, label),
-        ),
-        "comment" if a.issue_id.is_some() => {
-            context.issue_comment_markdown(label, a.entity_id)
+    match (issue_id, page_id) {
+        (Some(issue_id), _)
+            if resolves_to(queries::resolve_identifier(conn, label), issue_id) =>
+        {
+            if activity.action == "delete" {
+                context.issue_markdown(label)
+            } else {
+                context.issue_comment_markdown(label, activity.entity_id)
+            }
         }
-        "comment" => a.page_id.map_or_else(
-            || label.to_owned(),
-            |page_id| context.page_comment_markdown(label, page_id, a.entity_id),
-        ),
+        (_, Some(page_id))
+            if resolves_to(queries::resolve_page_identifier(conn, label), page_id) =>
+        {
+            if activity.action == "delete" {
+                context.page_markdown(label, page_id)
+            } else {
+                context.page_comment_markdown(label, page_id, activity.entity_id)
+            }
+        }
         _ => label.to_owned(),
     }
 }
 
-fn fmt_activity(a: &models::Activity, project: Option<&str>) -> String {
-    let who = match (&a.actor_display_name, &a.actor_username) {
-        (Some(d), _) if !d.is_empty() => d.clone(),
-        (_, Some(u)) => u.clone(),
+fn activity_reference(
+    conn: &rusqlite::Connection,
+    activity: &models::Activity,
+    project: Option<&str>,
+    context: Option<&IssueLinkContext>,
+) -> String {
+    let label = activity.entity_label.as_deref().unwrap_or("?");
+    let Some(context) = context else {
+        return label.to_owned();
+    };
+    if activity.entity_type == "plan_step" {
+        return queries::plans::resolve_plan_identifier(conn, label).map_or_else(
+            |_| label.to_owned(),
+            |plan_id| context.plan_markdown(label, plan_id),
+        );
+    }
+    if activity.entity_type == "comment" {
+        return activity_comment_reference(conn, context, activity, label);
+    }
+    if activity.action == "delete" {
+        return label.to_owned();
+    }
+
+    match activity.entity_type.as_str() {
+        "issue" if resolves_to(queries::resolve_identifier(conn, label), activity.entity_id) => {
+            context.issue_markdown(label)
+        }
+        "project"
+            if resolves_to(
+                queries::resolve_project_identifier(conn, label),
+                activity.entity_id,
+            ) =>
+        {
+            context.project_markdown(label)
+        }
+        "page" if resolves_to(
+            queries::resolve_page_identifier(conn, label),
+            activity.entity_id,
+        ) => context.page_markdown(label, activity.entity_id),
+        "plan" if resolves_to(
+            queries::plans::resolve_plan_identifier(conn, label),
+            activity.entity_id,
+        ) => context.plan_markdown(label, activity.entity_id),
+        "module" => match (
+            project,
+            queries::get_module(conn, activity.entity_id).ok(),
+        ) {
+            (Some(project), Some(module))
+                if Some(module.project_id) == activity.project_id
+                    && resolves_to(
+                        queries::resolve_project_identifier(conn, project),
+                        module.project_id,
+                    ) =>
+            {
+                context.module_markdown(project, activity.entity_id, label)
+            }
+            _ => label.to_owned(),
+        },
+        _ => label.to_owned(),
+    }
+}
+
+fn activity_issue_reference(
+    conn: &rusqlite::Connection,
+    context: Option<&IssueLinkContext>,
+    identifier: &str,
+) -> String {
+    let Some(context) = context else {
+        return identifier.to_owned();
+    };
+    queries::resolve_identifier(conn, identifier).map_or_else(
+        |_| identifier.to_owned(),
+        |id| {
+            queries::get_issue(conn, id).map_or_else(
+                |_| identifier.to_owned(),
+                |issue| {
+                    if issue.identifier == identifier {
+                        context.issue_markdown(identifier)
+                    } else {
+                        identifier.to_owned()
+                    }
+                },
+            )
+        },
+    )
+}
+
+fn activity_field_value(
+    conn: &rusqlite::Connection,
+    context: Option<&IssueLinkContext>,
+    field: Option<&str>,
+    value: &str,
+) -> String {
+    if matches!(field, Some("issue" | "anchor_issue")) {
+        activity_issue_reference(conn, context, value)
+    } else {
+        truncate_value(value, 60)
+    }
+}
+
+fn fmt_activity(
+    conn: &rusqlite::Connection,
+    activity: &models::Activity,
+    project: Option<&str>,
+    context: Option<&IssueLinkContext>,
+) -> String {
+    let who = match (&activity.actor_display_name, &activity.actor_username) {
+        (Some(display_name), _) if !display_name.is_empty() => display_name.clone(),
+        (_, Some(username)) => username.clone(),
         _ => "system".into(),
     };
-    let agent = if a.actor_is_bot { " (agent)" } else { "" };
-    let label = activity_reference(a, project);
+    let agent = if activity.actor_is_bot {
+        " (agent)"
+    } else {
+        ""
+    };
+    let label = activity_reference(conn, activity, project, context);
 
-    let detail = match a.action.as_str() {
+    let detail = match activity.action.as_str() {
         "create" => format!(
             "created {} {}: {}",
-            a.entity_type,
+            activity.entity_type,
             label,
-            truncate_value(a.new_value.as_deref().unwrap_or(""), 60)
+            truncate_value(activity.new_value.as_deref().unwrap_or(""), 60)
         ),
         "delete" => format!(
             "deleted {} {} ({})",
-            a.entity_type,
+            activity.entity_type,
             label,
-            truncate_value(a.old_value.as_deref().unwrap_or(""), 60)
+            truncate_value(activity.old_value.as_deref().unwrap_or(""), 60)
         ),
         "update" => format!(
             "{} {}: {} → {}",
             label,
-            a.field.as_deref().unwrap_or("?"),
-            truncate_value(a.old_value.as_deref().unwrap_or("(none)"), 60),
-            truncate_value(a.new_value.as_deref().unwrap_or("(none)"), 60)
+            activity.field.as_deref().unwrap_or("?"),
+            activity_field_value(
+                conn,
+                context,
+                activity.field.as_deref(),
+                activity.old_value.as_deref().unwrap_or("(none)")
+            ),
+            activity_field_value(
+                conn,
+                context,
+                activity.field.as_deref(),
+                activity.new_value.as_deref().unwrap_or("(none)")
+            )
         ),
-        "attach" => format!("{} +label {}", label, a.new_value.as_deref().unwrap_or("?")),
-        "detach" => format!("{} -label {}", label, a.old_value.as_deref().unwrap_or("?")),
+        "attach" => format!(
+            "{} +label {}",
+            label,
+            activity.new_value.as_deref().unwrap_or("?")
+        ),
+        "detach" => format!(
+            "{} -label {}",
+            label,
+            activity.old_value.as_deref().unwrap_or("?")
+        ),
         "link" => format!(
             "{} {} → {}",
             label,
-            a.field.as_deref().unwrap_or("relates_to"),
-            issue_reference(a.new_value.as_deref().unwrap_or("?"))
+            activity.field.as_deref().unwrap_or("relates_to"),
+            activity_issue_reference(conn, context, activity.new_value.as_deref().unwrap_or("?"))
         ),
         "unlink" => format!(
             "{} un-{} → {}",
             label,
-            a.field.as_deref().unwrap_or("relates_to"),
-            issue_reference(a.old_value.as_deref().unwrap_or("?"))
+            activity.field.as_deref().unwrap_or("relates_to"),
+            activity_issue_reference(conn, context, activity.old_value.as_deref().unwrap_or("?"))
         ),
         other => format!("{label} {other}"),
     };
 
     format!(
         "[{}] {}{} via {} — {}",
-        a.ts, who, agent, a.transport, detail
+        activity.ts, who, agent, activity.transport, detail
     )
 }
 
@@ -883,6 +1029,7 @@ impl LificMcp {
                 if has_more {
                     results.truncate(limit as usize);
                 }
+                let link_context = current_issue_link_context();
                 let mut out = format!("{} results:\n", results.len());
                 for r in &results {
                     let ident = r.identifier.as_deref().unwrap_or("");
@@ -890,17 +1037,8 @@ impl LificMcp {
                     // match on its parent so the reader knows to open the
                     // parent issue/page to find the thread (LIF-146).
                     if r.result_type == "comment" {
-                        let page_id = current_issue_link_context().and_then(|_| {
-                            looks_like_page_identifier(ident)
-                                .then(|| {
-                                    self.read(|conn| {
-                                        queries::resolve_page_identifier(conn, ident)
-                                    })
-                                    .ok()
-                                })
-                                .flatten()
-                        });
-                        let parent = current_issue_link_context().map_or_else(
+                        let page_id = r.parent_page_id;
+                        let parent = link_context.as_ref().map_or_else(
                             || ident.to_owned(),
                             |context| {
                                 page_id.map_or_else(
@@ -909,7 +1047,7 @@ impl LificMcp {
                                 )
                             },
                         );
-                        let comment = current_issue_link_context().map_or_else(
+                        let comment = link_context.as_ref().map_or_else(
                             || "[comment]".to_owned(),
                             |context| page_id.map_or_else(
                                 || context.issue_comment_markdown(ident, r.id),
@@ -922,17 +1060,20 @@ impl LificMcp {
                         ));
                     } else {
                         let identifier = if r.result_type == "page" {
-                            current_issue_link_context().map_or_else(
+                            link_context.as_ref().map_or_else(
                                 || ident.to_owned(),
                                 |context| context.page_markdown(ident, r.id),
                             )
                         } else if r.result_type == "plan" {
-                            current_issue_link_context().map_or_else(
+                            link_context.as_ref().map_or_else(
                                 || ident.to_owned(),
                                 |context| context.plan_markdown(ident, r.id),
                             )
                         } else {
-                            issue_reference(ident)
+                            link_context.as_ref().map_or_else(
+                                || ident.to_owned(),
+                                |context| context.issue_markdown(ident),
+                            )
                         };
                         out.push_str(&format!(
                             "- [{}] {} {} — {}\n",
@@ -965,17 +1106,19 @@ impl LificMcp {
             if looks_like_page_identifier(ident) {
             match self.read(|conn| {
                 let id = queries::resolve_page_identifier(conn, ident)?;
-                queries::get_page(conn, id)
+                let page = queries::get_page(conn, id)?;
+                let project_identifier = page
+                    .project_id
+                    .and_then(|project_id| queries::get_project(conn, project_id).ok())
+                    .map(|project| project.identifier);
+                let scope_reference = page_reference(&page);
+                Ok((page, scope_reference, project_identifier))
             }) {
-                Ok(page) => {
-                    let project_identifier = page
-                        .identifier
-                        .split_once("-DOC-")
-                        .map(|(project, _)| project.to_owned());
+                Ok((page, scope_reference, project_identifier)) => {
                     (
                         queries::activity::ActivityScope::Page(page.id),
                         page.project_id,
-                        page_reference(&page),
+                        scope_reference,
                         project_identifier,
                     )
                 }
@@ -983,16 +1126,18 @@ impl LificMcp {
             }
         } else if let Ok(issue) = self.read(|conn| {
             let id = queries::resolve_identifier(conn, ident)?;
-            queries::get_issue(conn, id)
+            let issue = queries::get_issue(conn, id)?;
+            let project_identifier = queries::get_project(conn, issue.project_id)
+                .ok()
+                .map(|project| project.identifier);
+            let scope_reference = issue_reference(&issue.identifier);
+            Ok((issue, scope_reference, project_identifier))
         }) {
-            let project_identifier = issue
-                .identifier
-                .rsplit_once('-')
-                .map(|(project, _)| project.to_owned());
+            let (issue, scope_reference, project_identifier) = issue;
             (
                 queries::activity::ActivityScope::Issue(issue.id),
                 Some(issue.project_id),
-                issue_reference(&issue.identifier),
+                scope_reference,
                 project_identifier,
             )
         } else {
@@ -1023,25 +1168,37 @@ impl LificMcp {
             return format!("Error: {e}");
         }
 
-        match self
-            .read(|conn| queries::activity::list_activity(conn, scope, Some(limit), Some(offset)))
-        {
-            Ok(feed) if feed.items.is_empty() && offset == 0 => {
+        let link_context = current_issue_link_context();
+        match self.read(|conn| {
+            let feed = queries::activity::list_activity(conn, scope, Some(limit), Some(offset))?;
+            // ponytail: feeds cap at 200; batch target checks only if this read path profiles hot.
+            let items: Vec<_> = feed
+                .items
+                .iter()
+                .map(|activity| {
+                    fmt_activity(
+                        conn,
+                        activity,
+                        project_identifier.as_deref(),
+                        link_context.as_ref(),
+                    )
+                })
+                .collect();
+            Ok((items, feed.has_more))
+        }) {
+            Ok((items, _)) if items.is_empty() && offset == 0 => {
                 format!("No recorded activity for {scope_reference} yet.")
             }
-            Ok(feed) => {
+            Ok((items, has_more)) => {
                 let mut out = format!(
                     "{} activity entries for {}:\n",
-                    feed.items.len(),
+                    items.len(),
                     scope_reference
                 );
-                for a in &feed.items {
-                    out.push_str(&format!(
-                        "- {}\n",
-                        fmt_activity(a, project_identifier.as_deref())
-                    ));
+                for item in &items {
+                    out.push_str(&format!("- {item}\n"));
                 }
-                append_pagination_hint(&mut out, feed.has_more, offset + limit);
+                append_pagination_hint(&mut out, has_more, offset + limit);
                 out
             }
             Err(e) => format!("Error: {e}"),
@@ -2522,13 +2679,17 @@ impl LificMcp {
                 if let Err(e) = require_role_mcp(&self.db, pid, models::Role::Viewer) {
                     return format!("Error: {e}");
                 }
+                let canonical_project = match canonical_project_identifier(&self.db, pid) {
+                    Ok(identifier) => identifier,
+                    Err(e) => return format!("Error: {e}"),
+                };
                 match self.read(|conn| queries::list_modules(conn, pid)) {
                     Ok(ms) => {
                         let mut out = format!("{} modules:\n", ms.len());
                         for m in &ms {
                             out.push_str(&format!(
                                 "- {} ({})",
-                                module_reference(proj, m),
+                                module_reference(&canonical_project, m),
                                 m.status
                             ));
                             if !m.description.is_empty() {
@@ -2690,6 +2851,10 @@ impl LificMcp {
                 if let Err(e) = require_structure_role_mcp(&self.db, pid) {
                     return format!("Error: {e}");
                 }
+                let canonical_project = match canonical_project_identifier(&self.db, pid) {
+                    Ok(identifier) => identifier,
+                    Err(e) => return format!("Error: {e}"),
+                };
                 let Some(ref name) = input.name else {
                     return "Error: name required".into();
                 };
@@ -2709,7 +2874,7 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: pid,
                         });
-                        format!("Created module {}", module_reference(proj, &m))
+                        format!("Created module {}", module_reference(&canonical_project, &m))
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2725,6 +2890,10 @@ impl LificMcp {
                 if let Err(e) = require_structure_role_mcp(&self.db, pid) {
                     return format!("Error: {e}");
                 }
+                let canonical_project = match canonical_project_identifier(&self.db, pid) {
+                    Ok(identifier) => identifier,
+                    Err(e) => return format!("Error: {e}"),
+                };
                 let Some(ref current) = input.current_name else {
                     return "Error: current_name required to identify module".into();
                 };
@@ -2748,7 +2917,7 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: pid,
                         });
-                        format!("Updated module {}", module_reference(proj, &m))
+                        format!("Updated module {}", module_reference(&canonical_project, &m))
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -3584,6 +3753,15 @@ mod tests {
     fn project_id_for(mcp: &LificMcp, identifier: &str) -> i64 {
         mcp.read(|conn| queries::resolve_project_identifier(conn, identifier))
             .expect("project id")
+    }
+
+    #[test]
+    fn canonical_project_identifier_comes_from_project_record() {
+        let m = mcp();
+        seed_project(&m, "Canonical", "CAN");
+        let project_id = project_id_for(&m, "CAN");
+
+        assert_eq!(canonical_project_identifier(&m.db, project_id).unwrap(), "CAN");
     }
 
     fn issue_id_for(mcp: &LificMcp, identifier: &str) -> i64 {
@@ -7850,6 +8028,152 @@ mod tests {
                 "[comment #1](https://tracker.example/TST/issues/TST-1#comment-1)"
             ),
             "got: {issue}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_activity_leaves_stale_identifiers_unlinked_after_project_rename() {
+        let m = mcp();
+        seed_project(&m, "Audit", "TST");
+        seed_issue(&m, "TST", "Historical issue");
+        let updated = m.manage_resource(Parameters(ManageResourceInput {
+            resource_type: "project".into(),
+            action: "update".into(),
+            project: Some("TST".into()),
+            identifier: Some("NEW".into()),
+            ..Default::default()
+        }));
+        assert!(updated.contains("Updated project NEW"), "got: {updated}");
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let out = crate::mcp::with_request_context(None, false, Some(context), || async {
+            m.get_activity(Parameters(GetActivityInput {
+                identifier: "NEW".into(),
+                ..Default::default()
+            }))
+        })
+        .await;
+
+        assert!(out.contains("created issue TST-1"), "got: {out}");
+        assert!(!out.contains("[TST-1]("), "stale link in: {out}");
+    }
+
+    #[tokio::test]
+    async fn get_activity_leaves_stale_relation_targets_unlinked_after_project_rename() {
+        let m = mcp();
+        seed_project(&m, "Audit", "TST");
+        seed_issue(&m, "TST", "Source");
+        seed_issue(&m, "TST", "Target");
+        let linked = m.link_issues(Parameters(LinkIssuesInput {
+            source: "TST-1".into(),
+            target: "TST-2".into(),
+            relation_type: "blocks".into(),
+        }));
+        assert_eq!(linked, "TST-1 blocks TST-2");
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let (live, stale) =
+            crate::mcp::with_request_context(None, false, Some(context), || async {
+                let live = m.get_activity(Parameters(GetActivityInput {
+                    identifier: "TST".into(),
+                    ..Default::default()
+                }));
+                m.manage_resource(Parameters(ManageResourceInput {
+                    resource_type: "project".into(),
+                    action: "update".into(),
+                    project: Some("TST".into()),
+                    identifier: Some("NEW".into()),
+                    ..Default::default()
+                }));
+                let stale = m.get_activity(Parameters(GetActivityInput {
+                    identifier: "NEW".into(),
+                    ..Default::default()
+                }));
+                (live, stale)
+            })
+            .await;
+
+        assert!(
+            live.contains(
+                "[TST-1](https://tracker.example/TST/issues/TST-1) blocks → [TST-2](https://tracker.example/TST/issues/TST-2)"
+            ),
+            "got: {live}"
+        );
+        assert!(stale.contains("TST-1 blocks → TST-2"), "got: {stale}");
+        assert!(
+            !stale.contains("[TST-2]("),
+            "stale relation link in: {stale}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_activity_links_plan_steps_to_their_parent_plan() {
+        let m = mcp();
+        seed_project(&m, "Audit", "TST");
+        let created = m.create_plan(Parameters(CreatePlanInput {
+            project: "TST".into(),
+            title: "Audit plan".into(),
+            anchor_issue: None,
+            steps: Some(vec![PlanStepInput {
+                title: "Exercise the link".into(),
+                ..Default::default()
+            }]),
+        }));
+        assert!(created.contains("Created TST-PLAN-1"), "got: {created}");
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let out = crate::mcp::with_request_context(None, false, Some(context), || async {
+            m.get_activity(Parameters(GetActivityInput {
+                identifier: "TST".into(),
+                ..Default::default()
+            }))
+        })
+        .await;
+
+        assert!(
+            out.contains(
+                "created plan_step [TST-PLAN-1](https://tracker.example/TST/plans/1): Exercise the link"
+            ),
+            "got: {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_activity_links_plan_step_issue_values() {
+        let m = mcp();
+        seed_project(&m, "Audit", "TST");
+        seed_issue(&m, "TST", "Linked issue");
+        m.create_plan(Parameters(CreatePlanInput {
+            project: "TST".into(),
+            title: "Audit plan".into(),
+            anchor_issue: None,
+            steps: Some(vec![PlanStepInput {
+                title: "Exercise the link".into(),
+                ..Default::default()
+            }]),
+        }));
+        let updated = m.update_plan_step(Parameters(UpdatePlanStepInput {
+            plan: "TST-PLAN-1".into(),
+            step_id: Some(1),
+            attach_issue: Some("TST-1".into()),
+            ..Default::default()
+        }));
+        assert!(updated.contains("Attached TST-1"), "got: {updated}");
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+
+        let out = crate::mcp::with_request_context(None, false, Some(context), || async {
+            m.get_activity(Parameters(GetActivityInput {
+                identifier: "TST".into(),
+                ..Default::default()
+            }))
+        })
+        .await;
+
+        assert!(
+            out.contains(
+                "[TST-PLAN-1](https://tracker.example/TST/plans/1) issue: (none) → [TST-1](https://tracker.example/TST/issues/TST-1)"
+            ),
+            "got: {out}"
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,11 +1,15 @@
-use std::{cmp::Ordering, sync::Arc};
+use std::{
+    cmp::Ordering,
+    fmt::{self, Display, Write as _},
+    sync::Arc,
+};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use rmcp::{handler::server::wrapper::Parameters, tool, tool_router};
 
 use crate::{
     db::{DbPool, models, queries},
-    links::IssueLinkContext,
+    links::{IssueLinkContext, MarkdownReference},
 };
 
 use super::schemas::*;
@@ -24,153 +28,385 @@ impl LificMcp {
     }
 }
 
-pub(crate) fn fmt_issue(i: &models::Issue) -> String {
-    let context = current_issue_link_context();
-    fmt_issue_with_context(i, context.as_ref())
+fn try_render(render: impl FnOnce(&mut String) -> fmt::Result) -> Result<String, fmt::Error> {
+    let mut output = String::new();
+    render(&mut output).map(|()| output)
 }
 
-fn fmt_issue_with_context(i: &models::Issue, context: Option<&IssueLinkContext>) -> String {
-    let mut s = format!(
-        "{} | {} | {} | {}",
-        issue_reference_with_context(context, &i.identifier),
-        i.status,
-        i.priority,
-        i.title
-    );
-    if !i.labels.is_empty() {
-        s.push_str(&format!(" [{}]", i.labels.join(", ")));
+fn render_response(render: impl FnOnce(&mut String) -> fmt::Result) -> String {
+    match try_render(render) {
+        Ok(output) => output,
+        Err(error) => format!("Error: failed to format response: {error}"),
     }
-    if !i.blocks.is_empty() {
-        s.push_str(&format!(
-            " blocks:{}",
-            i.blocks
-                .iter()
-                .map(|identifier| issue_reference_with_context(context, identifier))
-                .collect::<Vec<_>>()
-                .join(",")
-        ));
-    }
-    if !i.blocked_by.is_empty() {
-        s.push_str(&format!(
-            " blocked_by:{}",
-            i.blocked_by
-                .iter()
-                .map(|identifier| issue_reference_with_context(context, identifier))
-                .collect::<Vec<_>>()
-                .join(",")
-        ));
-    }
-    if !i.duplicates.is_empty() {
-        s.push_str(&format!(
-            " duplicates:{}",
-            i.duplicates
-                .iter()
-                .map(|identifier| issue_reference_with_context(context, identifier))
-                .collect::<Vec<_>>()
-                .join(",")
-        ));
-    }
-    if !i.duplicated_by.is_empty() {
-        s.push_str(&format!(
-            " duplicated_by:{}",
-            i.duplicated_by
-                .iter()
-                .map(|identifier| issue_reference_with_context(context, identifier))
-                .collect::<Vec<_>>()
-                .join(",")
-        ));
-    }
-    s
 }
 
-fn issue_reference(identifier: &str) -> String {
-    let context = current_issue_link_context();
-    issue_reference_with_context(context.as_ref(), identifier)
+fn finish_response(output: String, result: fmt::Result) -> String {
+    match result {
+        Ok(()) => output,
+        Err(error) => format!("Error: failed to format response: {error}"),
+    }
 }
 
-fn issue_reference_with_context(context: Option<&IssueLinkContext>, identifier: &str) -> String {
-    context.map_or_else(
-        || identifier.to_owned(),
-        |context| context.issue_markdown(identifier),
-    )
+fn write_joined<T>(
+    formatter: &mut fmt::Formatter<'_>,
+    values: &[T],
+    separator: &str,
+    mut write_value: impl FnMut(&mut fmt::Formatter<'_>, &T) -> fmt::Result,
+) -> fmt::Result {
+    values.split_first().map_or(Ok(()), |(first, rest)| {
+        write_value(formatter, first)?;
+        rest.iter().try_for_each(|value| {
+            formatter.write_str(separator)?;
+            write_value(formatter, value)
+        })
+    })
 }
 
-fn comment_reference(
+struct JoinedStrings<'a> {
+    values: &'a [String],
+    separator: &'a str,
+}
+
+impl Display for JoinedStrings<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_joined(
+            formatter,
+            self.values,
+            self.separator,
+            |formatter, value| formatter.write_str(value),
+        )
+    }
+}
+
+struct IssueReference<'a> {
+    context: Option<&'a IssueLinkContext>,
+    identifier: &'a str,
+}
+
+impl Display for IssueReference<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.context {
+            Some(context) => Display::fmt(&context.issue_markdown(self.identifier), formatter),
+            None => formatter.write_str(self.identifier),
+        }
+    }
+}
+
+struct IssueRelations<'a> {
+    label: &'a str,
+    identifiers: &'a [String],
+    context: Option<&'a IssueLinkContext>,
+}
+
+impl Display for IssueRelations<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.identifiers.split_first().map_or(Ok(()), |_| {
+            formatter.write_str(self.label)?;
+            write_joined(formatter, self.identifiers, ",", |formatter, identifier| {
+                Display::fmt(
+                    &IssueReference {
+                        context: self.context,
+                        identifier,
+                    },
+                    formatter,
+                )
+            })
+        })
+    }
+}
+
+struct IssueLine<'a> {
+    issue: &'a models::Issue,
+    context: Option<&'a IssueLinkContext>,
+}
+
+impl Display for IssueLine<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let issue = self.issue;
+        write!(
+            formatter,
+            "{} | {} | {} | {}",
+            IssueReference {
+                context: self.context,
+                identifier: &issue.identifier,
+            },
+            issue.status,
+            issue.priority,
+            issue.title
+        )?;
+        issue.labels.split_first().map_or(Ok(()), |_| {
+            write!(
+                formatter,
+                " [{}]",
+                JoinedStrings {
+                    values: &issue.labels,
+                    separator: ", ",
+                }
+            )
+        })?;
+        [
+            (" blocks:", issue.blocks.as_slice()),
+            (" blocked_by:", issue.blocked_by.as_slice()),
+            (" duplicates:", issue.duplicates.as_slice()),
+            (" duplicated_by:", issue.duplicated_by.as_slice()),
+        ]
+        .into_iter()
+        .try_for_each(|(label, identifiers)| {
+            Display::fmt(
+                &IssueRelations {
+                    label,
+                    identifiers,
+                    context: self.context,
+                },
+                formatter,
+            )
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ReferenceKind<'a> {
+    Issue(&'a str),
+    Project(&'a str),
+    Page(&'a str, i64),
+    Plan(&'a str, i64),
+    Module(&'a str, i64, &'a str),
+    IssueComment(&'a str, i64),
+    PageComment(&'a str, i64, i64),
+    IssueSearchComment(&'a str, i64),
+    PageSearchComment(&'a str, i64, i64),
+}
+
+#[derive(Clone, Copy)]
+enum ActivityScopeReference {
+    Issue,
+    Page(i64),
+    Project,
+}
+
+struct Reference<'a> {
+    context: Option<&'a IssueLinkContext>,
+    kind: ReferenceKind<'a>,
+}
+
+impl Display for Reference<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.kind.fmt_with_context(self.context, formatter)
+    }
+}
+
+impl ReferenceKind<'_> {
+    fn fmt_with_context(
+        self,
+        context: Option<&IssueLinkContext>,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        match context {
+            Some(context) => self.fmt_linked(context, formatter),
+            None => self.fmt_plain(formatter),
+        }
+    }
+
+    fn fmt_linked(
+        self,
+        context: &IssueLinkContext,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        match self {
+            Self::Issue(identifier) => Display::fmt(&context.issue_markdown(identifier), formatter),
+            Self::Project(identifier) => {
+                Display::fmt(&context.project_markdown(identifier), formatter)
+            }
+            Self::Page(identifier, page_id) => {
+                Display::fmt(&context.page_markdown(identifier, page_id), formatter)
+            }
+            Self::Plan(identifier, plan_id) => {
+                Display::fmt(&context.plan_markdown(identifier, plan_id), formatter)
+            }
+            Self::Module(project, module_id, label) => Display::fmt(
+                &context.module_markdown(project, module_id, label),
+                formatter,
+            ),
+            Self::IssueComment(identifier, comment_id)
+            | Self::IssueSearchComment(identifier, comment_id) => Display::fmt(
+                &context.issue_comment_markdown(identifier, comment_id),
+                formatter,
+            ),
+            Self::PageComment(identifier, page_id, comment_id)
+            | Self::PageSearchComment(identifier, page_id, comment_id) => Display::fmt(
+                &context.page_comment_markdown(identifier, page_id, comment_id),
+                formatter,
+            ),
+        }
+    }
+
+    fn fmt_plain(self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Module(_, _, label) => formatter.write_str(label),
+            Self::IssueSearchComment(_, _) | Self::PageSearchComment(_, _, _) => {
+                formatter.write_str("[comment]")
+            }
+            Self::IssueComment(_, comment_id) | Self::PageComment(_, _, comment_id) => {
+                write!(formatter, "comment #{comment_id}")
+            }
+            Self::Issue(identifier)
+            | Self::Project(identifier)
+            | Self::Page(identifier, _)
+            | Self::Plan(identifier, _) => formatter.write_str(identifier),
+        }
+    }
+}
+
+fn reference_with_context<'a>(
+    context: Option<&'a IssueLinkContext>,
+    kind: ReferenceKind<'a>,
+) -> Reference<'a> {
+    Reference { context, kind }
+}
+
+fn comment_reference_kind(
     parent_identifier: &str,
     parent: queries::comments::CommentParent,
     comment_id: i64,
-) -> String {
-    current_issue_link_context().map_or_else(
-        || format!("comment #{comment_id}"),
-        |context| match parent {
-            queries::comments::CommentParent::Issue(_) => {
-                context.issue_comment_markdown(parent_identifier, comment_id)
-            }
-            queries::comments::CommentParent::Page(page_id) => {
-                context.page_comment_markdown(parent_identifier, page_id, comment_id)
-            }
-        },
-    )
+) -> ReferenceKind<'_> {
+    match parent {
+        queries::comments::CommentParent::Issue(_) => {
+            ReferenceKind::IssueComment(parent_identifier, comment_id)
+        }
+        queries::comments::CommentParent::Page(page_id) => {
+            ReferenceKind::PageComment(parent_identifier, page_id, comment_id)
+        }
+    }
 }
 
-fn comment_parent_reference(
+fn comment_parent_reference_kind(
     parent_identifier: &str,
     parent: queries::comments::CommentParent,
-) -> String {
-    current_issue_link_context().map_or_else(
-        || parent_identifier.to_owned(),
-        |context| match parent {
-            queries::comments::CommentParent::Issue(_) => {
-                context.issue_markdown(parent_identifier)
-            }
-            queries::comments::CommentParent::Page(page_id) => {
-                context.page_markdown(parent_identifier, page_id)
-            }
-        },
+) -> ReferenceKind<'_> {
+    match parent {
+        queries::comments::CommentParent::Issue(_) => ReferenceKind::Issue(parent_identifier),
+        queries::comments::CommentParent::Page(page_id) => {
+            ReferenceKind::Page(parent_identifier, page_id)
+        }
+    }
+}
+
+fn issue_reference<'a>(
+    context: Option<&'a IssueLinkContext>,
+    identifier: &'a str,
+) -> Reference<'a> {
+    reference_with_context(context, ReferenceKind::Issue(identifier))
+}
+
+fn project_reference<'a>(
+    context: Option<&'a IssueLinkContext>,
+    identifier: &'a str,
+) -> Reference<'a> {
+    reference_with_context(context, ReferenceKind::Project(identifier))
+}
+
+fn page_reference<'a>(
+    context: Option<&'a IssueLinkContext>,
+    page: &'a models::Page,
+) -> Reference<'a> {
+    reference_with_context(context, ReferenceKind::Page(&page.identifier, page.id))
+}
+
+fn plan_reference<'a>(
+    context: Option<&'a IssueLinkContext>,
+    plan: &'a models::Plan,
+) -> Reference<'a> {
+    plan_reference_value(context, &plan.identifier, plan.id)
+}
+
+fn plan_reference_value<'a>(
+    context: Option<&'a IssueLinkContext>,
+    identifier: &'a str,
+    plan_id: i64,
+) -> Reference<'a> {
+    reference_with_context(context, ReferenceKind::Plan(identifier, plan_id))
+}
+
+fn module_reference<'a>(
+    context: Option<&'a IssueLinkContext>,
+    project: &'a str,
+    module: &'a models::Module,
+) -> Reference<'a> {
+    reference_with_context(
+        context,
+        ReferenceKind::Module(project, module.id, &module.name),
     )
 }
 
-fn project_reference(identifier: &str) -> String {
-    current_issue_link_context().map_or_else(
-        || identifier.to_owned(),
-        |context| context.project_markdown(identifier),
-    )
+struct IssueReferenceWithSuffix<'a> {
+    context: Option<&'a IssueLinkContext>,
+    value: &'a str,
 }
 
-fn page_reference(page: &models::Page) -> String {
-    current_issue_link_context().map_or_else(
-        || page.identifier.clone(),
-        |context| context.page_markdown(&page.identifier, page.id),
-    )
+impl Display for IssueReferenceWithSuffix<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.context, self.value.split_once(' ')) {
+            (Some(context), Some((identifier, suffix))) => match context.issue_url(identifier) {
+                Some(_) => write!(formatter, "{} {suffix}", context.issue_markdown(identifier)),
+                None => formatter.write_str(self.value),
+            },
+            (Some(context), None) => Display::fmt(&context.issue_markdown(self.value), formatter),
+            (None, _) => formatter.write_str(self.value),
+        }
+    }
 }
 
-fn plan_reference(plan: &models::Plan) -> String {
-    plan_reference_value(&plan.identifier, plan.id)
+struct IssueReferenceList<'a> {
+    label: &'a str,
+    values: &'a [String],
+    context: Option<&'a IssueLinkContext>,
 }
 
-fn plan_reference_value(identifier: &str, plan_id: i64) -> String {
-    current_issue_link_context().map_or_else(
-        || identifier.to_owned(),
-        |context| context.plan_markdown(identifier, plan_id),
-    )
+impl Display for IssueReferenceList<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.values.split_first().map_or(Ok(()), |_| {
+            formatter.write_str(self.label)?;
+            write_joined(formatter, self.values, ", ", |formatter, value| {
+                Display::fmt(
+                    &IssueReferenceWithSuffix {
+                        context: self.context,
+                        value,
+                    },
+                    formatter,
+                )
+            })?;
+            formatter.write_char('\n')
+        })
+    }
 }
 
-fn module_reference(project: &str, module: &models::Module) -> String {
-    current_issue_link_context().map_or_else(
-        || module.name.clone(),
-        |context| context.module_markdown(project, module.id, &module.name),
-    )
+struct CommentLines<'a> {
+    comments: &'a [models::Comment],
+    parent_identifier: &'a str,
+    parent: queries::comments::CommentParent,
+    context: Option<&'a IssueLinkContext>,
 }
 
-fn issue_reference_with_suffix(value: &str) -> String {
-    let Some((identifier, suffix)) = value.split_once(' ') else {
-        return issue_reference(value);
-    };
-    let rendered = issue_reference(identifier);
-    if rendered == identifier {
-        value.to_owned()
-    } else {
-        format!("{rendered} {suffix}")
+impl Display for CommentLines<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.comments.iter().try_for_each(|comment| {
+            write!(
+                formatter,
+                "[{}] {} ({})",
+                comment.created_at, comment.author, comment.author_display_name
+            )?;
+            self.context.map_or(Ok(()), |context| {
+                write!(
+                    formatter,
+                    " — {}",
+                    reference_with_context(
+                        Some(context),
+                        comment_reference_kind(self.parent_identifier, self.parent, comment.id),
+                    )
+                )
+            })?;
+            writeln!(formatter, ": {}", comment.content)
+        })
     }
 }
 
@@ -178,25 +414,71 @@ fn issue_reference_with_suffix(value: &str) -> String {
 /// Step lines carry `#<id>` so the agent can target edits, and issue-linked
 /// steps show provenance ("via LIF-42" / "reopened — LIF-42 reopened").
 pub(crate) fn fmt_plan(p: &models::Plan) -> String {
-    let anchor = p
-        .anchor_identifier
-        .as_ref()
-        .map(|a| format!(" — anchor {}", issue_reference(a)))
-        .unwrap_or_default();
-    let mut out = format!(
-        "{} [{}] {}{} — {}/{} done\n",
-        plan_reference(p),
-        p.status,
-        p.title,
-        anchor,
-        p.done_count,
-        p.step_count
-    );
-    fmt_steps(&p.steps, 0, &mut out);
-    out
+    let context = current_issue_link_context();
+    render_response(|output| {
+        write!(
+            output,
+            "{}",
+            PlanView {
+                plan: p,
+                context: context.as_deref(),
+            }
+        )
+    })
 }
 
-fn relative_age(timestamp: &str, now: DateTime<Utc>) -> Option<String> {
+struct PlanView<'a> {
+    plan: &'a models::Plan,
+    context: Option<&'a IssueLinkContext>,
+}
+
+impl Display for PlanView<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let plan = self.plan;
+        write!(
+            formatter,
+            "{} [{}] {}",
+            plan_reference(self.context, plan),
+            plan.status,
+            plan.title
+        )?;
+        plan.anchor_identifier.as_deref().map_or(Ok(()), |anchor| {
+            write!(
+                formatter,
+                " — anchor {}",
+                issue_reference(self.context, anchor)
+            )
+        })?;
+        writeln!(formatter, " — {}/{} done", plan.done_count, plan.step_count)?;
+        Display::fmt(
+            &PlanSteps {
+                nodes: &plan.steps,
+                depth: 0,
+                context: self.context,
+            },
+            formatter,
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RelativeAge {
+    Minutes(i64),
+    Hours(i64),
+    Days(i64),
+}
+
+impl Display for RelativeAge {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Minutes(value) => write!(formatter, "{value}m ago"),
+            Self::Hours(value) => write!(formatter, "{value}h ago"),
+            Self::Days(value) => write!(formatter, "{value}d ago"),
+        }
+    }
+}
+
+fn relative_age(timestamp: &str, now: DateTime<Utc>) -> Option<RelativeAge> {
     let activity_at = match NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%d %H:%M:%S") {
         Ok(timestamp) => timestamp.and_utc(),
         Err(_) => DateTime::parse_from_rfc3339(timestamp)
@@ -205,36 +487,58 @@ fn relative_age(timestamp: &str, now: DateTime<Utc>) -> Option<String> {
     };
     let minutes = now.signed_duration_since(activity_at).num_minutes().max(0);
     Some(if minutes < 60 {
-        format!("{minutes}m ago")
+        RelativeAge::Minutes(minutes)
     } else if minutes < 24 * 60 {
-        format!("{}h ago", minutes / 60)
+        RelativeAge::Hours(minutes / 60)
     } else {
-        format!("{}d ago", minutes / (24 * 60))
+        RelativeAge::Days(minutes / (24 * 60))
     })
 }
 
-fn fmt_project_agent_stats(
-    stats: &queries::ProjectAgentStats,
+#[derive(Clone, Copy)]
+enum ProjectAgentStat {
+    Workable(i64),
+    ActivePlans(i64),
+    LastActivity(RelativeAge),
+}
+
+impl Display for ProjectAgentStat {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Workable(count) => write!(formatter, "{count} workable"),
+            Self::ActivePlans(1) => formatter.write_str("1 active plan"),
+            Self::ActivePlans(count) => write!(formatter, "{count} active plans"),
+            Self::LastActivity(age) => write!(formatter, "last activity {age}"),
+        }
+    }
+}
+
+struct ProjectAgentStats<'a> {
+    stats: &'a queries::ProjectAgentStats,
     now: DateTime<Utc>,
-) -> Option<String> {
-    let mut parts = Vec::new();
-    if stats.workable > 0 {
-        parts.push(format!("{} workable", stats.workable));
-    }
-    if stats.active_plans > 0 {
-        let noun = if stats.active_plans == 1 {
-            "active plan"
-        } else {
-            "active plans"
+}
+
+impl Display for ProjectAgentStats<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let stats = self.stats;
+        let mut parts = [
+            (stats.workable > 0).then_some(ProjectAgentStat::Workable(stats.workable)),
+            (stats.active_plans > 0).then_some(ProjectAgentStat::ActivePlans(stats.active_plans)),
+            stats
+                .last_activity
+                .as_deref()
+                .and_then(|timestamp| relative_age(timestamp, self.now))
+                .map(ProjectAgentStat::LastActivity),
+        ]
+        .into_iter()
+        .flatten();
+        let Some(first) = parts.next() else {
+            return Ok(());
         };
-        parts.push(format!("{} {noun}", stats.active_plans));
+        write!(formatter, " ({first}")?;
+        parts.try_for_each(|part| write!(formatter, ", {part}"))?;
+        formatter.write_char(')')
     }
-    if let Some(last_activity) = stats.last_activity.as_deref()
-        && let Some(age) = relative_age(last_activity, now)
-    {
-        parts.push(format!("last activity {age}"));
-    }
-    (!parts.is_empty()).then(|| format!(" ({})", parts.join(", ")))
 }
 
 fn cmp_projects_by_activity(
@@ -321,66 +625,96 @@ fn issue_status_cascaded_plan_steps(
     Ok(rows.collect::<Result<Vec<_>, _>>()?)
 }
 
-fn fmt_issue_plan_step_cascade(
+struct IssuePlanStepCascade<'a> {
     action: PlanStepCascadeAction,
-    steps: &[CascadedPlanStep],
-) -> Option<String> {
-    match steps {
-        [] => None,
-        [step] => Some(format!(
-            " ({} plan step #{} in {})",
-            action.response_verb(),
-            step.id,
-            plan_reference_value(&step.plan_identifier, step.plan_id)
-        )),
-        steps => Some(format!(
-            " ({} {} plan steps: {})",
-            action.response_verb(),
-            steps.len(),
-            steps
-                .iter()
-                .map(|step| {
-                    format!(
+    steps: &'a [CascadedPlanStep],
+    context: Option<&'a IssueLinkContext>,
+}
+
+impl Display for IssuePlanStepCascade<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.steps {
+            [] => Ok(()),
+            [step] => write!(
+                formatter,
+                " ({} plan step #{} in {})",
+                self.action.response_verb(),
+                step.id,
+                plan_reference_value(self.context, &step.plan_identifier, step.plan_id)
+            ),
+            steps => {
+                write!(
+                    formatter,
+                    " ({} {} plan steps: ",
+                    self.action.response_verb(),
+                    steps.len()
+                )?;
+                write_joined(formatter, steps, ", ", |formatter, step| {
+                    write!(
+                        formatter,
                         "#{} in {}",
                         step.id,
-                        plan_reference_value(&step.plan_identifier, step.plan_id)
+                        plan_reference_value(self.context, &step.plan_identifier, step.plan_id)
                     )
-                })
-                .collect::<Vec<_>>()
-                .join(", ")
-        )),
+                })?;
+                formatter.write_char(')')
+            }
+        }
     }
 }
 
-fn fmt_steps(nodes: &[models::PlanStepNode], depth: usize, out: &mut String) {
-    for n in nodes {
-        let indent = "  ".repeat(depth);
-        let check = if n.done { "x" } else { " " };
-        // Provenance suffix for issue-linked steps.
-        let suffix = match (&n.issue_identifier, n.issue_status.as_deref()) {
-            (Some(iss), Some("done")) if n.done => {
-                format!(" (via {})", issue_reference(iss))
-            }
-            (Some(iss), _) if n.reopened_via_issue_at.is_some() && !n.done => {
-                format!(" (reopened — {} reopened)", issue_reference(iss))
-            }
-            (Some(iss), Some(st)) => format!(" [{}: {st}]", issue_reference(iss)),
-            (Some(iss), None) => format!(" [{}]", issue_reference(iss)),
-            _ => String::new(),
-        };
-        out.push_str(&format!(
-            "{indent}- [{check}] #{} {}{}\n",
-            n.id, n.title, suffix
-        ));
-        if !n.description.is_empty() {
-            out.push_str(&format!(
-                "{indent}    {}\n",
-                truncate_value(&n.description, 100)
-            ));
-        }
-        if !n.children.is_empty() {
-            fmt_steps(&n.children, depth + 1, out);
-        }
+struct PlanSteps<'a> {
+    nodes: &'a [models::PlanStepNode],
+    depth: usize,
+    context: Option<&'a IssueLinkContext>,
+}
+
+impl Display for PlanSteps<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.nodes.iter().try_for_each(|node| {
+            let check = if node.done { "x" } else { " " };
+            (0..self.depth).try_for_each(|_| formatter.write_str("  "))?;
+            write!(formatter, "- [{check}] #{} {}", node.id, node.title)?;
+            match (&node.issue_identifier, node.issue_status.as_deref()) {
+                (Some(iss), Some("done")) if node.done => {
+                    write!(formatter, " (via {})", issue_reference(self.context, iss))
+                }
+                (Some(iss), _) if node.reopened_via_issue_at.is_some() && !node.done => {
+                    write!(
+                        formatter,
+                        " (reopened — {} reopened)",
+                        issue_reference(self.context, iss)
+                    )
+                }
+                (Some(iss), Some(st)) => {
+                    write!(formatter, " [{}: {st}]", issue_reference(self.context, iss))
+                }
+                (Some(iss), None) => {
+                    write!(formatter, " [{}]", issue_reference(self.context, iss))
+                }
+                _ => Ok(()),
+            }?;
+            formatter.write_char('\n')?;
+            (!node.description.is_empty())
+                .then(|| {
+                    (0..self.depth).try_for_each(|_| formatter.write_str("  "))?;
+                    writeln!(formatter, "    {}", truncate_value(&node.description, 100))
+                })
+                .transpose()?;
+            (!node.children.is_empty())
+                .then(|| {
+                    Display::fmt(
+                        &Self {
+                            nodes: &node.children,
+                            depth: self.depth + 1,
+                            context: self.context,
+                        },
+                        formatter,
+                    )
+                })
+                .transpose()?;
+            Ok(())
+        })
     }
 }
 
@@ -483,14 +817,7 @@ fn looks_like_page_identifier(s: &str) -> bool {
 fn resolve_comment_parent(
     mcp: &LificMcp,
     identifier: &str,
-) -> Result<
-    (
-        queries::comments::CommentParent,
-        String,
-        Option<i64>,
-    ),
-    String,
-> {
+) -> Result<(queries::comments::CommentParent, String, Option<i64>), String> {
     if looks_like_page_identifier(identifier) {
         let conn = mcp.db.read().map_err(|e| e.to_string())?;
         let id = queries::resolve_page_identifier(&conn, identifier).map_err(|e| e.to_string())?;
@@ -518,14 +845,7 @@ fn resolve_comment_parent(
 fn resolve_comment_context(
     conn: &rusqlite::Connection,
     comment: &models::Comment,
-) -> Result<
-    (
-        Option<i64>,
-        queries::comments::CommentParent,
-        String,
-    ),
-    crate::error::LificError,
-> {
+) -> Result<(Option<i64>, queries::comments::CommentParent, String), crate::error::LificError> {
     if let Some(issue_id) = comment.issue_id {
         let issue = queries::get_issue(conn, issue_id)?;
         Ok((
@@ -550,24 +870,46 @@ fn resolve_comment_context(
 
 /// Append a paging hint to `out` if `has_more` is true.
 /// `next_offset` is the offset the agent should use to fetch the next page.
-fn append_pagination_hint(out: &mut String, has_more: bool, next_offset: i64) {
-    if has_more {
-        out.push_str(&format!(
-            "\n... more results available — call again with offset={next_offset}\n"
-        ));
-    }
+fn append_pagination_hint(
+    output: &mut impl fmt::Write,
+    has_more: bool,
+    next_offset: i64,
+) -> fmt::Result {
+    has_more
+        .then(|| {
+            writeln!(
+                output,
+                "\n... more results available — call again with offset={next_offset}"
+            )
+        })
+        .transpose()
+        .map(|_| ())
 }
 
 /// Truncate long values (descriptions, page bodies) for one-line activity
 /// rendering. Newlines collapse so an entry never spans lines.
-fn truncate_value(v: &str, max: usize) -> String {
-    let flat = v.replace('\n', " ");
-    if flat.chars().count() <= max {
-        flat
-    } else {
-        let cut: String = flat.chars().take(max).collect();
-        format!("{cut}…")
+struct TruncatedValue<'a> {
+    value: &'a str,
+    max: usize,
+}
+
+impl Display for TruncatedValue<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut characters = self.value.chars();
+        characters
+            .by_ref()
+            .take(self.max)
+            .try_for_each(|character| {
+                formatter.write_char(if character == '\n' { ' ' } else { character })
+            })?;
+        characters
+            .next()
+            .map_or(Ok(()), |_| formatter.write_char('…'))
     }
+}
+
+fn truncate_value(value: &str, max: usize) -> TruncatedValue<'_> {
+    TruncatedValue { value, max }
 }
 
 /// Render one audit entry as a compact line:
@@ -576,28 +918,26 @@ fn resolves_to(result: Result<i64, crate::error::LificError>, expected: i64) -> 
     result.is_ok_and(|id| id == expected)
 }
 
-fn activity_comment_reference(
+fn activity_comment_reference<'a>(
     conn: &rusqlite::Connection,
-    context: &IssueLinkContext,
+    context: &'a IssueLinkContext,
     activity: &models::Activity,
-    label: &str,
-) -> String {
+    label: &'a str,
+) -> MarkdownReference<'a> {
     let (issue_id, page_id) = if activity.action == "delete" {
         (activity.issue_id, activity.page_id)
     } else {
         let Ok(comment) = queries::comments::get_comment(conn, activity.entity_id) else {
-            return label.to_owned();
+            return MarkdownReference::plain(label);
         };
         if comment.issue_id != activity.issue_id || comment.page_id != activity.page_id {
-            return label.to_owned();
+            return MarkdownReference::plain(label);
         }
         (comment.issue_id, comment.page_id)
     };
 
     match (issue_id, page_id) {
-        (Some(issue_id), _)
-            if resolves_to(queries::resolve_identifier(conn, label), issue_id) =>
-        {
+        (Some(issue_id), _) if resolves_to(queries::resolve_identifier(conn, label), issue_id) => {
             if activity.action == "delete" {
                 context.issue_markdown(label)
             } else {
@@ -613,23 +953,23 @@ fn activity_comment_reference(
                 context.page_comment_markdown(label, page_id, activity.entity_id)
             }
         }
-        _ => label.to_owned(),
+        _ => MarkdownReference::plain(label),
     }
 }
 
-fn activity_reference(
+fn activity_reference<'a>(
     conn: &rusqlite::Connection,
-    activity: &models::Activity,
-    project: Option<&str>,
-    context: Option<&IssueLinkContext>,
-) -> String {
+    activity: &'a models::Activity,
+    project: Option<&'a str>,
+    context: Option<&'a IssueLinkContext>,
+) -> MarkdownReference<'a> {
     let label = activity.entity_label.as_deref().unwrap_or("?");
     let Some(context) = context else {
-        return label.to_owned();
+        return MarkdownReference::plain(label);
     };
     if activity.entity_type == "plan_step" {
         return queries::plans::resolve_plan_identifier(conn, label).map_or_else(
-            |_| label.to_owned(),
+            |_| MarkdownReference::plain(label),
             |plan_id| context.plan_markdown(label, plan_id),
         );
     }
@@ -637,7 +977,7 @@ fn activity_reference(
         return activity_comment_reference(conn, context, activity, label);
     }
     if activity.action == "delete" {
-        return label.to_owned();
+        return MarkdownReference::plain(label);
     }
 
     match activity.entity_type.as_str() {
@@ -652,18 +992,23 @@ fn activity_reference(
         {
             context.project_markdown(label)
         }
-        "page" if resolves_to(
-            queries::resolve_page_identifier(conn, label),
-            activity.entity_id,
-        ) => context.page_markdown(label, activity.entity_id),
-        "plan" if resolves_to(
-            queries::plans::resolve_plan_identifier(conn, label),
-            activity.entity_id,
-        ) => context.plan_markdown(label, activity.entity_id),
-        "module" => match (
-            project,
-            queries::get_module(conn, activity.entity_id).ok(),
-        ) {
+        "page"
+            if resolves_to(
+                queries::resolve_page_identifier(conn, label),
+                activity.entity_id,
+            ) =>
+        {
+            context.page_markdown(label, activity.entity_id)
+        }
+        "plan"
+            if resolves_to(
+                queries::plans::resolve_plan_identifier(conn, label),
+                activity.entity_id,
+            ) =>
+        {
+            context.plan_markdown(label, activity.entity_id)
+        }
+        "module" => match (project, queries::get_module(conn, activity.entity_id).ok()) {
             (Some(project), Some(module))
                 if Some(module.project_id) == activity.project_id
                     && resolves_to(
@@ -673,30 +1018,30 @@ fn activity_reference(
             {
                 context.module_markdown(project, activity.entity_id, label)
             }
-            _ => label.to_owned(),
+            _ => MarkdownReference::plain(label),
         },
-        _ => label.to_owned(),
+        _ => MarkdownReference::plain(label),
     }
 }
 
-fn activity_issue_reference(
+fn activity_issue_reference<'a>(
     conn: &rusqlite::Connection,
-    context: Option<&IssueLinkContext>,
-    identifier: &str,
-) -> String {
+    context: Option<&'a IssueLinkContext>,
+    identifier: &'a str,
+) -> MarkdownReference<'a> {
     let Some(context) = context else {
-        return identifier.to_owned();
+        return MarkdownReference::plain(identifier);
     };
     queries::resolve_identifier(conn, identifier).map_or_else(
-        |_| identifier.to_owned(),
+        |_| MarkdownReference::plain(identifier),
         |id| {
             queries::get_issue(conn, id).map_or_else(
-                |_| identifier.to_owned(),
+                |_| MarkdownReference::plain(identifier),
                 |issue| {
                     if issue.identifier == identifier {
                         context.issue_markdown(identifier)
                     } else {
-                        identifier.to_owned()
+                        MarkdownReference::plain(identifier)
                     }
                 },
             )
@@ -704,96 +1049,130 @@ fn activity_issue_reference(
     )
 }
 
-fn activity_field_value(
+fn activity_field_value<'a>(
     conn: &rusqlite::Connection,
-    context: Option<&IssueLinkContext>,
+    context: Option<&'a IssueLinkContext>,
     field: Option<&str>,
-    value: &str,
-) -> String {
+    value: &'a str,
+) -> ActivityFieldValue<'a> {
     if matches!(field, Some("issue" | "anchor_issue")) {
-        activity_issue_reference(conn, context, value)
+        ActivityFieldValue::Reference(activity_issue_reference(conn, context, value))
     } else {
-        truncate_value(value, 60)
+        ActivityFieldValue::Text(truncate_value(value, 60))
     }
 }
 
-fn fmt_activity(
-    conn: &rusqlite::Connection,
-    activity: &models::Activity,
-    project: Option<&str>,
-    context: Option<&IssueLinkContext>,
-) -> String {
-    let who = match (&activity.actor_display_name, &activity.actor_username) {
-        (Some(display_name), _) if !display_name.is_empty() => display_name.clone(),
-        (_, Some(username)) => username.clone(),
-        _ => "system".into(),
-    };
-    let agent = if activity.actor_is_bot {
-        " (agent)"
-    } else {
-        ""
-    };
-    let label = activity_reference(conn, activity, project, context);
+enum ActivityFieldValue<'a> {
+    Reference(MarkdownReference<'a>),
+    Text(TruncatedValue<'a>),
+}
 
-    let detail = match activity.action.as_str() {
-        "create" => format!(
-            "created {} {}: {}",
-            activity.entity_type,
-            label,
-            truncate_value(activity.new_value.as_deref().unwrap_or(""), 60)
-        ),
-        "delete" => format!(
-            "deleted {} {} ({})",
-            activity.entity_type,
-            label,
-            truncate_value(activity.old_value.as_deref().unwrap_or(""), 60)
-        ),
-        "update" => format!(
-            "{} {}: {} → {}",
-            label,
-            activity.field.as_deref().unwrap_or("?"),
-            activity_field_value(
-                conn,
-                context,
-                activity.field.as_deref(),
-                activity.old_value.as_deref().unwrap_or("(none)")
+impl Display for ActivityFieldValue<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reference(reference) => Display::fmt(reference, formatter),
+            Self::Text(value) => Display::fmt(value, formatter),
+        }
+    }
+}
+
+struct ActivityLine<'a> {
+    conn: &'a rusqlite::Connection,
+    activity: &'a models::Activity,
+    project: Option<&'a str>,
+    context: Option<&'a IssueLinkContext>,
+}
+
+impl Display for ActivityLine<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let activity = self.activity;
+        let who = match (&activity.actor_display_name, &activity.actor_username) {
+            (Some(display_name), _) if !display_name.is_empty() => display_name.as_str(),
+            (_, Some(username)) => username.as_str(),
+            _ => "system",
+        };
+        let agent = if activity.actor_is_bot {
+            " (agent)"
+        } else {
+            ""
+        };
+        let label = activity_reference(self.conn, activity, self.project, self.context);
+
+        write!(
+            formatter,
+            "[{}] {}{} via {} — ",
+            activity.ts, who, agent, activity.transport
+        )?;
+        match activity.action.as_str() {
+            "create" => write!(
+                formatter,
+                "created {} {}: {}",
+                activity.entity_type,
+                label,
+                truncate_value(activity.new_value.as_deref().unwrap_or(""), 60)
             ),
-            activity_field_value(
-                conn,
-                context,
-                activity.field.as_deref(),
-                activity.new_value.as_deref().unwrap_or("(none)")
-            )
-        ),
-        "attach" => format!(
-            "{} +label {}",
-            label,
-            activity.new_value.as_deref().unwrap_or("?")
-        ),
-        "detach" => format!(
-            "{} -label {}",
-            label,
-            activity.old_value.as_deref().unwrap_or("?")
-        ),
-        "link" => format!(
-            "{} {} → {}",
-            label,
-            activity.field.as_deref().unwrap_or("relates_to"),
-            activity_issue_reference(conn, context, activity.new_value.as_deref().unwrap_or("?"))
-        ),
-        "unlink" => format!(
-            "{} un-{} → {}",
-            label,
-            activity.field.as_deref().unwrap_or("relates_to"),
-            activity_issue_reference(conn, context, activity.old_value.as_deref().unwrap_or("?"))
-        ),
-        other => format!("{label} {other}"),
-    };
-
-    format!(
-        "[{}] {}{} via {} — {}",
-        activity.ts, who, agent, activity.transport, detail
-    )
+            "delete" => write!(
+                formatter,
+                "deleted {} {} ({})",
+                activity.entity_type,
+                label,
+                truncate_value(activity.old_value.as_deref().unwrap_or(""), 60)
+            ),
+            "update" => write!(
+                formatter,
+                "{} {}: {} → {}",
+                label,
+                activity.field.as_deref().unwrap_or("?"),
+                activity_field_value(
+                    self.conn,
+                    self.context,
+                    activity.field.as_deref(),
+                    activity.old_value.as_deref().unwrap_or("(none)")
+                ),
+                activity_field_value(
+                    self.conn,
+                    self.context,
+                    activity.field.as_deref(),
+                    activity.new_value.as_deref().unwrap_or("(none)")
+                )
+            ),
+            "attach" => write!(
+                formatter,
+                "{} +label {}",
+                label,
+                activity.new_value.as_deref().unwrap_or("?")
+            ),
+            "detach" => write!(
+                formatter,
+                "{} -label {}",
+                label,
+                activity.old_value.as_deref().unwrap_or("?")
+            ),
+            "link" => write!(
+                formatter,
+                "{} {} → {}",
+                label,
+                activity.field.as_deref().unwrap_or("relates_to"),
+                activity_issue_reference(
+                    self.conn,
+                    self.context,
+                    activity.new_value.as_deref().unwrap_or("?")
+                )
+            ),
+            "unlink" => write!(
+                formatter,
+                "{} un-{} → {}",
+                label,
+                activity.field.as_deref().unwrap_or("relates_to"),
+                activity_issue_reference(
+                    self.conn,
+                    self.context,
+                    activity.old_value.as_deref().unwrap_or("?")
+                )
+            ),
+            other => write!(formatter, "{label} {other}"),
+        }
+    }
 }
 
 // ── LIF-198: MCP authorization gates ────────────────────────────
@@ -1030,62 +1409,51 @@ impl LificMcp {
                     results.truncate(limit as usize);
                 }
                 let link_context = current_issue_link_context();
-                let mut out = format!("{} results:\n", results.len());
-                for r in &results {
-                    let ident = r.identifier.as_deref().unwrap_or("");
-                    // A comment hit has no title of its own; render it as a
-                    // match on its parent so the reader knows to open the
-                    // parent issue/page to find the thread (LIF-146).
-                    if r.result_type == "comment" {
-                        let page_id = r.parent_page_id;
-                        let parent = link_context.as_ref().map_or_else(
-                            || ident.to_owned(),
-                            |context| {
-                                page_id.map_or_else(
-                                    || context.issue_markdown(ident),
-                                    |page_id| context.page_markdown(ident, page_id),
-                                )
-                            },
-                        );
-                        let comment = link_context.as_ref().map_or_else(
-                            || "[comment]".to_owned(),
-                            |context| page_id.map_or_else(
-                                || context.issue_comment_markdown(ident, r.id),
-                                |page_id| context.page_comment_markdown(ident, page_id, r.id),
-                            ),
-                        );
-                        out.push_str(&format!(
-                            "- {} on {} — {}\n",
-                            comment, parent, r.snippet
-                        ));
-                    } else {
-                        let identifier = if r.result_type == "page" {
-                            link_context.as_ref().map_or_else(
-                                || ident.to_owned(),
-                                |context| context.page_markdown(ident, r.id),
-                            )
-                        } else if r.result_type == "plan" {
-                            link_context.as_ref().map_or_else(
-                                || ident.to_owned(),
-                                |context| context.plan_markdown(ident, r.id),
-                            )
+                render_response(|output| {
+                    writeln!(output, "{} results:", results.len())?;
+                    results.iter().try_for_each(|result| {
+                        let identifier = result.identifier.as_deref().unwrap_or("");
+                        // A comment hit has no title of its own; render it as a
+                        // match on its parent so the reader knows to open the
+                        // parent issue/page to find the thread (LIF-146).
+                        if result.result_type == "comment" {
+                            let page_id = result.parent_page_id;
+                            let parent = reference_with_context(
+                                link_context.as_deref(),
+                                page_id.map_or(ReferenceKind::Issue(identifier), |page_id| {
+                                    ReferenceKind::Page(identifier, page_id)
+                                }),
+                            );
+                            let comment = reference_with_context(
+                                link_context.as_deref(),
+                                page_id.map_or(
+                                    ReferenceKind::IssueSearchComment(identifier, result.id),
+                                    |page_id| {
+                                        ReferenceKind::PageSearchComment(
+                                            identifier, page_id, result.id,
+                                        )
+                                    },
+                                ),
+                            );
+                            writeln!(output, "- {comment} on {parent} — {}", result.snippet)
                         } else {
-                            link_context.as_ref().map_or_else(
-                                || ident.to_owned(),
-                                |context| context.issue_markdown(ident),
+                            let kind = match result.result_type.as_str() {
+                                "page" => ReferenceKind::Page(identifier, result.id),
+                                "plan" => ReferenceKind::Plan(identifier, result.id),
+                                _ => ReferenceKind::Issue(identifier),
+                            };
+                            writeln!(
+                                output,
+                                "- [{}] {} {} — {}",
+                                result.result_type,
+                                reference_with_context(link_context.as_deref(), kind),
+                                result.title,
+                                result.snippet
                             )
-                        };
-                        out.push_str(&format!(
-                            "- [{}] {} {} — {}\n",
-                            r.result_type,
-                            identifier,
-                            r.title,
-                            r.snippet
-                        ));
-                    }
-                }
-                append_pagination_hint(&mut out, has_more, offset + limit);
-                out
+                        }
+                    })?;
+                    append_pagination_hint(output, has_more, offset + limit)
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1102,65 +1470,61 @@ impl LificMcp {
         // Resolve the identifier shape: page → issue → project. Pages are
         // unambiguous (DOC segment); issue resolution requires a numeric
         // tail, so a bare project identifier falls through cleanly.
-        let (scope, project_id, scope_reference, project_identifier) =
+        let (scope, project_id, scope_reference, scope_identifier, project_identifier) =
             if looks_like_page_identifier(ident) {
-            match self.read(|conn| {
-                let id = queries::resolve_page_identifier(conn, ident)?;
-                let page = queries::get_page(conn, id)?;
-                let project_identifier = page
-                    .project_id
-                    .and_then(|project_id| queries::get_project(conn, project_id).ok())
-                    .map(|project| project.identifier);
-                let scope_reference = page_reference(&page);
-                Ok((page, scope_reference, project_identifier))
-            }) {
-                Ok((page, scope_reference, project_identifier)) => {
-                    (
+                match self.read(|conn| {
+                    let id = queries::resolve_page_identifier(conn, ident)?;
+                    let page = queries::get_page(conn, id)?;
+                    let project_identifier = page
+                        .project_id
+                        .and_then(|project_id| queries::get_project(conn, project_id).ok())
+                        .map(|project| project.identifier);
+                    Ok((page, project_identifier))
+                }) {
+                    Ok((page, project_identifier)) => (
                         queries::activity::ActivityScope::Page(page.id),
                         page.project_id,
-                        scope_reference,
+                        ActivityScopeReference::Page(page.id),
+                        page.identifier,
                         project_identifier,
-                    )
+                    ),
+                    Err(e) => return format!("Error: {e}"),
                 }
-                Err(e) => return format!("Error: {e}"),
-            }
-        } else if let Ok(issue) = self.read(|conn| {
-            let id = queries::resolve_identifier(conn, ident)?;
-            let issue = queries::get_issue(conn, id)?;
-            let project_identifier = queries::get_project(conn, issue.project_id)
-                .ok()
-                .map(|project| project.identifier);
-            let scope_reference = issue_reference(&issue.identifier);
-            Ok((issue, scope_reference, project_identifier))
-        }) {
-            let (issue, scope_reference, project_identifier) = issue;
-            (
-                queries::activity::ActivityScope::Issue(issue.id),
-                Some(issue.project_id),
-                scope_reference,
-                project_identifier,
-            )
-        } else {
-            match self.read(|conn| {
-                let id = queries::resolve_project_identifier(conn, ident)?;
-                queries::get_project(conn, id)
+            } else if let Ok(issue) = self.read(|conn| {
+                let id = queries::resolve_identifier(conn, ident)?;
+                let issue = queries::get_issue(conn, id)?;
+                let project_identifier = queries::get_project(conn, issue.project_id)
+                    .ok()
+                    .map(|project| project.identifier);
+                Ok((issue, project_identifier))
             }) {
-                Ok(project) => {
-                    let project_identifier = project.identifier.clone();
-                    (
+                let (issue, project_identifier) = issue;
+                (
+                    queries::activity::ActivityScope::Issue(issue.id),
+                    Some(issue.project_id),
+                    ActivityScopeReference::Issue,
+                    issue.identifier,
+                    project_identifier,
+                )
+            } else {
+                match self.read(|conn| {
+                    let id = queries::resolve_project_identifier(conn, ident)?;
+                    queries::get_project(conn, id)
+                }) {
+                    Ok(project) => (
                         queries::activity::ActivityScope::Project(project.id),
                         Some(project.id),
-                        project_reference(&project.identifier),
-                        Some(project_identifier),
-                    )
+                        ActivityScopeReference::Project,
+                        project.identifier,
+                        None,
+                    ),
+                    Err(_) => {
+                        return format!(
+                            "Error: '{ident}' is not a known issue, page, or project identifier"
+                        );
+                    }
                 }
-                Err(_) => {
-                    return format!(
-                        "Error: '{ident}' is not a known issue, page, or project identifier"
-                    );
-                }
-            }
-        };
+            };
 
         // LIF-198: resolve the scope's project (Viewer gate); workspace
         // pages (project_id None) fall back to admin-only.
@@ -1169,38 +1533,60 @@ impl LificMcp {
         }
 
         let link_context = current_issue_link_context();
+        let scope_reference = reference_with_context(
+            link_context.as_deref(),
+            match scope_reference {
+                ActivityScopeReference::Issue => ReferenceKind::Issue(&scope_identifier),
+                ActivityScopeReference::Page(page_id) => {
+                    ReferenceKind::Page(&scope_identifier, page_id)
+                }
+                ActivityScopeReference::Project => ReferenceKind::Project(&scope_identifier),
+            },
+        );
+        let activity_project_identifier = project_identifier.as_deref().or(matches!(
+            scope_reference.kind,
+            ReferenceKind::Project(_)
+        )
+        .then_some(scope_identifier.as_str()));
         match self.read(|conn| {
             let feed = queries::activity::list_activity(conn, scope, Some(limit), Some(offset))?;
-            // ponytail: feeds cap at 200; batch target checks only if this read path profiles hot.
-            let items: Vec<_> = feed
-                .items
-                .iter()
-                .map(|activity| {
-                    fmt_activity(
-                        conn,
-                        activity,
-                        project_identifier.as_deref(),
-                        link_context.as_ref(),
+            if feed.items.is_empty() {
+                return Ok((None, 0, feed.has_more));
+            }
+            let output = try_render(|output| {
+                writeln!(
+                    output,
+                    "{} activity entries for {scope_reference}:",
+                    feed.items.len()
+                )?;
+                feed.items.iter().try_for_each(|activity| {
+                    writeln!(
+                        output,
+                        "- {}",
+                        ActivityLine {
+                            conn,
+                            activity,
+                            project: activity_project_identifier,
+                            context: link_context.as_deref(),
+                        }
                     )
                 })
-                .collect();
-            Ok((items, feed.has_more))
+            })
+            .map_err(|error| {
+                crate::error::LificError::Internal(format!(
+                    "failed to format activity response: {error}"
+                ))
+            })?;
+            Ok((Some(output), feed.items.len(), feed.has_more))
         }) {
-            Ok((items, _)) if items.is_empty() && offset == 0 => {
-                format!("No recorded activity for {scope_reference} yet.")
+            Ok((None, _, _)) if offset == 0 => render_response(|output| {
+                write!(output, "No recorded activity for {scope_reference} yet.")
+            }),
+            Ok((Some(mut out), _, has_more)) => {
+                let result = append_pagination_hint(&mut out, has_more, offset + limit);
+                finish_response(out, result)
             }
-            Ok((items, has_more)) => {
-                let mut out = format!(
-                    "{} activity entries for {}:\n",
-                    items.len(),
-                    scope_reference
-                );
-                for item in &items {
-                    out.push_str(&format!("- {item}\n"));
-                }
-                append_pagination_hint(&mut out, has_more, offset + limit);
-                out
-            }
+            Ok((None, _, _)) => "No activity entries in this range.".into(),
             Err(e) => format!("Error: {e}"),
         }
     }
@@ -1258,15 +1644,20 @@ impl LificMcp {
                     issues.truncate(limit as usize);
                 }
                 let context = current_issue_link_context();
-                let mut out = format!("{} issues:\n", issues.len());
-                for i in &issues {
-                    out.push_str(&format!(
-                        "- {}\n",
-                        fmt_issue_with_context(i, context.as_ref())
-                    ));
-                }
-                append_pagination_hint(&mut out, has_more, offset + limit);
-                out
+                render_response(|output| {
+                    writeln!(output, "{} issues:", issues.len())?;
+                    issues.iter().try_for_each(|issue| {
+                        writeln!(
+                            output,
+                            "- {}",
+                            IssueLine {
+                                issue,
+                                context: context.as_deref(),
+                            }
+                        )
+                    })?;
+                    append_pagination_hint(output, has_more, offset + limit)
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1321,143 +1712,100 @@ impl LificMcp {
                 if let Err(e) = require_role_mcp(&self.db, issue.project_id, models::Role::Viewer) {
                     return format!("Error: {e}");
                 }
-                let mut out = format!(
-                    "{} — {}\nStatus: {} | Priority: {} | Module: {}\n",
-                    issue_reference(&issue.identifier),
-                    issue.title,
-                    issue.status,
-                    issue.priority,
-                    module_name
-                );
-                if !issue.labels.is_empty() {
-                    out.push_str(&format!("Labels: {}\n", issue.labels.join(", ")));
-                }
-                if !rels.blocks.is_empty() {
-                    out.push_str(&format!(
-                        "Blocks: {}\n",
-                        rels.blocks
-                            .iter()
-                            .map(|r| issue_reference_with_suffix(r))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ));
-                }
-                if !rels.blocked_by.is_empty() {
-                    out.push_str(&format!(
-                        "Blocked by: {}\n",
-                        rels.blocked_by
-                            .iter()
-                            .map(|r| issue_reference_with_suffix(r))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ));
-                }
-                if !rels.relates_to.is_empty() {
-                    out.push_str(&format!(
-                        "Relates to: {}\n",
-                        rels.relates_to
-                            .iter()
-                            .map(|r| issue_reference_with_suffix(r))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ));
-                }
-                if !rels.duplicates.is_empty() {
-                    out.push_str(&format!(
-                        "Duplicates: {}\n",
-                        rels.duplicates
-                            .iter()
-                            .map(|r| issue_reference_with_suffix(r))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ));
-                }
-                if !rels.duplicated_by.is_empty() {
-                    out.push_str(&format!(
-                        "Duplicated by: {}\n",
-                        rels.duplicated_by
-                            .iter()
-                            .map(|r| issue_reference_with_suffix(r))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ));
-                }
-                if !issue.description.is_empty() {
-                    out.push_str(&format!("\n{}\n", issue.description));
-                }
-                // Include comments per the requested trail mode (LIF-301).
-                if let Ok(comments) = self.read(|conn| {
-                    queries::comments::list_comments(
-                        conn,
-                        queries::comments::CommentParent::Issue(issue.id),
-                        None,
-                        None,
-                    )
-                }) && !comments.is_empty()
-                {
-                    let total = comments.len();
-                    match comment_mode {
-                        // Emit only a stub pointing at list_comments.
-                        "none" => {
-                            out.push_str(&format!(
-                                "\n--- Comments ({total}, omitted — use list_comments) ---\n"
-                            ));
-                        }
-                        // Last 3 by default; full header only when truncating.
-                        "recent" if total > 3 => {
-                            out.push_str(&format!(
-                                "\n--- Comments ({total}, showing last 3 — use list_comments) ---\n"
-                            ));
-                            for c in &comments[total - 3..] {
-                                if current_issue_link_context().is_some() {
-                                    out.push_str(&format!(
-                                        "[{}] {} ({}) — {}: {}\n",
-                                        c.created_at,
-                                        c.author,
-                                        c.author_display_name,
-                                        comment_reference(
-                                            &issue.identifier,
-                                            queries::comments::CommentParent::Issue(issue.id),
-                                            c.id
-                                        ),
-                                        c.content
-                                    ));
-                                } else {
-                                    out.push_str(&format!(
-                                        "[{}] {} ({}): {}\n",
-                                        c.created_at, c.author, c.author_display_name, c.content
-                                    ));
-                                }
+                let context = current_issue_link_context();
+                let comments = self
+                    .read(|conn| {
+                        queries::comments::list_comments(
+                            conn,
+                            queries::comments::CommentParent::Issue(issue.id),
+                            None,
+                            None,
+                        )
+                    })
+                    .ok()
+                    .filter(|comments| !comments.is_empty());
+                render_response(|output| {
+                    writeln!(
+                        output,
+                        "{} — {}\nStatus: {} | Priority: {} | Module: {}",
+                        issue_reference(context.as_deref(), &issue.identifier),
+                        issue.title,
+                        issue.status,
+                        issue.priority,
+                        module_name
+                    )?;
+                    issue.labels.split_first().map_or(Ok(()), |_| {
+                        writeln!(
+                            output,
+                            "Labels: {}",
+                            JoinedStrings {
+                                values: &issue.labels,
+                                separator: ", ",
+                            }
+                        )
+                    })?;
+                    [
+                        ("Blocks: ", rels.blocks.as_slice()),
+                        ("Blocked by: ", rels.blocked_by.as_slice()),
+                        ("Relates to: ", rels.relates_to.as_slice()),
+                        ("Duplicates: ", rels.duplicates.as_slice()),
+                        ("Duplicated by: ", rels.duplicated_by.as_slice()),
+                    ]
+                    .into_iter()
+                    .try_for_each(|(label, values)| {
+                        write!(
+                            output,
+                            "{}",
+                            IssueReferenceList {
+                                label,
+                                values,
+                                context: context.as_deref(),
+                            }
+                        )
+                    })?;
+                    (!issue.description.is_empty())
+                        .then(|| writeln!(output, "\n{}", issue.description))
+                        .transpose()?;
+                    comments.as_ref().map_or(Ok(()), |comments| {
+                        let total = comments.len();
+                        let parent = queries::comments::CommentParent::Issue(issue.id);
+                        match comment_mode {
+                            "none" => writeln!(
+                                output,
+                                "\n--- Comments ({total}, omitted — use list_comments) ---"
+                            ),
+                            "recent" if total > 3 => {
+                                writeln!(
+                                    output,
+                                    "\n--- Comments ({total}, showing last 3 — use list_comments) ---"
+                                )?;
+                                write!(
+                                    output,
+                                    "{}",
+                                    CommentLines {
+                                        comments: &comments[total - 3..],
+                                        parent_identifier: &issue.identifier,
+                                        parent,
+                                        context: context.as_deref(),
+                                    }
+                                )
+                            }
+                            _ => {
+                                writeln!(output, "\n--- Comments ({total}) ---")?;
+                                write!(
+                                    output,
+                                    "{}",
+                                    CommentLines {
+                                        comments,
+                                        parent_identifier: &issue.identifier,
+                                        parent,
+                                        context: context.as_deref(),
+                                    }
+                                )
                             }
                         }
-                        // "all", or "recent" with <= 3 comments: today's format.
-                        _ => {
-                            out.push_str(&format!("\n--- Comments ({total}) ---\n"));
-                            for c in &comments {
-                                if current_issue_link_context().is_some() {
-                                    out.push_str(&format!(
-                                        "[{}] {} ({}) — {}: {}\n",
-                                        c.created_at,
-                                        c.author,
-                                        c.author_display_name,
-                                        comment_reference(
-                                            &issue.identifier,
-                                            queries::comments::CommentParent::Issue(issue.id),
-                                            c.id
-                                        ),
-                                        c.content
-                                    ));
-                                } else {
-                                    out.push_str(&format!(
-                                        "[{}] {} ({}): {}\n",
-                                        c.created_at, c.author, c.author_display_name, c.content
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-                out
+                    })
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1520,13 +1868,13 @@ impl LificMcp {
                 return format!("Error: {e}");
             }
             match self.read(|conn| crate::export::export_project(conn, ident)) {
-                Ok(bundle) => {
-                    let mut out = format!("{} exported file(s):\n", bundle.files.len());
-                    for file in bundle.files {
-                        out.push_str(&format!("- {}\n", file.path));
-                    }
-                    out
-                }
+                Ok(bundle) => render_response(|output| {
+                    writeln!(output, "{} exported file(s):", bundle.files.len())?;
+                    bundle
+                        .files
+                        .iter()
+                        .try_for_each(|file| writeln!(output, "- {}", file.path))
+                }),
                 Err(e) => format!("Error: {e}"),
             }
         }
@@ -1570,11 +1918,15 @@ impl LificMcp {
                     project_id: issue.project_id,
                     issue_id: issue.id,
                 });
-                format!(
-                    "Created {}: {}",
-                    issue_reference(&issue.identifier),
-                    issue.title
-                )
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    write!(
+                        output,
+                        "Created {}: {}",
+                        issue_reference(context.as_deref(), &issue.identifier),
+                        issue.title
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1601,15 +1953,15 @@ impl LificMcp {
             // Keep an audit checkpoint before the direct issue update so the
             // response can name only steps the trigger actually changed.
             let previous_issue = queries::get_issue(conn, id)?;
-            let audit_checkpoint = if input.status.is_some() {
-                Some(
+            let audit_checkpoint = input
+                .status
+                .as_ref()
+                .map(|_| {
                     conn.query_row("SELECT COALESCE(MAX(id), 0) FROM audit_log", [], |row| {
                         row.get(0)
-                    })?,
-                )
-            } else {
-                None
-            };
+                    })
+                })
+                .transpose()?;
             // LIF-145 sentinel: field omitted (None) = skip, empty string = clear
             // (unassign module), non-empty = resolve + set.
             let module_id = match &input.module {
@@ -1656,17 +2008,32 @@ impl LificMcp {
                     project_id: issue.project_id,
                     issue_id: issue.id,
                 });
-                let mut output = format!(
-                    "Updated {}: {}",
-                    issue_reference(&issue.identifier),
-                    fmt_issue(&issue)
-                );
-                if let Some(note) = cascade_action
-                    .and_then(|action| fmt_issue_plan_step_cascade(action, &cascaded_steps))
-                {
-                    output.push_str(&note);
-                }
-                output
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    write!(
+                        output,
+                        "Updated {}: {}",
+                        IssueReference {
+                            context: context.as_deref(),
+                            identifier: &issue.identifier,
+                        },
+                        IssueLine {
+                            issue: &issue,
+                            context: context.as_deref(),
+                        }
+                    )?;
+                    cascade_action.map_or(Ok(()), |action| {
+                        write!(
+                            output,
+                            "{}",
+                            IssuePlanStepCascade {
+                                action,
+                                steps: &cascaded_steps,
+                                context: context.as_deref(),
+                            }
+                        )
+                    })
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1821,11 +2188,21 @@ impl LificMcp {
                     project_id: issue.project_id,
                     issue_id: issue.id,
                 });
-                format!(
-                    "Edited {}: {}",
-                    issue_reference(&issue.identifier),
-                    fmt_issue(&issue)
-                )
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    write!(
+                        output,
+                        "Edited {}: {}",
+                        IssueReference {
+                            context: context.as_deref(),
+                            identifier: &issue.identifier,
+                        },
+                        IssueLine {
+                            issue: &issue,
+                            context: context.as_deref(),
+                        }
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1924,55 +2301,65 @@ impl LificMcp {
                 };
                 let mut ordered: Vec<(&String, &Vec<&models::Issue>)> = groups.iter().collect();
                 ordered.sort_by_key(|(key, _)| rank(key));
-                let mut out = String::new();
-                if truncated {
-                    out.push_str(&format!(
-                        "warning: board view capped at {BOARD_CAP} issues — older issues are not shown. Use list_issues with offset for full paging.\n\n"
-                    ));
-                }
                 let context = current_issue_link_context();
                 let max_per_column = input.max_per_column.filter(|n| *n >= 0);
-                for (group, items) in ordered {
-                    // Status grouping keeps closed groups as count-only stubs:
-                    // header + stub on ONE line, replacing the item lines. Only
-                    // reached for non-empty groups (empty groups never enter
-                    // `groups`).
-                    if !include_closed
-                        && group_by == "status"
-                        && (group == "done" || group == "cancelled")
-                    {
-                        out.push_str(&format!(
-                            "── {} ({}) ── [omitted — pass include_closed=true]\n\n",
-                            group,
-                            items.len()
-                        ));
-                        continue;
-                    }
-                    out.push_str(&format!("── {} ({}) ──\n", group, items.len()));
-                    let shown = match max_per_column {
-                        Some(n) => (n as usize).min(items.len()),
-                        None => items.len(),
-                    };
-                    for i in &items[..shown] {
-                        out.push_str(&format!(
-                            "  {}\n",
-                            fmt_issue_with_context(i, context.as_ref())
-                        ));
-                    }
-                    if shown < items.len() {
-                        out.push_str(&format!(
-                            "  … +{} more (use list_issues)\n",
-                            items.len() - shown
-                        ));
-                    }
-                    out.push('\n');
-                }
-                if closed_omitted > 0 {
-                    out.push_str(&format!(
-                        "({closed_omitted} closed issues omitted — pass include_closed=true)\n"
-                    ));
-                }
-                out
+                render_response(|output| {
+                    truncated
+                        .then(|| {
+                            writeln!(
+                                output,
+                                "warning: board view capped at {BOARD_CAP} issues — older issues are not shown. Use list_issues with offset for full paging.\n"
+                            )
+                        })
+                        .transpose()?;
+                    ordered.into_iter().try_for_each(|(group, items)| {
+                        // Status grouping keeps closed groups as count-only stubs:
+                        // header + stub on ONE line, replacing the item lines.
+                        let closed_stub = !include_closed
+                            && group_by == "status"
+                            && matches!(group.as_str(), "done" | "cancelled");
+                        if closed_stub {
+                            return writeln!(
+                                output,
+                                "── {} ({}) ── [omitted — pass include_closed=true]\n",
+                                group,
+                                items.len()
+                            );
+                        }
+                        writeln!(output, "── {} ({}) ──", group, items.len())?;
+                        let shown = max_per_column
+                            .map_or(items.len(), |limit| (limit as usize).min(items.len()));
+                        items[..shown].iter().try_for_each(|issue| {
+                            writeln!(
+                                output,
+                                "  {}",
+                                IssueLine {
+                                    issue,
+                                    context: context.as_deref(),
+                                }
+                            )
+                        })?;
+                        (shown < items.len())
+                            .then(|| {
+                                writeln!(
+                                    output,
+                                    "  … +{} more (use list_issues)",
+                                    items.len() - shown
+                                )
+                            })
+                            .transpose()?;
+                        output.write_char('\n')
+                    })?;
+                    (closed_omitted > 0)
+                        .then(|| {
+                            writeln!(
+                                output,
+                                "({closed_omitted} closed issues omitted — pass include_closed=true)"
+                            )
+                        })
+                        .transpose()
+                        .map(|_| ())
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -2011,12 +2398,16 @@ impl LificMcp {
                     project_id: target.project_id,
                     issue_id: target.id,
                 });
-                format!(
-                    "{} {} {}",
-                    issue_reference(&source.identifier),
-                    input.relation_type,
-                    issue_reference(&target.identifier)
-                )
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    write!(
+                        output,
+                        "{} {} {}",
+                        issue_reference(context.as_deref(), &source.identifier),
+                        input.relation_type,
+                        issue_reference(context.as_deref(), &target.identifier)
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -2051,11 +2442,15 @@ impl LificMcp {
                     project_id: target.project_id,
                     issue_id: target.id,
                 });
-                format!(
-                    "Unlinked {} and {}",
-                    issue_reference(&source.identifier),
-                    issue_reference(&target.identifier)
-                )
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    write!(
+                        output,
+                        "Unlinked {} and {}",
+                        issue_reference(context.as_deref(), &source.identifier),
+                        issue_reference(context.as_deref(), &target.identifier)
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -2078,23 +2473,34 @@ impl LificMcp {
                 {
                     return format!("Error: {e}");
                 }
-                let mut out = format!(
-                    "{}{} — {}\nStatus: {} | Folder: {}\nCreated: {} | Updated: {}\n",
-                    if page.pinned { "📌 " } else { "" },
-                    page_reference(&page),
-                    page.title,
-                    page.status,
-                    folder_name.as_deref().unwrap_or("none"),
-                    page.created_at,
-                    page.updated_at
-                );
-                if !page.labels.is_empty() {
-                    out.push_str(&format!("Labels: {}\n", page.labels.join(", ")));
-                }
-                if !page.content.is_empty() {
-                    out.push_str(&format!("\n{}\n", page.content));
-                }
-                out
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    writeln!(
+                        output,
+                        "{}{} — {}\nStatus: {} | Folder: {}\nCreated: {} | Updated: {}",
+                        if page.pinned { "📌 " } else { "" },
+                        page_reference(context.as_deref(), &page),
+                        page.title,
+                        page.status,
+                        folder_name.as_deref().unwrap_or("none"),
+                        page.created_at,
+                        page.updated_at
+                    )?;
+                    page.labels.split_first().map_or(Ok(()), |_| {
+                        writeln!(
+                            output,
+                            "Labels: {}",
+                            JoinedStrings {
+                                values: &page.labels,
+                                separator: ", ",
+                            }
+                        )
+                    })?;
+                    (!page.content.is_empty())
+                        .then(|| writeln!(output, "\n{}", page.content))
+                        .transpose()
+                        .map(|_| ())
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -2137,7 +2543,15 @@ impl LificMcp {
                 if let Some(project_id) = page.project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                format!("Created {}: {}", page_reference(&page), page.title)
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    write!(
+                        output,
+                        "Created {}: {}",
+                        page_reference(context.as_deref(), &page),
+                        page.title
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -2190,7 +2604,15 @@ impl LificMcp {
                 if let Some(project_id) = page.project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                format!("Updated {}: {}", page_reference(&page), page.title)
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    write!(
+                        output,
+                        "Updated {}: {}",
+                        page_reference(context.as_deref(), &page),
+                        page.title
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -2263,7 +2685,15 @@ impl LificMcp {
                 if let Some(project_id) = page.project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                format!("Edited {}: {}", page_reference(&page), page.title)
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    write!(
+                        output,
+                        "Edited {}: {}",
+                        page_reference(context.as_deref(), &page),
+                        page.title
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -2423,6 +2853,7 @@ impl LificMcp {
         description = "List resources by type: project, module, label, folder, page, issue, or plan. Most types need a project identifier."
     )]
     fn list_resources(&self, Parameters(input): Parameters<ListResourcesInput>) -> String {
+        let context = current_issue_link_context();
         match input.resource_type.as_str() {
             "plan" => {
                 let Some(ref proj) = input.project else {
@@ -2450,26 +2881,28 @@ impl LificMcp {
                     )
                 }) {
                     Ok(plans) if plans.is_empty() => "No plans found.".into(),
-                    Ok(plans) => {
-                        let mut out = format!("{} plans:\n", plans.len());
-                        for p in &plans {
-                            let anchor = p
-                                .anchor_identifier
-                                .as_ref()
-                                .map(|a| format!(" — anchor {}", issue_reference(a)))
-                                .unwrap_or_default();
-                            out.push_str(&format!(
-                                "- {} | {} | {} ({}/{} done){}\n",
-                                plan_reference(p),
-                                p.status,
-                                p.title,
-                                p.done_count,
-                                p.step_count,
-                                anchor
-                            ));
-                        }
-                        out
-                    }
+                    Ok(plans) => render_response(|output| {
+                        writeln!(output, "{} plans:", plans.len())?;
+                        plans.iter().try_for_each(|plan| {
+                            write!(
+                                output,
+                                "- {} | {} | {} ({}/{} done)",
+                                plan_reference(context.as_deref(), plan),
+                                plan.status,
+                                plan.title,
+                                plan.done_count,
+                                plan.step_count
+                            )?;
+                            plan.anchor_identifier.as_deref().map_or(Ok(()), |anchor| {
+                                write!(
+                                    output,
+                                    " — anchor {}",
+                                    issue_reference(context.as_deref(), anchor)
+                                )
+                            })?;
+                            output.write_char('\n')
+                        })
+                    }),
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -2494,22 +2927,25 @@ impl LificMcp {
                     Ok((ps, stats)) => {
                         let mut ps = filter_visible(ps, &visible, |p| Some(p.id));
                         ps.sort_by(|left, right| cmp_projects_by_activity(left, right, &stats));
-                        let mut out = format!("{} projects:\n", ps.len());
                         let now = Utc::now();
-                        for p in &ps {
-                            out.push_str(&format!("- {} | {}", project_reference(&p.identifier), p.name));
-                            if !p.description.is_empty() {
-                                out.push_str(&format!(" — {}", p.description));
-                            }
-                            if let Some(suffix) = stats
-                                .get(&p.id)
-                                .and_then(|stats| fmt_project_agent_stats(stats, now))
-                            {
-                                out.push_str(&suffix);
-                            }
-                            out.push('\n');
-                        }
-                        out
+                        render_response(|output| {
+                            writeln!(output, "{} projects:", ps.len())?;
+                            ps.iter().try_for_each(|project| {
+                                write!(
+                                    output,
+                                    "- {} | {}",
+                                    project_reference(context.as_deref(), &project.identifier,),
+                                    project.name
+                                )?;
+                                (!project.description.is_empty())
+                                    .then(|| write!(output, " — {}", project.description))
+                                    .transpose()?;
+                                stats.get(&project.id).map_or(Ok(()), |stats| {
+                                    write!(output, "{}", ProjectAgentStats { stats, now })
+                                })?;
+                                output.write_char('\n')
+                            })
+                        })
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2543,18 +2979,23 @@ impl LificMcp {
                         if has_more {
                             issues.truncate(limit as usize);
                         }
-                        let mut out =
-                            format!("{} issues (use list_issues for filtering):\n", issues.len());
-                        for i in &issues {
-                            out.push_str(&format!(
-                                "- {} | {} | {}\n",
-                                issue_reference(&i.identifier),
-                                i.status,
-                                i.title
-                            ));
-                        }
-                        append_pagination_hint(&mut out, has_more, offset + limit);
-                        out
+                        render_response(|output| {
+                            writeln!(
+                                output,
+                                "{} issues (use list_issues for filtering):",
+                                issues.len()
+                            )?;
+                            issues.iter().try_for_each(|issue| {
+                                writeln!(
+                                    output,
+                                    "- {} | {} | {}",
+                                    issue_reference(context.as_deref(), &issue.identifier),
+                                    issue.status,
+                                    issue.title
+                                )
+                            })?;
+                            append_pagination_hint(output, has_more, offset + limit)
+                        })
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2631,39 +3072,44 @@ impl LificMcp {
                         if has_more {
                             pages.truncate(limit as usize);
                         }
-                        let mut out = format!("{} pages:\n", pages.len());
-                        for p in &pages {
-                            // Mirror `fmt_issue`: only suffix the label
-                            // bracket when there's something to show, so
-                            // unlabeled pages stay terse.
-                            let labels = if p.labels.is_empty() {
-                                String::new()
-                            } else {
-                                format!(" [{}]", p.labels.join(", "))
-                            };
-                            let folder = p
-                                .folder_id
-                                .and_then(|fid| folder_names.get(&fid))
-                                .map(|name| format!(" (folder: {name})"))
-                                .unwrap_or_default();
-                            // Timestamps are "YYYY-MM-DD HH:MM:SS"; the date
-                            // part keeps list lines scannable. Full stamps
-                            // live on get_page.
-                            let updated = p.updated_at.split(' ').next().unwrap_or(&p.updated_at);
-                            let pin = if p.pinned { "📌 " } else { "" };
-                            out.push_str(&format!(
-                                "- {}{} | {} | {}{}{} — updated {}\n",
-                                pin,
-                                page_reference(p),
-                                p.status,
-                                p.title,
-                                labels,
-                                folder,
-                                updated
-                            ));
-                        }
-                        append_pagination_hint(&mut out, has_more, offset + limit);
-                        out
+                        render_response(|output| {
+                            writeln!(output, "{} pages:", pages.len())?;
+                            pages.iter().try_for_each(|page| {
+                                // Timestamps are "YYYY-MM-DD HH:MM:SS"; the date
+                                // part keeps list lines scannable. Full stamps
+                                // live on get_page.
+                                let updated = page
+                                    .updated_at
+                                    .split(' ')
+                                    .next()
+                                    .unwrap_or(&page.updated_at);
+                                let pin = if page.pinned { "📌 " } else { "" };
+                                write!(
+                                    output,
+                                    "- {pin}{} | {} | {}",
+                                    page_reference(context.as_deref(), page),
+                                    page.status,
+                                    page.title
+                                )?;
+                                page.labels.split_first().map_or(Ok(()), |_| {
+                                    write!(
+                                        output,
+                                        " [{}]",
+                                        JoinedStrings {
+                                            values: &page.labels,
+                                            separator: ", ",
+                                        }
+                                    )
+                                })?;
+                                page.folder_id
+                                    .and_then(|folder_id| folder_names.get(&folder_id))
+                                    .map_or(Ok(()), |folder| {
+                                        write!(output, " (folder: {folder})")
+                                    })?;
+                                writeln!(output, " — updated {updated}")
+                            })?;
+                            append_pagination_hint(output, has_more, offset + limit)
+                        })
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2684,21 +3130,21 @@ impl LificMcp {
                     Err(e) => return format!("Error: {e}"),
                 };
                 match self.read(|conn| queries::list_modules(conn, pid)) {
-                    Ok(ms) => {
-                        let mut out = format!("{} modules:\n", ms.len());
-                        for m in &ms {
-                            out.push_str(&format!(
+                    Ok(modules) => render_response(|output| {
+                        writeln!(output, "{} modules:", modules.len())?;
+                        modules.iter().try_for_each(|module| {
+                            write!(
+                                output,
                                 "- {} ({})",
-                                module_reference(&canonical_project, m),
-                                m.status
-                            ));
-                            if !m.description.is_empty() {
-                                out.push_str(&format!(" — {}", m.description));
-                            }
-                            out.push('\n');
-                        }
-                        out
-                    }
+                                module_reference(context.as_deref(), &canonical_project, module,),
+                                module.status
+                            )?;
+                            (!module.description.is_empty())
+                                .then(|| write!(output, " — {}", module.description))
+                                .transpose()?;
+                            output.write_char('\n')
+                        })
+                    }),
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -2714,13 +3160,12 @@ impl LificMcp {
                     return format!("Error: {e}");
                 }
                 match self.read(|conn| queries::list_labels(conn, pid)) {
-                    Ok(ls) => {
-                        let mut out = format!("{} labels:\n", ls.len());
-                        for l in &ls {
-                            out.push_str(&format!("- {} ({})\n", l.name, l.color));
-                        }
-                        out
-                    }
+                    Ok(labels) => render_response(|output| {
+                        writeln!(output, "{} labels:", labels.len())?;
+                        labels.iter().try_for_each(|label| {
+                            writeln!(output, "- {} ({})", label.name, label.color)
+                        })
+                    }),
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -2736,13 +3181,12 @@ impl LificMcp {
                     return format!("Error: {e}");
                 }
                 match self.read(|conn| queries::list_folders(conn, pid)) {
-                    Ok(fs) => {
-                        let mut out = format!("{} folders:\n", fs.len());
-                        for f in &fs {
-                            out.push_str(&format!("- [{}] {}\n", f.id, f.name));
-                        }
-                        out
-                    }
+                    Ok(folders) => render_response(|output| {
+                        writeln!(output, "{} folders:", folders.len())?;
+                        folders.iter().try_for_each(|folder| {
+                            writeln!(output, "- [{}] {}", folder.id, folder.name)
+                        })
+                    }),
                     Err(e) => format!("Error: {e}"),
                 }
             }
@@ -2756,6 +3200,7 @@ impl LificMcp {
         description = "Create or update a project, module, label, or folder. Create project requires name and identifier; project update requires project=<IDENT>; module/label/folder create requires project and name; module/label/folder update requires project and current_name. Use delete for deletion."
     )]
     fn manage_resource(&self, Parameters(input): Parameters<ManageResourceInput>) -> String {
+        let context = current_issue_link_context();
         match (input.resource_type.as_str(), input.action.as_str()) {
             ("project", "create") => {
                 let Some(ref name) = input.name else {
@@ -2798,13 +3243,20 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectCreated {
                             project_id: p.id,
                         });
-                        format!("Created project {} | {}", project_reference(&p.identifier), p.name)
+                        render_response(|output| {
+                            write!(
+                                output,
+                                "Created project {} | {}",
+                                project_reference(context.as_deref(), &p.identifier),
+                                p.name
+                            )
+                        })
                     }
                     Err(e) => format!("Error: {e}"),
                 }
             }
             ("project", "update") => {
-                if input.current_name.is_some() && input.project.is_none() {
+                if matches!((&input.current_name, &input.project), (Some(_), None)) {
                     return "Error: project updates must be targeted with project=<identifier>, not current_name"
                         .into();
                 }
@@ -2835,7 +3287,14 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: p.id,
                         });
-                        format!("Updated project {} | {}", project_reference(&p.identifier), p.name)
+                        render_response(|output| {
+                            write!(
+                                output,
+                                "Updated project {} | {}",
+                                project_reference(context.as_deref(), &p.identifier),
+                                p.name
+                            )
+                        })
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2874,7 +3333,13 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: pid,
                         });
-                        format!("Created module {}", module_reference(&canonical_project, &m))
+                        render_response(|output| {
+                            write!(
+                                output,
+                                "Created module {}",
+                                module_reference(context.as_deref(), &canonical_project, &m)
+                            )
+                        })
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2917,7 +3382,13 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: pid,
                         });
-                        format!("Updated module {}", module_reference(&canonical_project, &m))
+                        render_response(|output| {
+                            write!(
+                                output,
+                                "Updated module {}",
+                                module_reference(context.as_deref(), &canonical_project, &m)
+                            )
+                        })
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -3073,9 +3544,9 @@ impl LificMcp {
     fn add_comment(&self, Parameters(input): Parameters<AddCommentInput>) -> String {
         let (parent, parent_identifier, project_id) =
             match resolve_comment_parent(self, &input.identifier) {
-            Ok(context) => context,
-            Err(e) => return format!("Error: {e}"),
-        };
+                Ok(context) => context,
+                Err(e) => return format!("Error: {e}"),
+            };
         if let Err(e) = self.require_comment_role_mcp(parent, models::Role::Viewer) {
             return format!("Error: {e}");
         }
@@ -3126,22 +3597,31 @@ impl LificMcp {
             // (LIF-115). The comment id is the useful new handle for any
             // follow-up edit/delete.
             Ok((c, event)) => {
-                if let Some(event) = event {
-                    self.emit(event);
-                }
-                if current_issue_link_context().is_some() {
-                    format!(
-                        "{} added to {} by {} at {}",
-                        comment_reference(&parent_identifier, parent, c.id),
-                        comment_parent_reference(&parent_identifier, parent),
-                        c.author,
-                        c.created_at
-                    )
-                } else {
-                    format!(
-                        "Comment #{} added to {} by {} at {}",
-                        c.id, parent_identifier, c.author, c.created_at
-                    )
+                event.into_iter().for_each(|event| self.emit(event));
+                match current_issue_link_context() {
+                    Some(context) => render_response(|output| {
+                        write!(
+                            output,
+                            "{} added to {} by {} at {}",
+                            reference_with_context(
+                                Some(context.as_ref()),
+                                comment_reference_kind(&parent_identifier, parent, c.id),
+                            ),
+                            reference_with_context(
+                                Some(context.as_ref()),
+                                comment_parent_reference_kind(&parent_identifier, parent),
+                            ),
+                            c.author,
+                            c.created_at
+                        )
+                    }),
+                    None => render_response(|output| {
+                        write!(
+                            output,
+                            "Comment #{} added to {} by {} at {}",
+                            c.id, parent_identifier, c.author, c.created_at
+                        )
+                    }),
                 }
             }
             Err(e) => format!("Error: {e}"),
@@ -3163,6 +3643,15 @@ impl LificMcp {
         let limit = input.limit.map(|limit| limit.clamp(1, 500));
         let offset = input.offset.unwrap_or(0).max(0);
         let order = input.order.as_deref().unwrap_or("asc");
+        let link_context = current_issue_link_context();
+        let parent_kind = match parent {
+            queries::comments::CommentParent::Issue(_) => {
+                ReferenceKind::Issue(parent_identifier.as_str())
+            }
+            queries::comments::CommentParent::Page(page_id) => {
+                ReferenceKind::Page(parent_identifier.as_str(), page_id)
+            }
+        };
 
         match self.read(|conn| {
             let comments = queries::comments::list_comments_paginated(
@@ -3180,71 +3669,76 @@ impl LificMcp {
                 if total == 0 {
                     format!(
                         "No comments on {}.",
-                        comment_parent_reference(&parent_identifier, parent)
+                        reference_with_context(link_context.as_deref(), parent_kind)
                     )
                 } else {
                     format!(
                         "No comments in this range on {} (offset {offset}, {total} total).",
-                        comment_parent_reference(&parent_identifier, parent)
+                        reference_with_context(link_context.as_deref(), parent_kind)
                     )
                 }
             }
             Ok((mut comments, total)) => {
                 let page_limit = limit.filter(|&limit| comments.len() as i64 > limit);
                 let has_more = page_limit.is_some();
-                if let Some(limit) = page_limit {
-                    comments.truncate(limit as usize);
-                }
+                page_limit
+                    .into_iter()
+                    .for_each(|page_limit| comments.truncate(page_limit as usize));
                 let shown = comments.len() as i64;
-                let mut out = if limit.is_some() && offset == 0 && shown < total {
-                    let edge = if order == "desc" {
-                        "most recent"
-                    } else {
-                        "oldest"
-                    };
-                    format!(
-                        "Showing {shown} {edge} of {total} comment(s) on {}:\n",
-                        comment_parent_reference(&parent_identifier, parent)
-                    )
-                } else if offset > 0 {
-                    format!(
-                        "Showing comments {}-{} of {total} on {} ({} first):\n",
-                        offset + 1,
-                        offset + shown,
-                        comment_parent_reference(&parent_identifier, parent),
-                        if order == "desc" { "newest" } else { "oldest" }
-                    )
-                } else {
-                    format!(
-                        "{total} comment(s) on {}:\n",
-                        comment_parent_reference(&parent_identifier, parent)
-                    )
-                };
-                for c in &comments {
-                    if current_issue_link_context().is_some() {
-                        out.push_str(&format!(
-                            "[{}] {} ({}) — {}: {}\n",
-                            c.created_at,
-                            c.author,
-                            c.author_display_name,
-                            comment_reference(&parent_identifier, parent, c.id),
-                            c.content
-                        ));
-                    } else {
-                        out.push_str(&format!(
-                            "[{}] {} ({}): {}\n",
-                            c.created_at, c.author, c.author_display_name, c.content
-                        ));
+                render_response(|output| {
+                    match (limit, offset, shown < total) {
+                        (Some(_), 0, true) => {
+                            let edge = if order == "desc" {
+                                "most recent"
+                            } else {
+                                "oldest"
+                            };
+                            writeln!(
+                                output,
+                                "Showing {shown} {edge} of {total} comment(s) on {}:",
+                                reference_with_context(link_context.as_deref(), parent_kind)
+                            )?;
+                        }
+                        (_, offset, _) if offset > 0 => {
+                            writeln!(
+                                output,
+                                "Showing comments {}-{} of {total} on {} ({} first):",
+                                offset + 1,
+                                offset + shown,
+                                reference_with_context(link_context.as_deref(), parent_kind),
+                                if order == "desc" { "newest" } else { "oldest" }
+                            )?;
+                        }
+                        _ => {
+                            writeln!(
+                                output,
+                                "{total} comment(s) on {}:",
+                                reference_with_context(link_context.as_deref(), parent_kind)
+                            )?;
+                        }
                     }
-                }
-                if has_more {
-                    let next_offset = offset + shown;
-                    let remaining = total.saturating_sub(next_offset);
-                    out.push_str(&format!(
-                        "\n... {remaining} more comment(s) — call again with the same author/order/limit and offset={next_offset}\n"
-                    ));
-                }
-                out
+                    write!(
+                        output,
+                        "{}",
+                        CommentLines {
+                            comments: &comments,
+                            parent_identifier: &parent_identifier,
+                            parent,
+                            context: link_context.as_deref(),
+                        }
+                    )?;
+                    has_more
+                        .then(|| {
+                            let next_offset = offset + shown;
+                            let remaining = total.saturating_sub(next_offset);
+                            writeln!(
+                                output,
+                                "\n... {remaining} more comment(s) — call again with the same author/order/limit and offset={next_offset}"
+                            )
+                        })
+                        .transpose()
+                        .map(|_| ())
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -3277,9 +3771,9 @@ impl LificMcp {
         // visible members, resolving the project from the comment's parent.
         let (project_id, parent, parent_identifier) =
             match self.read(|conn| resolve_comment_context(conn, &existing)) {
-            Ok(context) => context,
-            Err(e) => return format!("Error: {e}"),
-        };
+                Ok(context) => context,
+                Err(e) => return format!("Error: {e}"),
+            };
         let member_scoped = match crate::authz::authz_enforced(&self.db) {
             Ok(v) => v,
             Err(e) => return format!("Error: {e}"),
@@ -3303,14 +3797,21 @@ impl LificMcp {
                 } else if let Some(project_id) = project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                if current_issue_link_context().is_some() {
-                    format!(
-                        "{} edited at {}",
-                        comment_reference(&parent_identifier, parent, c.id),
-                        c.updated_at
-                    )
-                } else {
-                    format!("Comment #{} edited at {}", c.id, c.updated_at)
+                match current_issue_link_context() {
+                    Some(context) => render_response(|output| {
+                        write!(
+                            output,
+                            "{} edited at {}",
+                            reference_with_context(
+                                Some(context.as_ref()),
+                                comment_reference_kind(&parent_identifier, parent, c.id),
+                            ),
+                            c.updated_at
+                        )
+                    }),
+                    None => render_response(|output| {
+                        write!(output, "Comment #{} edited at {}", c.id, c.updated_at)
+                    }),
                 }
             }
             Err(e) => format!("Error: {e}"),
@@ -3338,9 +3839,9 @@ impl LificMcp {
 
         let (project_id, parent, parent_identifier) =
             match self.read(|conn| resolve_comment_context(conn, &existing)) {
-            Ok(context) => context,
-            Err(e) => return format!("Error: {e}"),
-        };
+                Ok(context) => context,
+                Err(e) => return format!("Error: {e}"),
+            };
 
         match self.write(|conn| queries::comments::delete_comment(conn, input.comment_id)) {
             Ok(()) => {
@@ -3352,14 +3853,21 @@ impl LificMcp {
                 } else if let Some(project_id) = project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                if current_issue_link_context().is_some() {
-                    format!(
-                        "Comment #{} deleted from {}",
-                        input.comment_id,
-                        comment_parent_reference(&parent_identifier, parent)
-                    )
-                } else {
-                    format!("Comment #{} deleted", input.comment_id)
+                match current_issue_link_context() {
+                    Some(context) => render_response(|output| {
+                        write!(
+                            output,
+                            "Comment #{} deleted from {}",
+                            input.comment_id,
+                            reference_with_context(
+                                Some(context.as_ref()),
+                                comment_parent_reference_kind(&parent_identifier, parent),
+                            )
+                        )
+                    }),
+                    None => render_response(|output| {
+                        write!(output, "Comment #{} deleted", input.comment_id)
+                    }),
                 }
             }
             Err(e) => format!("Error: {e}"),
@@ -3402,7 +3910,22 @@ impl LificMcp {
                 self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                     project_id: plan.project_id,
                 });
-                format!("Created {}\n{}", plan_reference(&plan), fmt_plan(&plan))
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    writeln!(
+                        output,
+                        "Created {}",
+                        plan_reference(context.as_deref(), &plan)
+                    )?;
+                    write!(
+                        output,
+                        "{}",
+                        PlanView {
+                            plan: &plan,
+                            context: context.as_deref(),
+                        }
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -3466,12 +3989,23 @@ impl LificMcp {
                 self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                     project_id: plan.project_id,
                 });
-                format!(
-                    "Edited step #{} in {}\n{}",
-                    input.step_id,
-                    plan_reference(&plan),
-                    fmt_plan(&plan)
-                )
+                let context = current_issue_link_context();
+                render_response(|output| {
+                    writeln!(
+                        output,
+                        "Edited step #{} in {}",
+                        input.step_id,
+                        plan_reference(context.as_deref(), &plan)
+                    )?;
+                    write!(
+                        output,
+                        "{}",
+                        PlanView {
+                            plan: &plan,
+                            context: context.as_deref(),
+                        }
+                    )
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -3515,6 +4049,7 @@ impl LificMcp {
             return format!("Error: {e}");
         }
 
+        let context = current_issue_link_context();
         match self.write(|conn| {
             let plan_id = queries::plans::resolve_plan_identifier(conn, &input.plan)?;
             let mut notes: Vec<String> = Vec::new();
@@ -3554,10 +4089,20 @@ impl LificMcp {
                             let iid = queries::resolve_identifier(conn, ident)?;
                             let issue = queries::get_issue(conn, iid)?;
                             queries::plans::set_step_issue(conn, step_id, Some(iid))?;
-                            notes.push(format!(
-                                "Attached {} to step #{step_id}",
-                                issue_reference(&issue.identifier)
-                            ));
+                            notes.push(
+                                try_render(|output| {
+                                    write!(
+                                        output,
+                                        "Attached {} to step #{step_id}",
+                                        issue_reference(context.as_deref(), &issue.identifier,)
+                                    )
+                                })
+                                .map_err(|error| {
+                                    crate::error::LificError::Internal(format!(
+                                        "failed to format plan-step response: {error}"
+                                    ))
+                                })?,
+                            );
                         }
                         if input.detach_issue.unwrap_or(false) {
                             queries::plans::set_step_issue(conn, step_id, None)?;
@@ -3565,30 +4110,50 @@ impl LificMcp {
                         }
                         if let Some(done) = input.done {
                             let effect = queries::plans::set_step_done(conn, step_id, done)?;
-                            let mut msg = format!(
-                                "Step #{step_id} {}",
-                                if done { "marked done" } else { "reopened" }
-                            );
-                            if let Some(iss) = &effect.issue_identifier {
-                                if effect.issue_status_changed {
-                                    let issue_id = queries::resolve_identifier(conn, iss)?;
+                            enum IssueEffect<'a> {
+                                MarkedDone(&'a str),
+                                AlreadyDone(&'a str),
+                                None,
+                            }
+                            let issue_effect = match effect.issue_identifier.as_deref() {
+                                Some(identifier) if effect.issue_status_changed => {
+                                    let issue_id = queries::resolve_identifier(conn, identifier)?;
                                     let issue = queries::get_issue(conn, issue_id)?;
                                     events.push(crate::realtime::RealtimeEvent::IssueUpdated {
                                         project_id: issue.project_id,
                                         issue_id: issue.id,
                                     });
-                                    msg.push_str(&format!(
-                                        " → {} marked done",
-                                        issue_reference(iss)
-                                    ));
-                                } else if done {
-                                    msg.push_str(&format!(
-                                        " (linked {} already done)",
-                                        issue_reference(iss)
-                                    ));
+                                    IssueEffect::MarkedDone(identifier)
                                 }
-                            }
-                            notes.push(msg);
+                                Some(identifier) if done => IssueEffect::AlreadyDone(identifier),
+                                _ => IssueEffect::None,
+                            };
+                            let message = try_render(|output| {
+                                write!(
+                                    output,
+                                    "Step #{step_id} {}",
+                                    if done { "marked done" } else { "reopened" }
+                                )?;
+                                match issue_effect {
+                                    IssueEffect::MarkedDone(identifier) => write!(
+                                        output,
+                                        " → {} marked done",
+                                        issue_reference(context.as_deref(), identifier)
+                                    ),
+                                    IssueEffect::AlreadyDone(identifier) => write!(
+                                        output,
+                                        " (linked {} already done)",
+                                        issue_reference(context.as_deref(), identifier)
+                                    ),
+                                    IssueEffect::None => Ok(()),
+                                }
+                            })
+                            .map_err(|error| {
+                                crate::error::LificError::Internal(format!(
+                                    "failed to format plan-step response: {error}"
+                                ))
+                            })?;
+                            notes.push(message);
                         }
                         if let Some(ref child_title) = input.add_child_title {
                             let child_issue = match &input.add_child_issue {
@@ -3643,18 +4208,34 @@ impl LificMcp {
                 // progress summary built from the same Plan fields as
                 // fmt_plan's header, minus the title and step tree). Pass
                 // echo_tree=true to restore the full re-rendered tree.
-                if input.echo_tree.unwrap_or(false) {
-                    format!("{}\n{}", notes.join("; "), fmt_plan(&plan))
-                } else {
-                    format!(
-                        "{}\n{} [{}]: {}/{} done",
-                        notes.join("; "),
-                        plan_reference(&plan),
-                        plan.status,
-                        plan.done_count,
-                        plan.step_count
-                    )
-                }
+                render_response(|output| {
+                    writeln!(
+                        output,
+                        "{}",
+                        JoinedStrings {
+                            values: &notes,
+                            separator: "; ",
+                        }
+                    )?;
+                    match input.echo_tree.unwrap_or(false) {
+                        true => write!(
+                            output,
+                            "{}",
+                            PlanView {
+                                plan: &plan,
+                                context: context.as_deref(),
+                            }
+                        ),
+                        false => write!(
+                            output,
+                            "{} [{}]: {}/{} done",
+                            plan_reference(context.as_deref(), &plan),
+                            plan.status,
+                            plan.done_count,
+                            plan.step_count
+                        ),
+                    }
+                })
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -3761,7 +4342,10 @@ mod tests {
         seed_project(&m, "Canonical", "CAN");
         let project_id = project_id_for(&m, "CAN");
 
-        assert_eq!(canonical_project_identifier(&m.db, project_id).unwrap(), "CAN");
+        assert_eq!(
+            canonical_project_identifier(&m.db, project_id).unwrap(),
+            "CAN"
+        );
     }
 
     fn issue_id_for(mcp: &LificMcp, identifier: &str) -> i64 {
@@ -4382,18 +4966,16 @@ mod tests {
         let m = mcp();
         seed_project(&m, "Test", "DEL");
         seed_issue(&m, "DEL", "Doomed");
-        let context =
-            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
 
-        let result =
-            crate::mcp::with_request_context(None, false, Some(context), || async {
-                m.delete(Parameters(DeleteInput {
-                    resource_type: "issue".into(),
-                    identifier: "DEL-01".into(),
-                    project: None,
-                }))
-            })
-            .await;
+        let result = crate::mcp::with_request_context(None, false, Some(context), || async {
+            m.delete(Parameters(DeleteInput {
+                resource_type: "issue".into(),
+                identifier: "DEL-01".into(),
+                project: None,
+            }))
+        })
+        .await;
 
         assert_eq!(result, "Deleted issue DEL-1");
     }
@@ -5060,14 +5642,10 @@ mod tests {
             display_name: author.display_name,
             is_admin: author.is_admin,
         };
-        let context =
-            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
 
-        let result = crate::mcp::with_request_context(
-            Some(auth_user),
-            false,
-            Some(context),
-            || async {
+        let result =
+            crate::mcp::with_request_context(Some(auth_user), false, Some(context), || async {
                 m.add_comment(Parameters(AddCommentInput {
                     identifier: "SRC-1".into(),
                     content: "Unique comment needle".into(),
@@ -5077,9 +5655,8 @@ mod tests {
                     result_type: Some("comment".into()),
                     ..Default::default()
                 }))
-            },
-        )
-        .await;
+            })
+            .await;
 
         assert!(
             result.contains(
@@ -5510,10 +6087,30 @@ mod tests {
         }
     }
 
-    // ── fmt_issue ──
+    // ── write_issue ──
+
+    struct FailingWriter;
+
+    impl fmt::Write for FailingWriter {
+        fn write_str(&mut self, _: &str) -> fmt::Result {
+            Err(fmt::Error)
+        }
+    }
 
     #[test]
-    fn fmt_issue_formats_relations_with_one_context_read() {
+    fn issue_relations_propagate_formatter_failures() {
+        let identifiers = vec!["T-2".into()];
+        let relations = IssueRelations {
+            label: " blocks:",
+            identifiers: &identifiers,
+            context: None,
+        };
+
+        assert!(write!(FailingWriter, "{relations}").is_err());
+    }
+
+    #[test]
+    fn write_issue_formats_relations_with_one_context_read() {
         let issue = models::Issue {
             id: 1,
             project_id: 1,
@@ -5538,7 +6135,17 @@ mod tests {
             duplicated_by: vec!["T-4".into()],
         };
         crate::mcp::reset_issue_link_context_reads();
-        let s = fmt_issue(&issue);
+        let context = current_issue_link_context();
+        let s = render_response(|output| {
+            write!(
+                output,
+                "{}",
+                IssueLine {
+                    issue: &issue,
+                    context: context.as_deref(),
+                }
+            )
+        });
         assert!(s.contains("[bug]"), "got: {s}");
         assert!(s.contains("blocks:T-2"), "got: {s}");
         assert!(s.contains("duplicates:T-3"), "got: {s}");
@@ -7625,14 +8232,10 @@ mod tests {
             display_name: author.display_name,
             is_admin: author.is_admin,
         };
-        let context =
-            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
 
-        let (comment_id, edited, deleted) = crate::mcp::with_request_context(
-            Some(auth_user),
-            false,
-            Some(context),
-            || async {
+        let (comment_id, edited, deleted) =
+            crate::mcp::with_request_context(Some(auth_user), false, Some(context), || async {
                 let added = m.add_comment(Parameters(AddCommentInput {
                     identifier: "PRJ-1".into(),
                     content: "original".into(),
@@ -7642,12 +8245,10 @@ mod tests {
                     comment_id,
                     content: "revised".into(),
                 }));
-                let deleted =
-                    m.delete_comment(Parameters(DeleteCommentInput { comment_id }));
+                let deleted = m.delete_comment(Parameters(DeleteCommentInput { comment_id }));
                 (comment_id, edited, deleted)
-            },
-        )
-        .await;
+            })
+            .await;
 
         assert!(
             edited.contains(&format!(
@@ -7978,8 +8579,7 @@ mod tests {
             display_name: author.display_name,
             is_admin: author.is_admin,
         };
-        let context =
-            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
 
         let (project, page, issue) =
             crate::mcp::with_request_context(Some(auth_user), false, Some(context), || async {
@@ -8005,15 +8605,11 @@ mod tests {
             .await;
 
         assert!(
-            project.contains(
-                "activity entries for [TST](https://tracker.example/TST/overview):"
-            ),
+            project.contains("activity entries for [TST](https://tracker.example/TST/overview):"),
             "got: {project}"
         );
         assert!(
-            page.contains(
-                "activity entries for [TST-DOC-1](https://tracker.example/TST/pages/1):"
-            ),
+            page.contains("activity entries for [TST-DOC-1](https://tracker.example/TST/pages/1):"),
             "got: {page}"
         );
         for expected in [
@@ -8024,9 +8620,7 @@ mod tests {
             assert!(project.contains(expected), "missing {expected}: {project}");
         }
         assert!(
-            issue.contains(
-                "[comment #1](https://tracker.example/TST/issues/TST-1#comment-1)"
-            ),
+            issue.contains("[comment #1](https://tracker.example/TST/issues/TST-1#comment-1)"),
             "got: {issue}"
         );
     }
@@ -8318,6 +8912,7 @@ mod tests {
         assert!(created.contains("Backend"));
         assert!(created.contains("schema"));
 
+        crate::mcp::reset_issue_link_context_reads();
         let got = m.get_plan(Parameters(GetPlanInput {
             plan: "PLN-PLAN-1".into(),
         }));
@@ -8326,6 +8921,7 @@ mod tests {
             "get_plan should rehydrate tree: {got}"
         );
         assert!(got.contains("0/4 done"), "header should count steps: {got}");
+        assert_eq!(crate::mcp::issue_link_context_reads(), 1);
     }
 
     #[tokio::test]
@@ -8348,19 +8944,17 @@ mod tests {
             .and_then(|value| value.split(|c: char| !c.is_ascii_digit()).next())
             .and_then(|value| value.parse().ok())
             .expect("step id in output");
-        let context =
-            crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
+        let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
 
-        let output =
-            crate::mcp::with_request_context(None, false, Some(context), || async {
-                m.update_plan_step(Parameters(UpdatePlanStepInput {
-                    plan: "PLN-PLAN-1".into(),
-                    step_id: Some(step_id),
-                    attach_issue: Some("PLN-01".into()),
-                    ..Default::default()
-                }))
-            })
-            .await;
+        let output = crate::mcp::with_request_context(None, false, Some(context), || async {
+            m.update_plan_step(Parameters(UpdatePlanStepInput {
+                plan: "PLN-PLAN-1".into(),
+                step_id: Some(step_id),
+                attach_issue: Some("PLN-01".into()),
+                ..Default::default()
+            }))
+        })
+        .await;
 
         assert!(
             output.contains("[PLN-1](https://tracker.example/PLN/issues/PLN-1)"),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -92,6 +92,73 @@ fn issue_reference_with_context(context: Option<&IssueLinkContext>, identifier: 
     )
 }
 
+fn comment_reference(
+    parent_identifier: &str,
+    parent: queries::comments::CommentParent,
+    comment_id: i64,
+) -> String {
+    current_issue_link_context().map_or_else(
+        || format!("comment #{comment_id}"),
+        |context| match parent {
+            queries::comments::CommentParent::Issue(_) => {
+                context.issue_comment_markdown(parent_identifier, comment_id)
+            }
+            queries::comments::CommentParent::Page(page_id) => {
+                context.page_comment_markdown(parent_identifier, page_id, comment_id)
+            }
+        },
+    )
+}
+
+fn comment_parent_reference(
+    parent_identifier: &str,
+    parent: queries::comments::CommentParent,
+) -> String {
+    current_issue_link_context().map_or_else(
+        || parent_identifier.to_owned(),
+        |context| match parent {
+            queries::comments::CommentParent::Issue(_) => {
+                context.issue_markdown(parent_identifier)
+            }
+            queries::comments::CommentParent::Page(page_id) => {
+                context.page_markdown(parent_identifier, page_id)
+            }
+        },
+    )
+}
+
+fn project_reference(identifier: &str) -> String {
+    current_issue_link_context().map_or_else(
+        || identifier.to_owned(),
+        |context| context.project_markdown(identifier),
+    )
+}
+
+fn page_reference(page: &models::Page) -> String {
+    current_issue_link_context().map_or_else(
+        || page.identifier.clone(),
+        |context| context.page_markdown(&page.identifier, page.id),
+    )
+}
+
+fn plan_reference(plan: &models::Plan) -> String {
+    plan_reference_value(&plan.identifier, plan.id)
+}
+
+fn plan_reference_value(identifier: &str, plan_id: i64) -> String {
+    current_issue_link_context().map_or_else(
+        || identifier.to_owned(),
+        |context| context.plan_markdown(identifier, plan_id),
+    )
+}
+
+fn module_reference(project: &str, module: &models::Module) -> String {
+    current_issue_link_context().map_or_else(
+        || module.name.clone(),
+        |context| context.module_markdown(project, module.id, &module.name),
+    )
+}
+
 fn issue_reference_with_suffix(value: &str) -> String {
     let Some((identifier, suffix)) = value.split_once(' ') else {
         return issue_reference(value);
@@ -115,7 +182,12 @@ pub(crate) fn fmt_plan(p: &models::Plan) -> String {
         .unwrap_or_default();
     let mut out = format!(
         "{} [{}] {}{} — {}/{} done\n",
-        p.identifier, p.status, p.title, anchor, p.done_count, p.step_count
+        plan_reference(p),
+        p.status,
+        p.title,
+        anchor,
+        p.done_count,
+        p.step_count
     );
     fmt_steps(&p.steps, 0, &mut out);
     out
@@ -207,6 +279,7 @@ impl PlanStepCascadeAction {
 
 struct CascadedPlanStep {
     id: i64,
+    plan_id: i64,
     plan_identifier: String,
 }
 
@@ -221,7 +294,7 @@ fn issue_status_cascaded_plan_steps(
     action: PlanStepCascadeAction,
 ) -> Result<Vec<CascadedPlanStep>, crate::error::LificError> {
     let mut stmt = conn.prepare_cached(
-        "SELECT ps.id, p.identifier || '-PLAN-' || pl.sequence
+        "SELECT ps.id, pl.id, p.identifier || '-PLAN-' || pl.sequence
            FROM audit_log al
            JOIN plan_steps ps ON ps.id = al.entity_id
            JOIN plans pl ON pl.id = ps.plan_id
@@ -237,7 +310,8 @@ fn issue_status_cascaded_plan_steps(
         |row| {
             Ok(CascadedPlanStep {
                 id: row.get(0)?,
-                plan_identifier: row.get(1)?,
+                plan_id: row.get(1)?,
+                plan_identifier: row.get(2)?,
             })
         },
     )?;
@@ -254,7 +328,7 @@ fn fmt_issue_plan_step_cascade(
             " ({} plan step #{} in {})",
             action.response_verb(),
             step.id,
-            step.plan_identifier
+            plan_reference_value(&step.plan_identifier, step.plan_id)
         )),
         steps => Some(format!(
             " ({} {} plan steps: {})",
@@ -262,7 +336,13 @@ fn fmt_issue_plan_step_cascade(
             steps.len(),
             steps
                 .iter()
-                .map(|step| format!("#{} in {}", step.id, step.plan_identifier))
+                .map(|step| {
+                    format!(
+                        "#{} in {}",
+                        step.id,
+                        plan_reference_value(&step.plan_identifier, step.plan_id)
+                    )
+                })
                 .collect::<Vec<_>>()
                 .join(", ")
         )),
@@ -743,20 +823,54 @@ impl LificMcp {
                     // match on its parent so the reader knows to open the
                     // parent issue/page to find the thread (LIF-146).
                     if r.result_type == "comment" {
+                        let page_id = current_issue_link_context().and_then(|_| {
+                            looks_like_page_identifier(ident)
+                                .then(|| {
+                                    self.read(|conn| {
+                                        queries::resolve_page_identifier(conn, ident)
+                                    })
+                                    .ok()
+                                })
+                                .flatten()
+                        });
+                        let parent = current_issue_link_context().map_or_else(
+                            || ident.to_owned(),
+                            |context| {
+                                page_id.map_or_else(
+                                    || context.issue_markdown(ident),
+                                    |page_id| context.page_markdown(ident, page_id),
+                                )
+                            },
+                        );
+                        let comment = current_issue_link_context().map_or_else(
+                            || "comment".to_owned(),
+                            |context| page_id.map_or_else(
+                                || context.issue_comment_markdown(ident, r.id),
+                                |page_id| context.page_comment_markdown(ident, page_id, r.id),
+                            ),
+                        );
                         out.push_str(&format!(
-                            "- [comment] on {} — {}\n",
-                            issue_reference(ident),
-                            r.snippet
+                            "- [{}] on {} — {}\n",
+                            comment, parent, r.snippet
                         ));
                     } else {
+                        let identifier = if r.result_type == "page" {
+                            current_issue_link_context().map_or_else(
+                                || ident.to_owned(),
+                                |context| context.page_markdown(ident, r.id),
+                            )
+                        } else if r.result_type == "plan" {
+                            current_issue_link_context().map_or_else(
+                                || ident.to_owned(),
+                                |context| context.plan_markdown(ident, r.id),
+                            )
+                        } else {
+                            issue_reference(ident)
+                        };
                         out.push_str(&format!(
                             "- [{}] {} {} — {}\n",
                             r.result_type,
-                            if r.result_type == "issue" {
-                                issue_reference(ident)
-                            } else {
-                                ident.to_owned()
-                            },
+                            identifier,
                             r.title,
                             r.snippet
                         ));
@@ -1051,20 +1165,50 @@ impl LificMcp {
                                 "\n--- Comments ({total}, showing last 3 — use list_comments) ---\n"
                             ));
                             for c in &comments[total - 3..] {
-                                out.push_str(&format!(
-                                    "[{}] {} ({}): {}\n",
-                                    c.created_at, c.author, c.author_display_name, c.content
-                                ));
+                                if current_issue_link_context().is_some() {
+                                    out.push_str(&format!(
+                                        "[{}] {} ({}) — {}: {}\n",
+                                        c.created_at,
+                                        c.author,
+                                        c.author_display_name,
+                                        comment_reference(
+                                            &issue.identifier,
+                                            queries::comments::CommentParent::Issue(issue.id),
+                                            c.id
+                                        ),
+                                        c.content
+                                    ));
+                                } else {
+                                    out.push_str(&format!(
+                                        "[{}] {} ({}): {}\n",
+                                        c.created_at, c.author, c.author_display_name, c.content
+                                    ));
+                                }
                             }
                         }
                         // "all", or "recent" with <= 3 comments: today's format.
                         _ => {
                             out.push_str(&format!("\n--- Comments ({total}) ---\n"));
                             for c in &comments {
-                                out.push_str(&format!(
-                                    "[{}] {} ({}): {}\n",
-                                    c.created_at, c.author, c.author_display_name, c.content
-                                ));
+                                if current_issue_link_context().is_some() {
+                                    out.push_str(&format!(
+                                        "[{}] {} ({}) — {}: {}\n",
+                                        c.created_at,
+                                        c.author,
+                                        c.author_display_name,
+                                        comment_reference(
+                                            &issue.identifier,
+                                            queries::comments::CommentParent::Issue(issue.id),
+                                            c.id
+                                        ),
+                                        c.content
+                                    ));
+                                } else {
+                                    out.push_str(&format!(
+                                        "[{}] {} ({}): {}\n",
+                                        c.created_at, c.author, c.author_display_name, c.content
+                                    ));
+                                }
                             }
                         }
                     }
@@ -1693,7 +1837,7 @@ impl LificMcp {
                 let mut out = format!(
                     "{}{} — {}\nStatus: {} | Folder: {}\nCreated: {} | Updated: {}\n",
                     if page.pinned { "📌 " } else { "" },
-                    page.identifier,
+                    page_reference(&page),
                     page.title,
                     page.status,
                     folder_name.as_deref().unwrap_or("none"),
@@ -1749,7 +1893,7 @@ impl LificMcp {
                 if let Some(project_id) = page.project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                format!("Created {}: {}", page.identifier, page.title)
+                format!("Created {}: {}", page_reference(&page), page.title)
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1802,7 +1946,7 @@ impl LificMcp {
                 if let Some(project_id) = page.project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                format!("Updated {}: {}", page.identifier, page.title)
+                format!("Updated {}: {}", page_reference(&page), page.title)
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1875,7 +2019,7 @@ impl LificMcp {
                 if let Some(project_id) = page.project_id {
                     self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
                 }
-                format!("Edited {}: {}", page.identifier, page.title)
+                format!("Edited {}: {}", page_reference(&page), page.title)
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -1925,7 +2069,13 @@ impl LificMcp {
                 match self.write(|conn| queries::plans::delete_plan(conn, id)) {
                     Ok(()) => {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
-                        format!("Deleted plan {}", input.identifier)
+                        format!(
+                            "Deleted plan {}",
+                            current_issue_link_context().map_or_else(
+                                || input.identifier.clone(),
+                                |context| context.plan_markdown(&input.identifier, id),
+                            )
+                        )
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -1951,7 +2101,13 @@ impl LificMcp {
                                 project_id,
                             });
                         }
-                        format!("Deleted page {}", input.identifier)
+                        format!(
+                            "Deleted page {}",
+                            current_issue_link_context().map_or_else(
+                                || input.identifier.clone(),
+                                |context| context.page_markdown(&input.identifier, id),
+                            )
+                        )
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -1975,7 +2131,7 @@ impl LificMcp {
                             Some(user_ids) => self.realtime.send_to_users(event, user_ids),
                             None => self.emit(event),
                         }
-                        format!("Deleted project {}", input.identifier)
+                        format!("Deleted project {}", project_reference(&input.identifier))
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2066,7 +2222,12 @@ impl LificMcp {
                                 .unwrap_or_default();
                             out.push_str(&format!(
                                 "- {} | {} | {} ({}/{} done){}\n",
-                                p.identifier, p.status, p.title, p.done_count, p.step_count, anchor
+                                plan_reference(p),
+                                p.status,
+                                p.title,
+                                p.done_count,
+                                p.step_count,
+                                anchor
                             ));
                         }
                         out
@@ -2098,7 +2259,7 @@ impl LificMcp {
                         let mut out = format!("{} projects:\n", ps.len());
                         let now = Utc::now();
                         for p in &ps {
-                            out.push_str(&format!("- {} | {}", p.identifier, p.name));
+                            out.push_str(&format!("- {} | {}", project_reference(&p.identifier), p.name));
                             if !p.description.is_empty() {
                                 out.push_str(&format!(" — {}", p.description));
                             }
@@ -2254,7 +2415,13 @@ impl LificMcp {
                             let pin = if p.pinned { "📌 " } else { "" };
                             out.push_str(&format!(
                                 "- {}{} | {} | {}{}{} — updated {}\n",
-                                pin, p.identifier, p.status, p.title, labels, folder, updated
+                                pin,
+                                page_reference(p),
+                                p.status,
+                                p.title,
+                                labels,
+                                folder,
+                                updated
                             ));
                         }
                         append_pagination_hint(&mut out, has_more, offset + limit);
@@ -2278,7 +2445,11 @@ impl LificMcp {
                     Ok(ms) => {
                         let mut out = format!("{} modules:\n", ms.len());
                         for m in &ms {
-                            out.push_str(&format!("- {} ({})", m.name, m.status));
+                            out.push_str(&format!(
+                                "- {} ({})",
+                                module_reference(proj, m),
+                                m.status
+                            ));
                             if !m.description.is_empty() {
                                 out.push_str(&format!(" — {}", m.description));
                             }
@@ -2385,7 +2556,7 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectCreated {
                             project_id: p.id,
                         });
-                        format!("Created project {} | {}", p.identifier, p.name)
+                        format!("Created project {} | {}", project_reference(&p.identifier), p.name)
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2422,7 +2593,7 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: p.id,
                         });
-                        format!("Updated project {} | {}", p.identifier, p.name)
+                        format!("Updated project {} | {}", project_reference(&p.identifier), p.name)
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2457,7 +2628,7 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: pid,
                         });
-                        format!("Created module [{}]: {}", m.id, m.name)
+                        format!("Created module {}", module_reference(proj, &m))
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2496,7 +2667,7 @@ impl LificMcp {
                         self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                             project_id: pid,
                         });
-                        format!("Updated module: {}", m.name)
+                        format!("Updated module {}", module_reference(proj, &m))
                     }
                     Err(e) => format!("Error: {e}"),
                 }
@@ -2721,13 +2892,20 @@ impl LificMcp {
                 if let Some(event) = event {
                     self.emit(event);
                 }
-                format!(
-                    "Comment #{} added to {} by {} at {}",
-                    c.id,
-                    issue_reference(&input.identifier),
-                    c.author,
-                    c.created_at
-                )
+                if current_issue_link_context().is_some() {
+                    format!(
+                        "{} added to {} by {} at {}",
+                        comment_reference(&input.identifier, parent, c.id),
+                        comment_parent_reference(&input.identifier, parent),
+                        c.author,
+                        c.created_at
+                    )
+                } else {
+                    format!(
+                        "Comment #{} added to {} by {} at {}",
+                        c.id, input.identifier, c.author, c.created_at
+                    )
+                }
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -2763,11 +2941,14 @@ impl LificMcp {
         }) {
             Ok((comments, total)) if comments.is_empty() => {
                 if total == 0 {
-                    format!("No comments on {}.", issue_reference(&input.identifier))
+                    format!(
+                        "No comments on {}.",
+                        comment_parent_reference(&input.identifier, parent)
+                    )
                 } else {
                     format!(
                         "No comments in this range on {} (offset {offset}, {total} total).",
-                        issue_reference(&input.identifier)
+                        comment_parent_reference(&input.identifier, parent)
                     )
                 }
             }
@@ -2786,27 +2967,38 @@ impl LificMcp {
                     };
                     format!(
                         "Showing {shown} {edge} of {total} comment(s) on {}:\n",
-                        issue_reference(&input.identifier)
+                        comment_parent_reference(&input.identifier, parent)
                     )
                 } else if offset > 0 {
                     format!(
                         "Showing comments {}-{} of {total} on {} ({} first):\n",
                         offset + 1,
                         offset + shown,
-                        issue_reference(&input.identifier),
+                        comment_parent_reference(&input.identifier, parent),
                         if order == "desc" { "newest" } else { "oldest" }
                     )
                 } else {
                     format!(
                         "{total} comment(s) on {}:\n",
-                        issue_reference(&input.identifier)
+                        comment_parent_reference(&input.identifier, parent)
                     )
                 };
                 for c in &comments {
-                    out.push_str(&format!(
-                        "[{}] {} ({}): {}\n",
-                        c.created_at, c.author, c.author_display_name, c.content
-                    ));
+                    if current_issue_link_context().is_some() {
+                        out.push_str(&format!(
+                            "[{}] {} ({}) — {}: {}\n",
+                            c.created_at,
+                            c.author,
+                            c.author_display_name,
+                            comment_reference(&input.identifier, parent, c.id),
+                            c.content
+                        ));
+                    } else {
+                        out.push_str(&format!(
+                            "[{}] {} ({}): {}\n",
+                            c.created_at, c.author, c.author_display_name, c.content
+                        ));
+                    }
                 }
                 if has_more {
                     let next_offset = offset + shown;
@@ -2955,7 +3147,7 @@ impl LificMcp {
                 self.emit(crate::realtime::RealtimeEvent::ProjectUpdated {
                     project_id: plan.project_id,
                 });
-                format!("Created {}\n{}", plan.identifier, fmt_plan(&plan))
+                format!("Created {}\n{}", plan_reference(&plan), fmt_plan(&plan))
             }
             Err(e) => format!("Error: {e}"),
         }
@@ -3022,7 +3214,7 @@ impl LificMcp {
                 format!(
                     "Edited step #{} in {}\n{}",
                     input.step_id,
-                    plan.identifier,
+                    plan_reference(&plan),
                     fmt_plan(&plan)
                 )
             }
@@ -3201,7 +3393,7 @@ impl LificMcp {
                     format!(
                         "{}\n{} [{}]: {}/{} done",
                         notes.join("; "),
-                        plan.identifier,
+                        plan_reference(&plan),
                         plan.status,
                         plan.done_count,
                         plan.step_count

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -142,31 +142,25 @@ fn effective_issuer(state: &OAuthState, headers: &HeaderMap) -> String {
     else {
         return state.issuer.clone();
     };
-    match host_header.parse::<axum::http::uri::Authority>() {
-        Ok(authority) if authority.as_str() == host_header => {
-            // Authority.host() keeps IPv6 brackets ("[::1]"); the allowlist
-            // stores bare addresses ("::1").
-            let host = authority.host().trim_start_matches('[').trim_end_matches(']');
-            if state
-                .allowed_hosts
-                .iter()
-                .any(|allowed| allowed.eq_ignore_ascii_case(host))
-            {
-                // Allowlisted hosts are loopback names (a proxy host only
-                // enters the allowlist via public_url, which makes the issuer
-                // explicit), so plain http matches what the client dialed.
-                format!("http://{host_header}")
-            } else {
-                warn!(
-                    host = %host_header,
-                    issuer = %state.issuer,
-                    "request Host does not match the advertised OAuth issuer; \
-                     set server.public_url for proxied deployments"
-                );
-                state.issuer.clone()
-            }
+    match crate::links::parse_http_authority(host_header) {
+        Some(authority)
+            if crate::links::authority_is_allowlisted(&authority, &state.allowed_hosts) =>
+        {
+            // Allowlisted hosts are loopback names (a proxy host only enters
+            // the allowlist via public_url, which makes the issuer explicit),
+            // so plain http matches what the client dialed.
+            format!("http://{authority}")
         }
-        _ => state.issuer.clone(),
+        Some(_) => {
+            warn!(
+                host = %host_header,
+                issuer = %state.issuer,
+                "request Host does not match the advertised OAuth issuer; \
+                 set server.public_url for proxied deployments"
+            );
+            state.issuer.clone()
+        }
+        None => state.issuer.clone(),
     }
 }
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -22,26 +22,43 @@
   import Toaster from "./lib/toast/Toaster.svelte"; // LIF-243
   import { hasSession, getInstance, autoLogin, saveSession, clearSession, me } from "./lib/api";
   import { REALTIME_INVALIDATE_EVENT, type RealtimeEvent } from "./lib/autoRefresh.svelte";
+  import {
+    commentTargetFromHash,
+    routeForCommentHash,
+    routeWithCommentTarget,
+    splitResourcePath,
+  } from "./lib/commentLinks";
   import { motionReduced } from "./lib/theme";
   import { fade } from "svelte/transition";
   import { onDestroy, onMount } from "svelte";
 
   // Path-style deep links (LIF-247): external tools (e.g. the Dashboard)
   // link to plain paths like /LIF/overview or /LIF/issues/LIF-42. The server
-  // SPA-fallbacks those to index.html, but this app is hash-routed — so a
-  // path-only URL would silently land on Home. Translate the path into the
-  // hash route once at boot and clean the address bar. Runs before the
-  // initial `route` read below so the very first render targets the right
-  // page. Unknown paths fall through to the SPA's own 404, which is correct.
-  if (window.location.pathname !== "/" && !window.location.hash) {
+  // SPA-fallbacks those to index.html, but this app is hash-routed. Keep the
+  // path as the initial route when it carries a comment fragment; otherwise
+  // translate it into the hash route once at boot. A fragment already uses
+  // the browser's hash, so replacing it would make the router see only
+  // `comment-123` and render its 404 page.
+  const resourcePath = splitResourcePath(window.location.pathname);
+  const pathRoute =
+    window.location.pathname !== "/" && !window.location.hash.startsWith("#/")
+      ? (resourcePath?.route ?? window.location.pathname) +
+        window.location.search
+      : null;
+  const appBasePath =
+    resourcePath?.basePath ??
+    (window.location.hash.startsWith("#/")
+      ? window.location.pathname.replace(/\/$/, "")
+      : "");
+  if (pathRoute && !window.location.hash) {
     history.replaceState(
       null,
       "",
-      "/#" + window.location.pathname + window.location.search,
+      appBasePath + "/#" + pathRoute,
     );
   }
 
-  let route = $state(window.location.hash.slice(1) || "/");
+  let route = $state(pathRoute ?? (window.location.hash.slice(1) || "/"));
 
   // LIF-215: single-user mode. On a cold load with no session, ask the
   // instance whether web auto-login is enabled; if so, silently mint an admin
@@ -79,8 +96,20 @@
   }
 
   $effect(() => {
-    function onHash() {
-      route = window.location.hash.slice(1) || "/";
+    function onHash(event: HashChangeEvent) {
+      const hash = new URL(event.newURL).hash;
+      const commentTarget = commentTargetFromHash(hash);
+      if (commentTarget) {
+        const nextRoute = routeForCommentHash(hash, route);
+        if (hash.startsWith("#/")) route = nextRoute;
+        history.replaceState(
+          null,
+          "",
+          appBasePath + "/#" + routeWithCommentTarget(nextRoute, commentTarget),
+        );
+      } else if (hash === "" || hash.startsWith("#/")) {
+        route = hash.slice(1) || "/";
+      }
     }
     window.addEventListener("hashchange", onHash);
     return () => window.removeEventListener("hashchange", onHash);

--- a/web/src/lib/Comments.svelte
+++ b/web/src/lib/Comments.svelte
@@ -81,7 +81,10 @@
     if (!target || scrollingTarget === target || comments.length === 0) return;
     scrollingTarget = target;
     void tick().then(() => {
-      if (pendingCommentTarget !== target) return;
+      if (pendingCommentTarget !== target) {
+        if (scrollingTarget === target) scrollingTarget = null;
+        return;
+      }
       const comment = document.getElementById(target);
       if (!comment) {
         scrollingTarget = null;

--- a/web/src/lib/Comments.svelte
+++ b/web/src/lib/Comments.svelte
@@ -23,7 +23,12 @@
   import { MENTION_RE } from "./mentions";
   import { MessageSquare, CornerDownLeft, Paperclip } from "lucide-svelte";
   import { fly } from "svelte/transition";
-  import { tick, onDestroy } from "svelte";
+  import { tick, onDestroy, onMount } from "svelte";
+  import {
+    commentTargetFromHash,
+    routeWithCommentTarget,
+    splitResourcePath,
+  } from "./commentLinks";
   import { filesFromClipboard, insertAtCaret } from "./attachments/compose";
   import { createUploadController } from "./attachments/uploads.svelte";
   import DropOverlay from "./attachments/DropOverlay.svelte";
@@ -60,14 +65,42 @@
 
   let canSend = $derived(draft.trim().length > 0 && !submitting);
 
-  let hashScrolled = false;
+  let pendingCommentTarget = $state(commentTargetFromHash(window.location.hash));
+  let scrollingTarget: string | null = null;
+
+  onMount(() => {
+    function onHashChange(event: HashChangeEvent) {
+      pendingCommentTarget = commentTargetFromHash(new URL(event.newURL).hash);
+    }
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  });
+
   $effect(() => {
-    if (hashScrolled || comments.length === 0) return;
-    const target = window.location.hash.slice(1);
-    hashScrolled = true;
-    if (!target.startsWith("comment-")) return;
+    const target = pendingCommentTarget;
+    if (!target || scrollingTarget === target || comments.length === 0) return;
+    scrollingTarget = target;
     void tick().then(() => {
-      document.getElementById(target)?.scrollIntoView({ block: "center" });
+      if (pendingCommentTarget !== target) return;
+      const comment = document.getElementById(target);
+      if (!comment) {
+        scrollingTarget = null;
+        return;
+      }
+      comment.scrollIntoView({ block: "center" });
+      const resourcePath = splitResourcePath(window.location.pathname);
+      if (resourcePath && window.location.hash === `#${target}`) {
+        const route = resourcePath.route + window.location.search;
+        history.replaceState(
+          null,
+          "",
+          resourcePath.basePath +
+            "/#" +
+            routeWithCommentTarget(route, target),
+        );
+      }
+      pendingCommentTarget = null;
+      scrollingTarget = null;
     });
   });
 

--- a/web/src/lib/Comments.svelte
+++ b/web/src/lib/Comments.svelte
@@ -60,6 +60,17 @@
 
   let canSend = $derived(draft.trim().length > 0 && !submitting);
 
+  let hashScrolled = false;
+  $effect(() => {
+    if (hashScrolled || comments.length === 0) return;
+    const target = window.location.hash.slice(1);
+    hashScrolled = true;
+    if (!target.startsWith("comment-")) return;
+    void tick().then(() => {
+      document.getElementById(target)?.scrollIntoView({ block: "center" });
+    });
+  });
+
   // ── @mention autocomplete (LIF-263) ─────────────────────
   //
   // Candidates are fetched once when the project id is known; the popover
@@ -315,7 +326,7 @@
     <ol class="cmt__thread">
       {#each comments as comment (comment.id)}
         {@const author = comment.author_display_name || comment.author}
-        <li class="cmt__item" in:fly={{ y: 6, duration: 180 }}>
+        <li id={`comment-${comment.id}`} class="cmt__item" in:fly={{ y: 6, duration: 180 }}>
           <div class="cmt__avatar" aria-hidden="true">{initials(author)}</div>
           <div class="cmt__body">
             <div class="cmt__meta">

--- a/web/src/lib/commentLinks.ts
+++ b/web/src/lib/commentLinks.ts
@@ -1,0 +1,37 @@
+const COMMENT_ANCHOR = /^#comment-([1-9]\d*)$/;
+const COMMENT_TARGET = /^comment-([1-9]\d*)$/;
+const RESOURCE_PATH =
+  /^(.*)(\/[A-Za-z][A-Za-z0-9_-]*\/(?:overview|issues\/[A-Za-z][A-Za-z0-9_-]*-\d+|pages\/\d+|plans\/\d+|modules\/\d+))\/?$/i;
+
+export function splitResourcePath(
+  pathname: string,
+): { basePath: string; route: string } | null {
+  const match = pathname.match(RESOURCE_PATH);
+  return match ? { basePath: match[1], route: match[2] } : null;
+}
+
+export function commentTargetFromHash(hash: string): string | null {
+  const anchor = hash.match(COMMENT_ANCHOR);
+  if (anchor) return `comment-${anchor[1]}`;
+  if (!hash.startsWith("#/")) return null;
+
+  const queryStart = hash.indexOf("?");
+  if (queryStart < 0) return null;
+  const id = new URLSearchParams(hash.slice(queryStart + 1)).get("comment");
+  return id && /^[1-9]\d*$/.test(id) ? `comment-${id}` : null;
+}
+
+export function routeForCommentHash(hash: string, currentRoute: string): string {
+  return hash.startsWith("#/") ? hash.slice(1) || "/" : currentRoute;
+}
+
+export function routeWithCommentTarget(route: string, target: string): string {
+  const match = target.match(COMMENT_TARGET);
+  if (!match) return route;
+
+  const queryStart = route.indexOf("?");
+  const path = queryStart < 0 ? route : route.slice(0, queryStart);
+  const query = new URLSearchParams(queryStart < 0 ? "" : route.slice(queryStart + 1));
+  query.set("comment", match[1]);
+  return `${path}?${query}`;
+}

--- a/web/tests/commentLinks.test.ts
+++ b/web/tests/commentLinks.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+  commentTargetFromHash,
+  routeForCommentHash,
+  routeWithCommentTarget,
+  splitResourcePath,
+} from "../src/lib/commentLinks";
+
+describe("comment links", () => {
+  test("reads canonical anchors and normalized hash-route queries", () => {
+    expect(commentTargetFromHash("#comment-42")).toBe("comment-42");
+    expect(
+      commentTargetFromHash("#/LIF/issues/LIF-1?view=all&comment=42"),
+    ).toBe("comment-42");
+    expect(commentTargetFromHash("#unrelated")).toBeNull();
+  });
+
+  test("preserves route query parameters while carrying the comment target", () => {
+    expect(
+      routeWithCommentTarget("/LIF/issues/LIF-1?view=all", "comment-42"),
+    ).toBe("/LIF/issues/LIF-1?view=all&comment=42");
+  });
+
+  test("keeps plain anchors on the current route and adopts routed hashes", () => {
+    expect(
+      routeForCommentHash("#comment-42", "/LIF/issues/LIF-1"),
+    ).toBe("/LIF/issues/LIF-1");
+    expect(
+      routeForCommentHash(
+        "#/LIF/issues/LIF-2?comment=42",
+        "/LIF/issues/LIF-1",
+      ),
+    ).toBe("/LIF/issues/LIF-2?comment=42");
+  });
+
+  test("separates a public URL base path from the resource route", () => {
+    expect(splitResourcePath("/lific/LIF/issues/LIF-42")).toEqual({
+      basePath: "/lific",
+      route: "/LIF/issues/LIF-42",
+    });
+    expect(splitResourcePath("/LIF/pages/17")).toEqual({
+      basePath: "",
+      route: "/LIF/pages/17",
+    });
+    expect(splitResourcePath("/unrelated/path")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- render canonical Markdown links for projects, issues, project and workspace pages, plans, modules, and issue/page comments throughout MCP-over-HTTP responses
- add `web_url` fields to HTTP CLI JSON and Markdown links to human-readable HTTP CLI output, using the configured server URL
- link comments to their existing parent detail route with stable `#comment-N` anchors and make the web router preserve or adopt the correct route before scrolling
- keep stdio MCP and direct-SQL output plain because those transports do not know the authoritative external hostname

## Origin and safety model

- MCP creates links only from an explicit `server.public_url` or the direct request `Host` when that host matches the configured allowlist; forwarded headers are not trusted
- CLI links use the HTTP server URL from client configuration
- link bases must be HTTP(S), contain an authority, and have no credentials, query, or fragment; configured base paths are preserved
- MCP revalidates canonical identifiers so stale audit values, renamed projects, deleted resources, and the reserved `DOC` identifier do not produce plausible but invalid links
- HTTP CLI resolution carries the server-returned canonical issue and project identifiers into link construction instead of reconstructing them from case-insensitive user input
- deleted-resource receipts remain plain text because their target routes no longer exist

## Implementation notes

- centralize URL construction and Markdown escaping in a shared request-scoped link context
- read the MCP link context once per tool response and borrow it through nested issue, plan, page, module, relation, and comment formatters
- write linked output directly into response formatters without intermediate decorated response strings or repeated link-context ownership
- cover normal resource output, activity, search, plans and steps, relations, mutations, and comment CRUD without adding a separate comment page
- include parent page IDs in comment search results so page-comment URLs can target the correct route

## Test coverage

- origin selection and URL safety tests exercise explicit `server.public_url` precedence, allowlisted direct `Host` fallback, configured base-path preservation, and rejection of non-HTTP, credential-bearing, query-bearing, fragment-bearing, or otherwise ambiguous bases
- route-generation tests exercise projects, issues, project/workspace pages, plans, modules, and issue/page comments, including Markdown escaping and keeping malformed or reserved `DOC` identifiers plain outside workspace-page routes
- HTTP CLI tests exercise JSON and human output for normal resources, search comment hits, comment CRUD results, and modules; they also prove that case-insensitive lookup preserves the canonical identifier returned by the server
- MCP tests exercise resource lists/details, mutations, search, activity, relations, and plan steps, including direct comment anchors, parent links after comment deletion, plan-step links to their parent plan or attached issue, and plain output for deleted or stale identifiers after project renames
- MCP context tests prove that nested issue and plan rendering reads the link context once per tool response
- browser tests exercise canonical anchors, routed comment queries, existing route-query preservation, same-tab `#comment-N` changes, route adoption for `#/...?...comment=N`, and deployments under a public URL base path