### PR TITLE
feat(web): copy identifiers from headers, board cards, and list rows

### DIFF
--- a/web/src/lib/Breadcrumbs.svelte
+++ b/web/src/lib/Breadcrumbs.svelte
@@ -16,6 +16,11 @@
      *  breakpoint — matches Topbar hiding the project scope on phones,
      *  where the app header already shows the project. */
     hideBelowSm?: boolean;
+    /** The identifier to copy. When set, a copy button appears after the
+     *  label on hover or keyboard focus. It carries the value rather than a
+     *  flag because `label` is truncated for display while the copy has to
+     *  land the whole identifier. */
+    copy?: string;
   }
 </script>
 
@@ -31,6 +36,7 @@
   // this stays a pure presentational component.
 
   import { ChevronRight } from "lucide-svelte";
+  import CopyIdButton from "./CopyIdButton.svelte";
 
   let { segments }: { segments: Crumb[] } = $props();
 
@@ -59,7 +65,11 @@
           <ChevronRight size={12} class="text-[var(--text-faint)]" />
         </li>
       {/if}
-      <li class="min-w-0 flex items-center {seg.hideBelowSm ? 'hidden sm:flex' : ''}">
+      <li
+        class="group min-w-0 flex items-center {seg.hideBelowSm
+          ? 'hidden sm:flex'
+          : ''}"
+      >
         {#if seg.href && !isLast}
           <a
             href={seg.href}
@@ -87,6 +97,27 @@
             {/if}
             <span class="truncate max-w-[9rem] sm:max-w-[14rem]">{seg.label}</span>
           </span>
+        {/if}
+        {#if seg.copy}
+          <!-- Sibling of the crumb, never a wrapper: a linked crumb still
+               navigates across its whole hit area. Hidden below `sm` because
+               there is no hover on touch, and an invisible-but-tappable
+               button next to the label would be a trap there.
+
+               Width collapses to zero at rest so an idle trail reads as if
+               the button weren't there — reserving the box left odd gaps
+               between crumbs. It grows on hover, which nudges everything to
+               its right; `display: none` would avoid that too but drops the
+               button out of the tab order entirely. -->
+          <CopyIdButton
+            value={seg.copy}
+            label={seg.copy}
+            class="shrink-0 hidden sm:grid place-items-center overflow-hidden
+                   w-0 opacity-0 group-hover:w-5 group-hover:opacity-100
+                   focus-visible:w-5 focus-visible:opacity-100
+                   rounded text-[var(--text-faint)] hover:text-[var(--accent)]
+                   transition-all"
+          />
         {/if}
       </li>
     {/each}

--- a/web/src/lib/CopyIdButton.svelte
+++ b/web/src/lib/CopyIdButton.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  // One-tap copy for an identifier. The inline Copy -> Check flip is the
+  // success cue — nicer than a toast for a one-tap copy — while
+  // copyToClipboard still raises an error toast when the clipboard is
+  // unavailable, so a blocked copy can never read as a silent no-op.
+  //
+  // Children are optional. Pass the identifier as children for the bordered
+  // pill that reads "LIF-42 ⧉" (PeekPanel, ProjectSettings); omit them for an
+  // icon-only button where something else already renders the label
+  // (Breadcrumbs, where the crumb itself is the identifier).
+
+  import type { Snippet } from "svelte";
+  import { onDestroy } from "svelte";
+  import { Copy, Check } from "lucide-svelte";
+  import { copyToClipboard } from "./clipboard";
+
+  let {
+    value,
+    label = "identifier",
+    iconSize = 12,
+    class: klass = "",
+    iconClass = "",
+    children,
+  }: {
+    /** The full text to copy. Call sites pass the whole identifier even when
+     *  the visible label next to it is truncated. */
+    value: string;
+    /** Names the thing being copied in the tooltip and aria-label:
+     *  "Copy identifier", "Copy LIF-42". */
+    label?: string;
+    iconSize?: number;
+    class?: string;
+    /** Extra classes for the Copy icon alone — pill call sites reveal just
+     *  the icon on hover while their label stays put. Check never takes them:
+     *  the confirmation has to be visible wherever the click came from. */
+    iconClass?: string;
+    children?: Snippet;
+  } = $props();
+
+  let copied = $state(false);
+  let resetTimer: number | undefined;
+
+  async function copy(event: MouseEvent) {
+    // This button sits beside a breadcrumb link and inside clickable panel
+    // rows, so the copy must never double as a navigation.
+    event.preventDefault();
+    event.stopPropagation();
+    if (!(await copyToClipboard(value, { silentSuccess: true }))) return;
+    copied = true;
+    window.clearTimeout(resetTimer);
+    resetTimer = window.setTimeout(() => {
+      copied = false;
+    }, 1500);
+  }
+
+  onDestroy(() => window.clearTimeout(resetTimer));
+</script>
+
+<button
+  type="button"
+  class={klass}
+  onclick={copy}
+  title={`Copy ${label}`}
+  aria-label={`Copy ${label}`}
+>
+  {@render children?.()}
+  {#if copied}
+    <Check size={iconSize} />
+  {:else}
+    <Copy size={iconSize} class={iconClass} />
+  {/if}
+</button>

--- a/web/src/lib/issues/IssueCard.svelte
+++ b/web/src/lib/issues/IssueCard.svelte
@@ -6,9 +6,11 @@
   import PriorityIcon from "../PriorityIcon.svelte";
   import Tooltip from "../Tooltip.svelte";
   import TimeAgo from "../TimeAgo.svelte";
-  import { PanelRight, ExternalLink } from "lucide-svelte";
+  import { PanelRight, ExternalLink, Copy } from "lucide-svelte";
   import { openContextMenu } from "../contextMenuState.svelte"; // LIF-248
   import { projectCodeOf } from "../references"; // LIF-248
+  import { copyToClipboard } from "../clipboard";
+  import CopyIdButton from "../CopyIdButton.svelte";
 
   let {
     issue,
@@ -48,6 +50,13 @@
             "noopener",
           ),
       },
+      {
+        // Toasts rather than flipping a checkmark: the menu closes on
+        // action, so there is nothing left on screen to confirm on.
+        label: "Copy identifier",
+        icon: Copy,
+        action: () => copyToClipboard(issue.identifier),
+      },
     ]);
   }
 </script>
@@ -74,6 +83,20 @@
     <span class="text-micro font-mono text-[var(--text-faint)]">
       {issue.identifier}
     </span>
+    <!-- Copy the identifier without opening the card. Reserving the box
+         costs nothing here: the flex-1 spacer below absorbs it, so the peek
+         and priority affordances stay put. Pointer devices only — the touch
+         path to an identifier is the peek sheet. -->
+    <CopyIdButton
+      value={issue.identifier}
+      label={issue.identifier}
+      iconSize={11}
+      class="hidden shrink-0 size-5 items-center justify-center rounded
+             text-[var(--text-faint)] hover:text-[var(--accent)]
+             hover:bg-[var(--bg-subtle)] transition-colors
+             [@media(hover:hover)]:flex [@media(hover:hover)]:opacity-0
+             [@media(hover:hover)]:group-hover:opacity-100"
+    />
     <div class="flex-1"></div>
     <!-- LIF-244: hover-revealed peek trigger on pointer devices. On touch
          it's always visible (LIF-275) — with drag being the only other

--- a/web/src/lib/issues/IssueCard.svelte
+++ b/web/src/lib/issues/IssueCard.svelte
@@ -80,23 +80,30 @@
 >
   <!-- Top row: identifier + peek affordance + priority -->
   <div class="flex items-center gap-2 mb-1.5">
-    <span class="text-micro font-mono text-[var(--text-faint)]">
-      {issue.identifier}
-    </span>
-    <!-- Copy the identifier without opening the card. Reserving the box
-         costs nothing here: the flex-1 spacer below absorbs it, so the peek
-         and priority affordances stay put. Pointer devices only — the touch
-         path to an identifier is the peek sheet. -->
-    <CopyIdButton
-      value={issue.identifier}
-      label={issue.identifier}
-      iconSize={11}
-      class="hidden shrink-0 size-5 items-center justify-center rounded
-             text-[var(--text-faint)] hover:text-[var(--accent)]
-             hover:bg-[var(--bg-subtle)] transition-colors
-             [@media(hover:hover)]:flex [@media(hover:hover)]:opacity-0
-             [@media(hover:hover)]:group-hover:opacity-100"
-    />
+    <!-- Identifier and its copy button pair up in their own flex so the
+         button stays close to the identifier it copies, while the row's
+         gap-2 keeps separating the affordances on the right. The small gap
+         is deliberate: at zero the button's hover background bleeds into
+         the identifier text.
+         Copying without opening the card costs no layout here: the flex-1
+         spacer below absorbs the button's box, so the peek and priority
+         affordances stay put. Pointer devices only — the touch path to an
+         identifier is the peek sheet. -->
+    <div class="flex items-center gap-1">
+      <span class="text-micro font-mono text-[var(--text-faint)]">
+        {issue.identifier}
+      </span>
+      <CopyIdButton
+        value={issue.identifier}
+        label={issue.identifier}
+        iconSize={11}
+        class="hidden shrink-0 size-5 items-center justify-center rounded
+               text-[var(--text-faint)] hover:text-[var(--accent)]
+               hover:bg-[var(--bg-subtle)] transition-colors
+               [@media(hover:hover)]:flex [@media(hover:hover)]:opacity-0
+               [@media(hover:hover)]:group-hover:opacity-100"
+      />
+    </div>
     <div class="flex-1"></div>
     <!-- LIF-244: hover-revealed peek trigger on pointer devices. On touch
          it's always visible (LIF-275) — with drag being the only other

--- a/web/src/lib/issues/IssueRow.svelte
+++ b/web/src/lib/issues/IssueRow.svelte
@@ -10,7 +10,7 @@
   // state instance; keeping them explicit here first makes the seam
   // reviewable and build-verifiable.
   import type { Issue, Label, Module } from "../api";
-  import { Check, Signal, Layers, PanelRight, ExternalLink } from "lucide-svelte";
+  import { Check, Signal, Layers, PanelRight, ExternalLink, Copy } from "lucide-svelte";
   import StatusIcon from "../StatusIcon.svelte";
   import PriorityIcon from "../PriorityIcon.svelte";
   import ProjectIcon from "../ProjectIcon.svelte";
@@ -18,6 +18,7 @@
   import TimeAgo from "../TimeAgo.svelte";
   import { STATUSES, PRIORITIES, descriptionPreview } from "./grouping";
   import { openContextMenu } from "../contextMenuState.svelte"; // LIF-248
+  import { copyToClipboard } from "../clipboard";
   import { projectCodeOf } from "../references"; // LIF-248
 
   let {
@@ -135,6 +136,16 @@
             "_blank",
             "noopener",
           ),
+      },
+      {
+        // The row's identifier column is a fixed 72px butted against the
+        // title, so a hover-revealed button there would squeeze one or
+        // shove the other on every row the pointer crosses. The menu that
+        // already exists costs no pixels. Toasts rather than flipping a
+        // checkmark: the menu closes on action.
+        label: "Copy identifier",
+        icon: Copy,
+        action: () => copyToClipboard(issue.identifier),
       },
     ]);
   }

--- a/web/src/lib/issues/PeekPanel.svelte
+++ b/web/src/lib/issues/PeekPanel.svelte
@@ -37,20 +37,20 @@
   import { peekState, closePeek, notifyPeekSync } from "./peek.svelte";
   import { updateIssueWithUndo } from "./state.svelte";
   import { toast } from "../toast/toast.svelte";
-  import { copyToClipboard } from "../clipboard";
   import { STATUSES, PRIORITIES } from "./grouping";
   import { projectCodeOf } from "../references";
   import StatusIcon from "../StatusIcon.svelte";
   import PriorityIcon from "../PriorityIcon.svelte";
   import ProjectIcon from "../ProjectIcon.svelte";
   import Skeleton from "../Skeleton.svelte"; // LIF-281
+  import CopyIdButton from "../CopyIdButton.svelte";
   import InlineTitle from "../InlineTitle.svelte";
   import Markdown from "../Markdown.svelte";
   import Select from "../Select.svelte";
   import { formatDate } from "../format";
   import { motionReduced } from "../theme";
   import { fly, fade } from "svelte/transition";
-  import { X, Copy, Check, ArrowUpRight, MessageSquare, Layers } from "lucide-svelte";
+  import { X, ArrowUpRight, MessageSquare, Layers } from "lucide-svelte";
 
   let {
     navigate,
@@ -64,7 +64,6 @@
   let commentCount = $state<number | null>(null);
   let loading = $state(false);
   let error = $state("");
-  let copied = $state(false);
 
   // Guards against a stale fetch (for a since-superseded identifier)
   // landing after a newer one — "opening another issue while open swaps
@@ -172,17 +171,6 @@
     }
   }
 
-  async function copyIdentifier() {
-    if (!issue) return;
-    // Keep the inline checkmark flip on success (nicer than a toast for a
-    // one-tap copy); the helper still surfaces an error toast on failure.
-    const ok = await copyToClipboard(issue.identifier, { silentSuccess: true });
-    if (ok) {
-      copied = true;
-      window.setTimeout(() => { copied = false; }, 1500);
-    }
-  }
-
   function openFullView() {
     if (!issue) return;
     const path = `/${projectCodeOf(issue.identifier)}/issues/${issue.identifier}`;
@@ -277,16 +265,16 @@
          scrolls. -->
     <div class="shrink-0 flex items-center gap-2 px-4 pt-2 pb-2 md:pt-4 border-b border-[var(--border)]">
       {#if issue}
-        <button
+        <CopyIdButton
+          value={issue.identifier}
+          iconSize={11}
+          iconClass="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity"
           class="group inline-flex items-center gap-1 text-caption font-mono font-semibold
                  px-1.5 py-0.5 rounded border border-[var(--border)] text-[var(--text-muted)]
                  hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
-          onclick={copyIdentifier}
-          title="Copy identifier"
         >
           {issue.identifier}
-          {#if copied}<Check size={11} />{:else}<Copy size={11} class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity" />{/if}
-        </button>
+        </CopyIdButton>
         {#if commentCount !== null && commentCount > 0}
           <span class="inline-flex items-center gap-1 text-caption text-[var(--text-faint)]">
             <MessageSquare size={12} />
@@ -490,14 +478,16 @@
          cover. -->
     {#if issue}
       <div class="shrink-0 border-t border-[var(--border)] px-4 py-3 flex items-center justify-between gap-2">
-        <button
-          class="inline-flex items-center gap-1 text-body-sm text-[var(--text-muted)]
-                 hover:text-[var(--text)] transition-colors"
-          onclick={copyIdentifier}
+        <!-- flex-row-reverse keeps the icon ahead of the label here, where the
+             button reads as an action rather than as an identifier pill. -->
+        <CopyIdButton
+          value={issue.identifier}
+          iconSize={13}
+          class="inline-flex flex-row-reverse items-center gap-1 text-body-sm
+                 text-[var(--text-muted)] hover:text-[var(--text)] transition-colors"
         >
-          {#if copied}<Check size={13} />{:else}<Copy size={13} />{/if}
           Copy identifier
-        </button>
+        </CopyIdButton>
         <button
           class="inline-flex items-center gap-1.5 text-body-sm font-medium
                  text-[var(--accent)] hover:underline transition-colors"

--- a/web/src/routes/IssueDetail.svelte
+++ b/web/src/routes/IssueDetail.svelte
@@ -467,12 +467,12 @@
   backRoute={backHref()}
   backLabel={backText()}
   breadcrumbSegments={[
-    { label: projectIdentifier, href: `#/${projectIdentifier}/overview`, mono: true, hideBelowSm: true },
+    { label: projectIdentifier, href: `#/${projectIdentifier}/overview`, mono: true, hideBelowSm: true, copy: projectIdentifier },
     // Collapsed below sm: since LIF-349 the app header already reads
     // "<project>  Issues", so this crumb is duplicated text on a phone and
     // the detail topbar has no room to spare.
     { label: backText(), href: `#${backHref()}`, hideBelowSm: true },
-    { label: issue?.identifier ?? issueIdentifier, mono: true },
+    { label: issue?.identifier ?? issueIdentifier, mono: true, copy: issue?.identifier ?? issueIdentifier },
   ]}
   {editable}
   {canComment}

--- a/web/src/routes/ModuleDetail.svelte
+++ b/web/src/routes/ModuleDetail.svelte
@@ -282,7 +282,7 @@
       <div class="flex items-center gap-1.5 shrink-0 min-w-0">
         <Breadcrumbs
           segments={[
-            { label: projectIdentifier, href: `#/${projectIdentifier}/overview`, mono: true, hideBelowSm: true },
+            { label: projectIdentifier, href: `#/${projectIdentifier}/overview`, mono: true, hideBelowSm: true, copy: projectIdentifier },
             { label: "Modules", href: `#/${projectIdentifier}/modules` },
             { label: mod.name },
           ]}

--- a/web/src/routes/PageDetail.svelte
+++ b/web/src/routes/PageDetail.svelte
@@ -309,7 +309,7 @@
   // otherwise never surfaced in the shell.
   let breadcrumbSegments = $derived.by<import("../lib/Breadcrumbs.svelte").Crumb[]>(() => {
     const crumbs: import("../lib/Breadcrumbs.svelte").Crumb[] = [
-      { label: projectIdentifier, href: `#/${projectIdentifier}/overview`, mono: true, hideBelowSm: true },
+      { label: projectIdentifier, href: `#/${projectIdentifier}/overview`, mono: true, hideBelowSm: true, copy: projectIdentifier },
       // Collapsed below sm — the app header already states the section.
       { label: "Pages", href: `#/${projectIdentifier}/pages`, hideBelowSm: true },
     ];
@@ -317,7 +317,9 @@
       const name = folders.find((f) => f.id === page!.folder_id)?.name;
       if (name) crumbs.push({ label: name, href: `#/${projectIdentifier}/pages` });
     }
-    crumbs.push({ label: page?.identifier || "Page", mono: true });
+    // `copy` stays unset until the page loads, so nobody can copy the
+    // placeholder "Page" label.
+    crumbs.push({ label: page?.identifier || "Page", mono: true, copy: page?.identifier });
     return crumbs;
   });
 

--- a/web/src/routes/PlanDetail.svelte
+++ b/web/src/routes/PlanDetail.svelte
@@ -352,9 +352,13 @@
   backRoute={`/${projectIdentifier}/plans`}
   backLabel="Plans"
   breadcrumbSegments={[
-    { label: projectIdentifier, href: `#/${projectIdentifier}/overview`, mono: true, hideBelowSm: true },
+    { label: projectIdentifier, href: `#/${projectIdentifier}/overview`, mono: true, hideBelowSm: true, copy: projectIdentifier },
     { label: "Plans", href: `#/${projectIdentifier}/plans` },
-    { label: plan?.title || plan?.identifier || `PLAN-${planId}` },
+    // The trail ends in the identifier, not the title, matching issues and
+    // pages: the title already reads as the heading directly below, while the
+    // identifier had nowhere else to surface. `copy` stays unset until the
+    // plan loads so nobody copies the `PLAN-3` placeholder.
+    { label: plan?.identifier ?? `PLAN-${planId}`, mono: true, copy: plan?.identifier },
   ]}
   editable={canEdit}
   title={plan?.title ?? ""}

--- a/web/src/routes/ProjectSettings.svelte
+++ b/web/src/routes/ProjectSettings.svelte
@@ -33,17 +33,17 @@
   import { formatDate } from "../lib/format";
   import TimeAgo from "../lib/TimeAgo.svelte";
   import {
-    ChevronRight, Download, Pencil, Copy, Check, ArrowRight, History,
+    ChevronRight, Download, Pencil, Check, ArrowRight, History,
     AlertTriangle, ChevronDown,
   } from "lucide-svelte";
   import ErrorState from "../lib/ErrorState.svelte";
   import Skeleton from "../lib/Skeleton.svelte";
+  import CopyIdButton from "../lib/CopyIdButton.svelte";
   import { getContext } from "svelte";
   // LIF-234: role-aware affordance gating. `canManage` = lead/admin (or
   // enforcement off) — settings edits, danger zone, members, and import are
   // all lead-level. `canEdit` = maintainer/admin — label management.
   import { projectRole, loadProjectRole } from "../lib/projectRole.svelte";
-  import { copyToClipboard } from "../lib/clipboard";
   import { toast } from "../lib/toast/toast.svelte";
 
   const topbarCtx = getContext<{
@@ -79,7 +79,6 @@
   let editingDesc = $state(false);
   let draftDesc = $state("");
   let savedAt = $state(0); // ms timestamp of last successful field save
-  let copied = $state(false);
 
   // Danger zone
   let dangerOpen = $state(false);
@@ -227,17 +226,6 @@
     onProjectChange?.();
     savedAt = Date.now();
     window.setTimeout(() => { if (Date.now() - savedAt >= 1900) savedAt = 0; }, 2000);
-  }
-
-  async function copyIdentifier() {
-    if (!project) return;
-    // Inline checkmark flip stays as the success cue; the helper still toasts
-    // on failure so a blocked clipboard no longer no-ops silently.
-    const ok = await copyToClipboard(project.identifier, { silentSuccess: true });
-    if (ok) {
-      copied = true;
-      window.setTimeout(() => { copied = false; }, 1500);
-    }
   }
 
   // ── Importance heuristic ─────────────────────────────
@@ -450,16 +438,16 @@
                   <Pencil size={14} class="text-[var(--text-faint)] opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity" />
                 </button>
               {/if}
-              <button
+              <CopyIdButton
+                value={project.identifier}
+                iconSize={11}
+                iconClass="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity"
                 class="group inline-flex items-center gap-1 text-micro font-mono font-semibold
                        px-1.5 py-0.5 rounded border border-[var(--border)] text-[var(--text-muted)]
                        hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
-                onclick={copyIdentifier}
-                title="Copy identifier"
               >
                 {project.identifier}
-                {#if copied}<Check size={11} />{:else}<Copy size={11} class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity" />{/if}
-              </button>
+              </CopyIdButton>
               {#if savedAt}
                 <span class="inline-flex items-center gap-1 text-micro text-[var(--success)]" aria-live="polite">
                   <Check size={11} /> Saved


### PR DESCRIPTION
Identifiers are the handles used in MCP tools, exports and cross-references, but the only way to get one out of the UI was to select the text by hand or open the issue and use the peek panel.

### Detail headers

`Crumb` gains an opt-in `copy` field. When set, a copy button appears after the label on hover or keyboard focus:

```
BLT  ›  Issues  ›  BLT-25 ⧉
```

It carries the value rather than a flag because crumb labels are truncated for display while the copy has to land the whole identifier. The button's width collapses to zero at rest, so an idle trail looks exactly as it does today — reserving the box left odd gaps between crumbs. `display: none` would avoid the reserve too, but drops the button out of the tab order, so width it is. Below `sm` it is hidden outright: there is no hover on touch, and an invisible-but-tappable button beside the label would be a trap.

Enabled on the project code in all four detail headers, plus the issue and page identifiers.

`PlanDetail` also swaps its trailing crumb from the plan title to the plan identifier, matching what issues and pages already do — the title reads as the heading directly below, so it was printing twice while the identifier had nowhere to surface.

### Board cards and list rows

- **Board card**: hover-revealed button beside the identifier, following the peek affordance's own reveal pattern. The `flex-1` spacer absorbs its box, so peek and priority never shift.
- **List row**: the same action in the context menu instead. The row's identifier column is a fixed 72px butted against the title, where a hover button would squeeze one or shove the other on every row the pointer crosses; the menu that already exists costs no pixels.
- Both gain a `Copy identifier` context-menu entry, which toasts rather than flipping a checkmark — the menu closes on action, leaving nothing on screen to confirm on.

### One component instead of three

`PeekPanel` and `ProjectSettings` each hand-rolled the same copy + `Copy`/`Check` flip + 1.5s timeout. That now lives in `CopyIdButton`, which both adopt with their existing classes and no visual change. Optional children make it either an identifier pill or an icon-only button.

One behavior change worth flagging: PeekPanel's header pill and its footer button used to share a single `copied` flag, so clicking either flipped both. They now flip independently.

### Verification

`bun run check` is clean (49 warnings, all pre-existing — identical to `master`) and `bun run build` passes. Walked in the running app: every identifier crumb across issue, page, module and plan; the board card; the list row's context menu; keyboard focus reaching the button; a narrow viewport; and the failure path with `writeText` and `execCommand` both forced to fail, which toasts and leaves the icon un-flipped.
