### PR TITLE
feat(web): comment anchors and #N auto-linking

### DIFF
--- a/web/src/lib/Comments.svelte
+++ b/web/src/lib/Comments.svelte
@@ -366,6 +366,7 @@
           <div class="cmt__avatar" aria-hidden="true">{initials(author)}</div>
           <div class="cmt__body">
             <div class="cmt__meta">
+              <a href="#comment-{comment.id}" class="cmt__anchor">#{comment.id}</a>
               <span class="cmt__author">{author}</span>
               <span class="cmt__time"><TimeAgo date={comment.created_at} /></span>
             </div>
@@ -569,6 +570,16 @@
     align-items: baseline;
     gap: 0.5rem;
     margin-bottom: 0.125rem;
+  }
+  .cmt__anchor {
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-faint);
+    text-decoration: none;
+  }
+  .cmt__anchor:hover {
+    color: var(--text-muted);
+    text-decoration: underline;
   }
   .cmt__author {
     font-size: 0.875rem;

--- a/web/src/lib/Markdown.svelte
+++ b/web/src/lib/Markdown.svelte
@@ -2,7 +2,7 @@
   import { marked } from "marked";
   import DOMPurify from "dompurify";
   import IssueHoverCard from "./IssueHoverCard.svelte";
-  import { IDENTIFIER_RE, refKind, routeFor, projectCodeOf } from "./references";
+  import { IDENTIFIER_RE, PROJECT_CODE_RE, refKind, routeFor, projectCodeOf } from "./references";
   import { openPeek } from "./issues/peek.svelte"; // LIF-248
   import { openContextMenu } from "./contextMenuState.svelte"; // LIF-248
   import { PanelRight, ExternalLink } from "lucide-svelte";
@@ -63,6 +63,64 @@
       });
       if (mentionKnown.size > 0) out = linkMentionsInText(out, mentionKnown);
       return out;
+    });
+  }
+
+  // Cross-issue comment links: "WS-25#comment-42" → anchor on the WS-25 issue page.
+  // Must run before linkIdentifiers so the full "IDENT#comment-N" token is consumed
+  // as one unit before IDENTIFIER_RE picks up "WS-25" alone.
+  const CROSS_COMMENT_RE = new RegExp(
+    `\\b(${PROJECT_CODE_RE}-\\d+)#comment-([1-9]\\d*)\\b`,
+    "g",
+  );
+
+  function linkCrossCommentRefs(html: string): string {
+    let skipDepth = 0;
+    return html.replace(/<[^>]+>|[^<]+/g, (token) => {
+      if (token[0] === "<") {
+        const m = token.match(TAG_NAME_RE);
+        if (m && SKIP_LINKING_TAGS.has(m[1].toLowerCase())) {
+          const isClosing = token[1] === "/";
+          const isSelfClosing = token.endsWith("/>");
+          if (isClosing) skipDepth = Math.max(0, skipDepth - 1);
+          else if (!isSelfClosing) skipDepth += 1;
+        }
+        return token;
+      }
+      if (skipDepth > 0) return token;
+      return token.replace(CROSS_COMMENT_RE, (_, ident, commentId) => {
+        const project = projectCodeOf(ident);
+        // routeFor returns "#/PROJECT/issues/IDENT"; append ?comment=N so
+        // commentTargetFromHash can scroll to the right comment on load.
+        const href = `${routeFor(project, "issue", ident)}?comment=${commentId}`;
+        return `<a href="${href}" class="identifier-link" data-issue-ident="${ident}">${ident}#comment-${commentId}</a>`;
+      });
+    });
+  }
+
+  // Same-page comment refs: bare "#42" → "#comment-42" anchor on the current page.
+  // Runs after linkIdentifiers so issue identifiers ("WS-25") are already wrapped
+  // and won't be re-processed. The <a>/<code>/<pre> depth guard ensures "#42"
+  // inside code spans or existing links is left alone.
+  const COMMENT_REF_RE = /(?<![A-Za-z0-9_-])#([1-9]\d*)\b/g;
+
+  function linkCommentRefs(html: string): string {
+    let skipDepth = 0;
+    return html.replace(/<[^>]+>|[^<]+/g, (token) => {
+      if (token[0] === "<") {
+        const m = token.match(TAG_NAME_RE);
+        if (m && SKIP_LINKING_TAGS.has(m[1].toLowerCase())) {
+          const isClosing = token[1] === "/";
+          const isSelfClosing = token.endsWith("/>");
+          if (isClosing) skipDepth = Math.max(0, skipDepth - 1);
+          else if (!isSelfClosing) skipDepth += 1;
+        }
+        return token;
+      }
+      if (skipDepth > 0) return token;
+      return token.replace(COMMENT_REF_RE, (_, n) =>
+        `<a href="#comment-${n}" class="comment-ref">#${n}</a>`,
+      );
     });
   }
 
@@ -134,7 +192,11 @@
   // their class + data-* attributes, GFM tables, task-list checkboxes, and the
   // LIF-262 attachment img/chip markup).
   let html = $derived(
-    DOMPurify.sanitize(decorateAttachmentLinks(linkIdentifiers(rendered, mentionMap)), {
+    DOMPurify.sanitize(
+      decorateAttachmentLinks(
+        linkCommentRefs(linkIdentifiers(linkCrossCommentRefs(rendered), mentionMap)),
+      ),
+      {
       // Keep the data-mermaid / data-lang / data-issue-ident / data-mention
       // hooks the post-render effects (and mention chips) read, plus
       // data-attachment (chip decoration) and the download attr on


### PR DESCRIPTION
## Problem

Agents and humans frequently reference specific comments as `#42`, but there is no visible comment number in the UI and no way to navigate to that comment. The link is dead — it goes nowhere. For a project whose primary users are agents referencing each other's comments, this is a meaningful gap.

The comment `id` already exists in the DB and is returned by the API. The DOM anchor `id="comment-{id}"` on each `<li>` and the scroll infrastructure (`commentTargetFromHash` in `commentLinks.ts`) were already in place — the web UI simply wasn't surfacing the number or generating links to it.

---

## Changes

**`Comments.svelte`** — adds a clickable `#N` link to each comment header. Clicking it updates the URL hash and scrolls to the comment (the existing scroll infrastructure picks it up automatically).

**`Markdown.svelte`** — two new post-processing passes modelled on the existing `linkIdentifiers`:

- `linkCrossCommentRefs` — `WS-25#comment-42` in text becomes a link to issue WS-25 with `?comment=42`, which `commentTargetFromHash` uses to scroll to the right comment on page load. Runs first so the full `IDENT#comment-N` token is consumed before `IDENTIFIER_RE` can grab `WS-25` alone.
- `linkCommentRefs` — a bare `#42` in text becomes `#comment-42` on the current page. Runs after `linkIdentifiers`.

Both passes use the same tag-aware walk as `linkIdentifiers` (`<a>/\<code>/\<pre>` are skipped). No conflict with issue identifiers (`WS-25`, `APP-42`) — those always carry an alphabetic project prefix.

Backend unchanged.

---

## Verification

- Existing identifier linking (`WS-25` → issue) unaffected
- `# heading` and ```#42``` are not linked
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --all-targets` — 1229 passed, 0 failed