### PR TITLE
feat(web): edit and delete own comments

### DIFF
--- a/web/src/lib/Comments.svelte
+++ b/web/src/lib/Comments.svelte
@@ -21,7 +21,7 @@
   } from "./api";
   import { fuzzyMatch } from "./fuzzy";
   import { MENTION_RE } from "./mentions";
-  import { MessageSquare, CornerDownLeft, Paperclip } from "lucide-svelte";
+  import { MessageSquare, CornerDownLeft, Paperclip, MoreHorizontal } from "lucide-svelte";
   import { fly } from "svelte/transition";
   import { tick, onDestroy, onMount } from "svelte";
   import {
@@ -33,11 +33,15 @@
   import { createUploadController } from "./attachments/uploads.svelte";
   import DropOverlay from "./attachments/DropOverlay.svelte";
   import PendingUploads from "./attachments/PendingUploads.svelte";
+  import { canManageComment, commentWasEdited } from "./commentState";
 
   let {
     comments,
     editable = true,
     onSubmit,
+    currentUser = null,
+    onUpdate,
+    onDelete,
     placeholder = "Write a comment\u2026",
     // LIF-263: project the comments belong to. When set, the composer
     // fetches @mention candidates and offers autocomplete. Null (workspace
@@ -53,6 +57,9 @@
     comments: Comment[];
     editable?: boolean;
     onSubmit: (content: string) => Promise<Comment | null>;
+    currentUser?: { id: number } | null;
+    onUpdate?: (id: number, content: string) => Promise<Comment | null>;
+    onDelete?: (id: number) => Promise<boolean>;
     placeholder?: string;
     projectId?: number | null;
     attachTo?: { entity_type: AttachmentEntity; entity_id: number } | null;
@@ -62,6 +69,14 @@
   let submitting = $state(false);
   let textareaEl = $state<HTMLTextAreaElement | null>(null);
   let fileInputEl = $state<HTMLInputElement | null>(null);
+  let editingId = $state<number | null>(null);
+  let editDraft = $state("");
+  let editTextareaEl = $state<HTMLTextAreaElement | null>(null);
+  let editFileInputEl = $state<HTMLInputElement | null>(null);
+  let updatingId = $state<number | null>(null);
+  let deletingId = $state<number | null>(null);
+  let menuId = $state<number | null>(null);
+  let confirmDeleteId = $state<number | null>(null);
 
   let canSend = $derived(draft.trim().length > 0 && !submitting);
 
@@ -162,13 +177,14 @@
   });
 
   function updateMentionContext() {
-    const el = textareaEl;
+    const el = editingId === null ? textareaEl : editTextareaEl;
     if (!el || candidates.length === 0) {
       mentionOpen = false;
       return;
     }
     const caret = el.selectionStart ?? 0;
-    const before = draft.slice(0, caret);
+    const activeDraft = editingId === null ? draft : editDraft;
+    const before = activeDraft.slice(0, caret);
     const m = before.match(ACTIVE_MENTION_RE);
     if (m) {
       mentionOpen = true;
@@ -181,13 +197,15 @@
   }
 
   function selectMention(cand: MentionCandidate) {
-    const el = textareaEl;
+    const el = editingId === null ? textareaEl : editTextareaEl;
     if (!el) return;
-    const caret = el.selectionStart ?? draft.length;
-    const before = draft.slice(0, mentionStart);
-    const after = draft.slice(caret);
+    const activeDraft = editingId === null ? draft : editDraft;
+    const caret = el.selectionStart ?? activeDraft.length;
+    const before = activeDraft.slice(0, mentionStart);
+    const after = activeDraft.slice(caret);
     const insert = `@${cand.username} `;
-    draft = before + insert + after;
+    if (editingId === null) draft = before + insert + after;
+    else editDraft = before + insert + after;
     mentionOpen = false;
     // Restore caret just past the inserted token + trailing space.
     const nextCaret = before.length + insert.length;
@@ -256,7 +274,12 @@
     if (onMentionKeydown(e)) return;
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
-      submit();
+      if (editingId === null) submit();
+      else saveEdit();
+    }
+    if (e.key === "Escape" && editingId !== null) {
+      e.preventDefault();
+      cancelEdit();
     }
   }
 
@@ -267,7 +290,7 @@
 
   // Grow the textarea with its content; CSS min-height floors it.
   function resize() {
-    const el = textareaEl;
+    const el = editingId === null ? textareaEl : editTextareaEl;
     if (!el) return;
     el.style.height = "auto";
     el.style.height = `${el.scrollHeight}px`;
@@ -275,14 +298,18 @@
 
   // ── LIF-262: attachment uploads ──────────────────────────
 
-  function insertSnippet(snippet: string) {
-    const el = textareaEl;
+  function insertSnippet(snippet: string, edit = false) {
+    const el = edit ? editTextareaEl : textareaEl;
+    const activeDraft = edit ? editDraft : draft;
     if (!el) {
-      draft = draft + (draft.endsWith("\n") || draft === "" ? "" : "\n") + snippet + "\n";
+      const next = activeDraft + (activeDraft.endsWith("\n") || activeDraft === "" ? "" : "\n") + snippet + "\n";
+      if (edit) editDraft = next;
+      else draft = next;
       return;
     }
-    const { text, caret } = insertAtCaret(el, draft, snippet);
-    draft = text;
+    const { text, caret } = insertAtCaret(el, activeDraft, snippet);
+    if (edit) editDraft = text;
+    else draft = text;
     requestAnimationFrame(() => {
       el.focus();
       el.setSelectionRange(caret, caret);
@@ -298,18 +325,28 @@
   });
   onDestroy(() => uploads.destroy());
 
-  function onPaste(e: ClipboardEvent) {
+  const editUploads = createUploadController({
+    // Link only after a successful PUT re-scans the saved Markdown. This
+    // keeps Cancel and editor switches free of attachment side effects.
+    link: () => null,
+    onInsert: (snippet) => {
+      if (editingId !== null) insertSnippet(snippet, true);
+    },
+  });
+  onDestroy(() => editUploads.destroy());
+
+  function onPaste(e: ClipboardEvent, edit = false) {
     const files = filesFromClipboard(e);
     if (files.length > 0) {
       e.preventDefault();
-      uploads.enqueue(files);
+      (edit ? editUploads : uploads).enqueue(files);
     }
   }
 
-  function onFilePicked(e: Event) {
+  function onFilePicked(e: Event, edit = false) {
     const input = e.target as HTMLInputElement;
     if (input.files && input.files.length > 0) {
-      uploads.enqueue(Array.from(input.files));
+      (edit ? editUploads : uploads).enqueue(Array.from(input.files));
       input.value = "";
     }
   }
@@ -320,6 +357,47 @@
       .slice(0, 2)
       .map((w) => w[0]?.toUpperCase() ?? "")
       .join("");
+  }
+
+  function startEdit(comment: Comment) {
+    editUploads.destroy();
+    editingId = comment.id;
+    editDraft = comment.content;
+    menuId = null;
+    confirmDeleteId = null;
+    tick().then(() => {
+      editTextareaEl?.focus();
+      resize();
+    });
+  }
+
+  function cancelEdit() {
+    if (updatingId !== null) return;
+    editUploads.destroy();
+    editingId = null;
+    editDraft = "";
+    mentionOpen = false;
+  }
+
+  async function saveEdit() {
+    if (editingId === null || updatingId !== null || editUploads.busy || editDraft.trim() === "" || !onUpdate) return;
+    const id = editingId;
+    updatingId = id;
+    const updated = await onUpdate(id, editDraft.trim());
+    updatingId = null;
+    if (updated && editingId === id) cancelEdit();
+  }
+
+  async function confirmDelete(id: number) {
+    if (deletingId !== null || !onDelete) return;
+    deletingId = id;
+    const deleted = await onDelete(id);
+    deletingId = null;
+    if (deleted) {
+      if (editingId === id) cancelEdit();
+      menuId = null;
+      confirmDeleteId = null;
+    }
   }
 
   // LIF-159 — palette "Add comment" action: scroll the composer into
@@ -337,9 +415,10 @@
   // composer into view.
   export async function insertQuote(text: string) {
     const quoted = text.split("\n").map((l) => "> " + l).join("\n") + "\n\n";
-    draft = quoted + draft;
+    if (editingId === null) draft = quoted + draft;
+    else editDraft = quoted + editDraft;
     await tick();
-    const el = textareaEl;
+    const el = editingId === null ? textareaEl : editTextareaEl;
     if (el) {
       el.focus();
       resize();
@@ -369,10 +448,69 @@
               <a href="#comment-{comment.id}" class="cmt__anchor">#{comment.id}</a>
               <span class="cmt__author">{author}</span>
               <span class="cmt__time"><TimeAgo date={comment.created_at} /></span>
+              {#if commentWasEdited(comment)}
+                <span class="cmt__edited" title={`Edited ${comment.updated_at}`}>edited</span>
+              {/if}
+              {#if canManageComment(comment, currentUser, onUpdate !== undefined && onDelete !== undefined)}
+                <div class="cmt__menu-wrap">
+                  <button
+                    type="button"
+                    class="cmt__menu-button"
+                    aria-label={`Comment ${comment.id} actions`}
+                    aria-haspopup="menu"
+                    aria-expanded={menuId === comment.id}
+                    onclick={() => {
+                      menuId = menuId === comment.id ? null : comment.id;
+                      confirmDeleteId = null;
+                    }}
+                    onfocus={() => (menuId = comment.id)}
+                    onkeydown={(e) => { if (e.key === "Escape") menuId = null; }}
+                  ><MoreHorizontal size={16} /></button>
+                  {#if menuId === comment.id}
+                    <div class="cmt__menu" role="menu" aria-label={`Comment ${comment.id} actions`}>
+                      {#if confirmDeleteId === comment.id}
+                        <p>Delete this comment?</p>
+                        <div class="cmt__menu-confirm">
+                          <button type="button" onclick={() => (confirmDeleteId = null)} disabled={deletingId === comment.id}>Cancel</button>
+                          <button type="button" class="cmt__delete" onclick={() => confirmDelete(comment.id)} disabled={deletingId === comment.id}>
+                            {deletingId === comment.id ? "Deleting…" : "Delete"}
+                          </button>
+                        </div>
+                      {:else}
+                        <button type="button" role="menuitem" onclick={() => startEdit(comment)} disabled={updatingId !== null || deletingId !== null}>Edit</button>
+                        <button type="button" role="menuitem" onclick={() => (confirmDeleteId = comment.id)} disabled={updatingId !== null || deletingId !== null}>Delete</button>
+                      {/if}
+                    </div>
+                  {/if}
+                </div>
+              {/if}
             </div>
-            <div class="cmt__md">
-              <Markdown content={comment.content} mentions={candidates} class="text-sm" />
-            </div>
+            {#if editingId === comment.id}
+              <DropOverlay onFiles={(files) => editUploads.enqueue(files)}>
+                <div class="cmt__composer cmt__editor">
+                  <div class="cmt__input-wrap">
+                    <textarea bind:this={editTextareaEl} bind:value={editDraft} class="cmt__input" oninput={onInput} onkeydown={onKeydown} onclick={updateMentionContext} onpaste={(e) => onPaste(e, true)}></textarea>
+                    {#if mentionOpen && mentionMatches.length > 0}
+                      <ul class="mention-pop" role="listbox" aria-label="Mention a user">
+                        {#each mentionMatches as cand, i (cand.user_id)}
+                          <li><button type="button" role="option" aria-selected={i === mentionIndex} class="mention-pop__row" class:is-active={i === mentionIndex} onmousedown={(e) => { e.preventDefault(); selectMention(cand); }} onmouseenter={() => (mentionIndex = i)}><span class="mention-pop__avatar" aria-hidden="true">{initialsOf(cand.display_name || cand.username)}</span><span class="mention-pop__text"><span class="mention-pop__name">{cand.display_name || cand.username}</span><span class="mention-pop__user">@{cand.username}</span></span></button></li>
+                        {/each}
+                      </ul>
+                    {/if}
+                  </div>
+                  <PendingUploads controller={editUploads} />
+                  <div class="cmt__toolbar">
+                    <div class="cmt__toolbar-left"><button type="button" class="cmt__attach" onclick={() => editFileInputEl?.click()} disabled={editUploads.busy}><Paperclip size={13} /><span>{editUploads.busy ? "Uploading…" : "Attach"}</span></button><span class="cmt__hint">Markdown · drag, paste or attach files</span></div>
+                    <div class="cmt__actions"><span class="cmt__kbd" aria-hidden="true"><kbd>{isMac ? "⌘" : "Ctrl"}</kbd><kbd><CornerDownLeft size={11} /></kbd></span><button type="button" class="cmt__cancel" onclick={cancelEdit} disabled={updatingId === comment.id}>Cancel</button><button type="button" class="cmt__send" onclick={saveEdit} disabled={editDraft.trim() === "" || editUploads.busy || updatingId === comment.id}>{updatingId === comment.id ? "Saving…" : "Save"}</button></div>
+                  </div>
+                  <input bind:this={editFileInputEl} type="file" class="cmt__file-input" multiple accept="image/*,application/pdf,text/plain,.log,application/zip" onchange={(e) => onFilePicked(e, true)} />
+                </div>
+              </DropOverlay>
+            {:else}
+              <div class="cmt__md">
+                <Markdown content={comment.content} mentions={candidates} class="text-sm" />
+              </div>
+            {/if}
           </div>
         </li>
       {/each}
@@ -590,6 +728,33 @@
     font-size: 0.75rem;
     color: var(--text-muted);
   }
+  .cmt__edited {
+    font-size: 0.6875rem;
+    color: var(--text-faint);
+    font-style: italic;
+  }
+  .cmt__menu-wrap { position: relative; margin-left: auto; }
+  .cmt__menu-button {
+    display: grid; place-items: center; width: 1.75rem; height: 1.75rem;
+    border: 0; border-radius: 0.375rem; background: transparent;
+    color: var(--text-muted);
+  }
+  .cmt__menu-button:hover, .cmt__menu-button:focus-visible { background: var(--bg-subtle); color: var(--text); outline: none; }
+  .cmt__menu {
+    position: absolute; z-index: 30; right: 0; top: calc(100% + 0.25rem);
+    min-width: 8rem; padding: 0.25rem; border: 1px solid var(--border);
+    border-radius: 0.5rem; background: var(--surface); box-shadow: 0 8px 20px rgb(0 0 0 / 0.18);
+  }
+  .cmt__menu > button, .cmt__menu-confirm > button {
+    border: 0; border-radius: 0.3125rem; background: transparent; color: var(--text);
+    padding: 0.375rem 0.5rem; font-size: 0.75rem;
+  }
+  .cmt__menu > button { display: block; width: 100%; text-align: left; }
+  .cmt__menu > button:hover:not(:disabled) { background: var(--bg-subtle); }
+  .cmt__menu p { margin: 0; padding: 0.375rem 0.5rem; font-size: 0.75rem; color: var(--text-muted); }
+  .cmt__menu-confirm { display: flex; justify-content: flex-end; gap: 0.25rem; }
+  .cmt__menu-confirm .cmt__delete { color: var(--error); }
+  .cmt__editor { margin-top: 0.5rem; }
   /* Markdown body in full-strength text so it reads as content, not an
      afterthought. Kill the leading margin the prose layer adds. */
   .cmt__md :global(.prose > :first-child) {
@@ -766,6 +931,11 @@
     opacity: 0.4;
     cursor: not-allowed;
   }
+  .cmt__cancel {
+    border: 0; border-radius: 0.5rem; padding: 0.4375rem 0.625rem;
+    background: transparent; color: var(--text-muted); font-size: 0.8125rem; font-weight: 500;
+  }
+  .cmt__cancel:hover:not(:disabled) { color: var(--text); background: var(--bg-subtle); }
 
   /* ── @mention popover (LIF-263) ─────────────────────── */
   /* Command-Palette vocabulary: a floating surface card with a soft

--- a/web/src/lib/Comments.svelte
+++ b/web/src/lib/Comments.svelte
@@ -33,7 +33,12 @@
   import { createUploadController } from "./attachments/uploads.svelte";
   import DropOverlay from "./attachments/DropOverlay.svelte";
   import PendingUploads from "./attachments/PendingUploads.svelte";
-  import { canManageComment, commentWasEdited } from "./commentState";
+  import {
+    canManageComment,
+    commentKeyboardAction,
+    commentWasEdited,
+    type CommentKeyboardContext,
+  } from "./commentState";
 
   let {
     comments,
@@ -269,18 +274,28 @@
     }
   }
 
-  function onKeydown(e: KeyboardEvent) {
+  function onKeydown(e: KeyboardEvent, context: Exclude<CommentKeyboardContext, "menu">) {
     // The mention popover consumes ↑/↓/Enter/Tab/Esc while open.
     if (onMentionKeydown(e)) return;
-    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-      e.preventDefault();
-      if (editingId === null) submit();
-      else saveEdit();
-    }
-    if (e.key === "Escape" && editingId !== null) {
-      e.preventDefault();
+    const action = commentKeyboardAction(context, e.key, e.metaKey || e.ctrlKey);
+    if (!action) return;
+    e.preventDefault();
+    if (action === "submit") void submit();
+    if (action === "save") void saveEdit();
+    if (action === "cancel") {
+      // The editor disappears synchronously, so DocumentDetail can no longer
+      // detect a focused textarea when the event reaches its window handler.
+      e.stopPropagation();
       cancelEdit();
     }
+  }
+
+  function onMenuKeydown(e: KeyboardEvent) {
+    if (menuId === null || commentKeyboardAction("menu", e.key, e.metaKey || e.ctrlKey) !== "close-menu") return;
+    e.preventDefault();
+    e.stopPropagation();
+    menuId = null;
+    confirmDeleteId = null;
   }
 
   function onInput() {
@@ -463,11 +478,10 @@
                       menuId = menuId === comment.id ? null : comment.id;
                       confirmDeleteId = null;
                     }}
-                    onfocus={() => (menuId = comment.id)}
-                    onkeydown={(e) => { if (e.key === "Escape") menuId = null; }}
+                    onkeydown={onMenuKeydown}
                   ><MoreHorizontal size={16} /></button>
                   {#if menuId === comment.id}
-                    <div class="cmt__menu" role="menu" aria-label={`Comment ${comment.id} actions`}>
+                    <div class="cmt__menu" role="menu" tabindex="-1" aria-label={`Comment ${comment.id} actions`} onkeydown={onMenuKeydown}>
                       {#if confirmDeleteId === comment.id}
                         <p>Delete this comment?</p>
                         <div class="cmt__menu-confirm">
@@ -489,7 +503,7 @@
               <DropOverlay onFiles={(files) => editUploads.enqueue(files)}>
                 <div class="cmt__composer cmt__editor">
                   <div class="cmt__input-wrap">
-                    <textarea bind:this={editTextareaEl} bind:value={editDraft} class="cmt__input" oninput={onInput} onkeydown={onKeydown} onclick={updateMentionContext} onpaste={(e) => onPaste(e, true)}></textarea>
+                    <textarea bind:this={editTextareaEl} bind:value={editDraft} class="cmt__input" oninput={onInput} onkeydown={(e) => onKeydown(e, "edit")} onclick={updateMentionContext} onpaste={(e) => onPaste(e, true)}></textarea>
                     {#if mentionOpen && mentionMatches.length > 0}
                       <ul class="mention-pop" role="listbox" aria-label="Mention a user">
                         {#each mentionMatches as cand, i (cand.user_id)}
@@ -537,7 +551,7 @@
           {placeholder}
           class="cmt__input"
           oninput={onInput}
-          onkeydown={onKeydown}
+          onkeydown={(e) => onKeydown(e, "new")}
           onclick={updateMentionContext}
           onpaste={onPaste}
           onblur={() => setTimeout(() => (mentionOpen = false), 120)}

--- a/web/src/lib/DocumentDetail.svelte
+++ b/web/src/lib/DocumentDetail.svelte
@@ -30,7 +30,7 @@
   import Breadcrumbs, { type Crumb } from "./Breadcrumbs.svelte";
   import { Download, PanelRight, X } from "lucide-svelte";
   import { getContext, type Snippet } from "svelte";
-  import type { Activity, Comment } from "./api";
+  import type { Activity, AuthUser, Comment } from "./api";
   import { isTypingContext } from "./shortcuts";
   import { peekState } from "./issues/peek.svelte"; // LIF-248
   import { contextMenuState } from "./contextMenuState.svelte"; // LIF-248
@@ -86,6 +86,9 @@
     // Comments (optional)
     comments,
     onNewComment,
+    currentUser = null,
+    onUpdateComment,
+    onDeleteComment,
     // LIF-263: project id the comments belong to, used to fetch @mention
     // autocomplete candidates. Null for workspace pages (no member list).
     mentionProjectId = null,
@@ -154,6 +157,9 @@
     onDelete?: () => Promise<boolean>;
     comments?: Comment[];
     onNewComment?: (content: string) => Promise<Comment | null>;
+    currentUser?: AuthUser | null;
+    onUpdateComment?: (id: number, content: string) => Promise<Comment | null>;
+    onDeleteComment?: (id: number) => Promise<boolean>;
     mentionProjectId?: number | null;
     activity?: Activity[];
     paletteActions?: PaletteAction[];
@@ -482,12 +488,15 @@
     <Comments
       bind:this={commentsRef}
       {comments}
+      {currentUser}
       editable={commentsEnabled}
       onSubmit={async (content) => {
         const created = await onNewComment(content);
         if (created) attachmentRefresh += 1;
         return created;
       }}
+      onUpdate={onUpdateComment}
+      onDelete={onDeleteComment}
       projectId={mentionProjectId}
     />
   {/if}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -860,6 +860,19 @@ export async function createPageComment(pageId: number, content: string) {
   });
 }
 
+export async function updateComment(id: number, content: string) {
+  return request<Comment>(`/comments/${id}`, {
+    method: "PUT",
+    body: JSON.stringify({ content }),
+  });
+}
+
+export async function deleteComment(id: number) {
+  return request<{ deleted: boolean }>(`/comments/${id}`, {
+    method: "DELETE",
+  });
+}
+
 // ── Attachments (LIF-262) ────────────────────────────────────
 //
 // Image + file uploads on issues, comments, and pages. Bytes are stored

--- a/web/src/lib/commentState.ts
+++ b/web/src/lib/commentState.ts
@@ -1,0 +1,21 @@
+import type { Comment } from "./api";
+
+export function canManageComment(
+  comment: Comment,
+  currentUser: { id: number } | null,
+  actionsAvailable: boolean,
+): boolean {
+  return actionsAvailable && currentUser?.id === comment.user_id;
+}
+
+export function commentWasEdited(comment: Comment): boolean {
+  return comment.updated_at !== comment.created_at;
+}
+
+export function replaceComment(comments: Comment[], updated: Comment): Comment[] {
+  return comments.map((comment) => comment.id === updated.id ? updated : comment);
+}
+
+export function removeComment(comments: Comment[], id: number): Comment[] {
+  return comments.filter((comment) => comment.id !== id);
+}

--- a/web/src/lib/commentState.ts
+++ b/web/src/lib/commentState.ts
@@ -1,5 +1,24 @@
 import type { Comment } from "./api";
 
+export type CommentKeyboardContext = "new" | "edit" | "menu";
+export type CommentKeyboardAction = "submit" | "save" | "cancel" | "close-menu";
+
+export function commentKeyboardAction(
+  context: CommentKeyboardContext,
+  key: string,
+  modified: boolean,
+): CommentKeyboardAction | null {
+  if (key === "Enter" && modified) {
+    if (context === "new") return "submit";
+    if (context === "edit") return "save";
+  }
+  if (key === "Escape") {
+    if (context === "edit") return "cancel";
+    if (context === "menu") return "close-menu";
+  }
+  return null;
+}
+
 export function canManageComment(
   comment: Comment,
   currentUser: { id: number } | null,

--- a/web/src/routes/IssueDetail.svelte
+++ b/web/src/routes/IssueDetail.svelte
@@ -8,12 +8,16 @@
     createLabel,
     listComments,
     createComment,
+    updateComment,
+    deleteComment,
     listIssueActivity,
+    me,
     type Issue,
     type Module,
     type Label,
     type Comment,
     type Activity,
+    type AuthUser,
   } from "../lib/api";
   import DocumentDetail from "../lib/DocumentDetail.svelte";
   import LabelEditor from "../lib/LabelEditor.svelte";
@@ -28,6 +32,7 @@
   import { projectRole, loadProjectRole } from "../lib/projectRole.svelte"; // LIF-234
   import { startAutoRefresh } from "../lib/autoRefresh.svelte";
   import { toast } from "../lib/toast/toast.svelte"; // LIF-284
+  import { removeComment, replaceComment } from "../lib/commentState";
   import { ArrowUpRight, ChevronDown } from "lucide-svelte";
 
   let {
@@ -76,9 +81,14 @@
   let modules = $state<Module[]>([]);
   let labels = $state<Label[]>([]);
   let comments = $state<Comment[]>([]);
+  let currentUser = $state<AuthUser | null>(null);
   let activity = $state<Activity[]>([]);
   let loading = $state(true);
   let error = $state("");
+
+  void me().then((res) => {
+    if (res.ok) currentUser = res.data;
+  });
 
   // Sidebar dropdown states (issue-specific; the body's read/edit mode
   // lives inside DocumentDetail).
@@ -347,6 +357,28 @@
     return res.data;
   }
 
+  async function handleUpdateComment(id: number, content: string) {
+    const res = await updateComment(id, content);
+    if (!res.ok) {
+      toast(`Couldn't update comment: ${res.error}`, { kind: "error" });
+      return null;
+    }
+    comments = replaceComment(comments, res.data);
+    refreshActivity();
+    return res.data;
+  }
+
+  async function handleDeleteComment(id: number): Promise<boolean> {
+    const res = await deleteComment(id);
+    if (!res.ok) {
+      toast(`Couldn't delete comment: ${res.error}`, { kind: "error" });
+      return false;
+    }
+    comments = removeComment(comments, id);
+    refreshActivity();
+    return true;
+  }
+
   async function exportMarkdown() {
     if (!issue || exporting) return;
     exporting = true;
@@ -497,6 +529,9 @@
   onDelete={handleDelete}
   {comments}
   onNewComment={handleNewComment}
+  {currentUser}
+  onUpdateComment={handleUpdateComment}
+  onDeleteComment={handleDeleteComment}
   mentionProjectId={issue?.project_id ?? null}
   {activity}
   {paletteActions}

--- a/web/src/routes/PageDetail.svelte
+++ b/web/src/routes/PageDetail.svelte
@@ -6,6 +6,9 @@
     downloadPageExport,
     listPageComments,
     createPageComment,
+    updateComment,
+    deleteComment,
+    me,
     listLabels,
     listFolders,
     listPageActivity,
@@ -14,6 +17,7 @@
     type Label,
     type Folder,
     type Activity,
+    type AuthUser,
   } from "../lib/api";
   import DocumentDetail from "../lib/DocumentDetail.svelte";
   import LabelEditor from "../lib/LabelEditor.svelte";
@@ -23,6 +27,7 @@
   import { startAutoRefresh } from "../lib/autoRefresh.svelte";
   import { projectRole, loadProjectRole, ensureMeAdmin } from "../lib/projectRole.svelte"; // LIF-234
   import { toast } from "../lib/toast/toast.svelte"; // LIF-284
+  import { removeComment, replaceComment } from "../lib/commentState";
   import {
     PenLine,
     CircleDot,
@@ -78,6 +83,7 @@
   );
 
   let comments = $state<Comment[]>([]);
+  let currentUser = $state<AuthUser | null>(null);
   let activity = $state<Activity[]>([]);
   // LIF-105: project labels available for attachment. Stays empty for
   // workspace pages (project_id === null) — labels are project-scoped.
@@ -88,6 +94,10 @@
   let folders = $state<Folder[]>([]);
   let loading = $state(true);
   let error = $state("");
+
+  void me().then((res) => {
+    if (res.ok) currentUser = res.data;
+  });
 
   // Save indicator
   let saving = $state(false);
@@ -279,6 +289,26 @@
     return res.data;
   }
 
+  async function handleUpdateComment(id: number, content: string) {
+    const res = await updateComment(id, content);
+    if (!res.ok) {
+      toast(`Couldn't update comment: ${res.error}`, { kind: "error" });
+      return null;
+    }
+    comments = replaceComment(comments, res.data);
+    return res.data;
+  }
+
+  async function handleDeleteComment(id: number): Promise<boolean> {
+    const res = await deleteComment(id);
+    if (!res.ok) {
+      toast(`Couldn't delete comment: ${res.error}`, { kind: "error" });
+      return false;
+    }
+    comments = removeComment(comments, id);
+    return true;
+  }
+
   async function exportMarkdown() {
     if (!page || exporting) return;
     exporting = true;
@@ -392,6 +422,9 @@
   onDelete={handleDelete}
   {comments}
   onNewComment={handleNewComment}
+  {currentUser}
+  onUpdateComment={handleUpdateComment}
+  onDeleteComment={handleDeleteComment}
   mentionProjectId={page?.project_id ?? null}
   {activity}
   {paletteActions}

--- a/web/tests/comments.test.ts
+++ b/web/tests/comments.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
+import type { Component } from "svelte";
+import { createServer, type ViteDevServer } from "vite";
+import { fileURLToPath } from "node:url";
+import type { Comment } from "../src/lib/api";
+import {
+  canManageComment,
+  commentWasEdited,
+  removeComment,
+  replaceComment,
+} from "../src/lib/commentState";
+
+Object.assign(globalThis, {
+  window: {
+    location: {
+      origin: "http://localhost",
+      hash: "",
+      pathname: "/LIFIC/issues/LIFIC-6",
+      search: "",
+    },
+  },
+  localStorage: { getItem: () => null },
+});
+
+const { deleteComment, updateComment } = await import("../src/lib/api");
+
+const originalFetch = globalThis.fetch;
+let vite: ViteDevServer;
+let Comments: Component<any>;
+let renderComponent: typeof import("svelte/server").render;
+
+beforeAll(async () => {
+  vite = await createServer({
+    server: { middlewareMode: true },
+    appType: "custom",
+    resolve: {
+      alias: {
+        dompurify: fileURLToPath(new URL("./dompurify.ssr.ts", import.meta.url)),
+      },
+    },
+  });
+  ({ default: Comments } = await vite.ssrLoadModule("/src/lib/Comments.svelte"));
+  ({ render: renderComponent } = await vite.ssrLoadModule("svelte/server"));
+}, 20_000);
+
+afterAll(async () => {
+  await vite.close();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function comment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: 42,
+    issue_id: 7,
+    page_id: null,
+    user_id: 3,
+    author: "owner",
+    author_display_name: "Owner",
+    content: "Original",
+    created_at: "2026-08-13 10:00:00",
+    updated_at: "2026-08-13 10:00:00",
+    ...overrides,
+  };
+}
+
+test("only the comment author gets web mutation actions", () => {
+  const own = comment();
+
+  expect(canManageComment(own, { id: 3 }, true)).toBe(true);
+  expect(canManageComment(own, { id: 9 }, true)).toBe(false);
+  expect(canManageComment(own, { id: 3 }, false)).toBe(false);
+});
+
+test("renders mutation actions only for the comment author", () => {
+  const props = {
+    comments: [comment()],
+    onSubmit: async () => null,
+    onUpdate: async () => null,
+    onDelete: async () => false,
+  };
+
+  const owner = renderComponent(Comments, { props: { ...props, currentUser: { id: 3 } } }).body;
+  const otherUser = renderComponent(Comments, { props: { ...props, currentUser: { id: 9 } } }).body;
+
+  expect(owner).toContain("Comment 42 actions");
+  expect(otherUser).not.toContain("Comment 42 actions");
+});
+
+test("marks comments edited only when the update timestamp changes", () => {
+  expect(commentWasEdited(comment())).toBe(false);
+  expect(commentWasEdited(comment({ updated_at: "2026-08-13 10:05:00" }))).toBe(true);
+});
+
+test("renders the original time and exact edited timestamp", () => {
+  const edited = comment({ updated_at: "2026-08-13 10:05:00" });
+  const html = renderComponent(Comments, {
+    props: { comments: [edited], onSubmit: async () => null },
+  }).body;
+
+  expect(html).toContain("edited");
+  expect(html).toContain('title="Edited 2026-08-13 10:05:00"');
+});
+
+test("replaces and removes comments without disturbing their order", () => {
+  const first = comment({ id: 1 });
+  const second = comment({ id: 2 });
+  const updated = comment({ id: 1, content: "Revised" });
+
+  expect(replaceComment([first, second], updated)).toEqual([updated, second]);
+  expect(removeComment([first, second], 1)).toEqual([second]);
+});
+
+test("updates a comment through its typed API call", async () => {
+  let call: { url: string; init?: RequestInit } | undefined;
+  globalThis.fetch = (async (url, init) => {
+    call = { url: String(url), init };
+    return new Response(JSON.stringify({ id: 42, content: "Revised" }), { status: 200 });
+  }) as typeof fetch;
+
+  const result = await updateComment(42, "Revised");
+
+  expect(result).toEqual({ ok: true, data: { id: 42, content: "Revised" } });
+  expect(call).toMatchObject({
+    url: "/api/comments/42",
+    init: { method: "PUT", body: JSON.stringify({ content: "Revised" }) },
+  });
+});
+
+test("deletes a comment through its typed API call", async () => {
+  let call: { url: string; init?: RequestInit } | undefined;
+  globalThis.fetch = (async (url, init) => {
+    call = { url: String(url), init };
+    return new Response(JSON.stringify({ deleted: true }), { status: 200 });
+  }) as typeof fetch;
+
+  const result = await deleteComment(42);
+
+  expect(result).toEqual({ ok: true, data: { deleted: true } });
+  expect(call).toMatchObject({ url: "/api/comments/42", init: { method: "DELETE" } });
+});

--- a/web/tests/comments.test.ts
+++ b/web/tests/comments.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import type { Comment } from "../src/lib/api";
 import {
   canManageComment,
+  commentKeyboardAction,
   commentWasEdited,
   removeComment,
   replaceComment,
@@ -72,6 +73,14 @@ test("only the comment author gets web mutation actions", () => {
   expect(canManageComment(own, { id: 3 }, true)).toBe(true);
   expect(canManageComment(own, { id: 9 }, true)).toBe(false);
   expect(canManageComment(own, { id: 3 }, false)).toBe(false);
+});
+
+test("routes comment shortcuts by the focused interaction", () => {
+  expect(commentKeyboardAction("new", "Enter", true)).toBe("submit");
+  expect(commentKeyboardAction("edit", "Enter", true)).toBe("save");
+  expect(commentKeyboardAction("edit", "Escape", false)).toBe("cancel");
+  expect(commentKeyboardAction("menu", "Escape", false)).toBe("close-menu");
+  expect(commentKeyboardAction("new", "Escape", false)).toBeNull();
 });
 
 test("renders mutation actions only for the comment author", () => {

--- a/web/tests/dompurify.ssr.ts
+++ b/web/tests/dompurify.ssr.ts
@@ -1,0 +1,5 @@
+export default {
+  sanitize(html: string): string {
+    return html;
+  },
+};


### PR DESCRIPTION
## Problem

Comment authors cannot fix a typo, add missing context, or delete their own comments through the web interface. The REST API already supports updating and deleting comments, but those actions are not exposed in the UI.

This affects comments on both issues and pages. Users currently have to bypass the web interface even for a simple correction to their own text.

---

## Changes

**`Comments.svelte`** — adds an author-only action menu for editing and deleting comments.

Editing happens inline and preserves the existing composer capabilities:

- Markdown, mentions, quoting, paste, drag-and-drop, and attachment picking
- save by button or Cmd/Ctrl+Enter
- cancel by Escape or the Cancel button
- empty content cannot be saved
- only one editor can be open; switching comments discards the previous draft
- repeated actions are disabled while a request is in flight

Deletion requires inline confirmation. A comment is removed from local state only after the server responds successfully.

Edited comments retain their original publication time and show an `edited` label with the exact `updated_at` value in a tooltip.

**`api.ts`** — adds typed `updateComment` and `deleteComment` functions over the existing `PUT` and `DELETE /api/comments/{id}` endpoints.

**`DocumentDetail.svelte`, `IssueDetail.svelte`, `PageDetail.svelte`** — pass the current user and mutation callbacks into the shared comments component. A successful update replaces the comment in local state; a successful deletion removes it. Failures use the existing toast system.

**`commentState.ts`** — contains the shared, testable ownership and local comment-list update logic.

The backend and REST authorization are unchanged. Administrators retain their existing ability to modify other users’ comments through REST, but the web interface does not expose those actions.

---

## Verification

- Edit and delete actions render only for the comment author
- Issue and Page comments use the same mutation flow
- API calls use `PUT` and `DELETE /api/comments/{id}`
- The `edited` label exposes the exact `updated_at` value
- `bun test` — 12 passed, 0 failed
- `bun run check` — 0 errors
- `bun run build` — successful
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --all-targets` — 1235 passed, 0 failed

