### PR TITLE
Initialize activity rate from 24-hour audit history

### DIFF
--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -33,7 +33,9 @@ pub enum ActivityScope {
 pub const MAX_LIMIT: i64 = 200;
 const DEFAULT_LIMIT: i64 = super::DEFAULT_PAGE_LIMIT;
 
-/// Return the trailing-24-hour activity count for the websocket's initial snapshot.
+/// Return trailing-24-hour logical mutations for the websocket's initial snapshot.
+/// Multi-field trigger rows are grouped by their realtime invalidation target so
+/// the result uses the same one-update unit as the client counter.
 /// `None` means unrestricted visibility; `Some` limits rows to visible projects.
 pub fn activity_count(
     conn: &Connection,
@@ -44,8 +46,12 @@ pub fn activity_count(
     };
 
     let sql = format!(
-        "SELECT COUNT(*) FROM audit_log a
-         WHERE a.ts >= datetime('now', '-24 hours'){project_filter}"
+        "SELECT COUNT(*) FROM (
+             SELECT 1 FROM audit_log a
+             WHERE a.ts >= datetime('now', '-24 hours'){project_filter}
+             GROUP BY a.ts, a.actor_user_id, a.transport, a.action,
+                      a.project_id, a.issue_id, a.page_id, a.entity_type, a.entity_id
+         )"
     );
     conn.prepare_cached(&sql)?
         .query_row(
@@ -286,17 +292,27 @@ mod tests {
             // only events inside the rolling 24-hour window.
             conn.execute("UPDATE audit_log SET ts = datetime('now', '-25 hours')", [])
                 .unwrap();
-            queries::create_issue(&conn, &new_issue(first.id, "Fresh first")).unwrap();
+            let issue = queries::create_issue(&conn, &new_issue(first.id, "Fresh first")).unwrap();
+            queries::update_issue(
+                &conn,
+                issue.id,
+                &UpdateIssue {
+                    title: Some("Renamed first".into()),
+                    description: Some("Changed too".into()),
+                    ..no_update()
+                },
+            )
+            .unwrap();
             queries::create_issue(&conn, &new_issue(second.id, "Fresh second one")).unwrap();
             queries::create_issue(&conn, &new_issue(second.id, "Fresh second two")).unwrap();
             (first.id, second.id)
         };
 
         let conn = pool.read().unwrap();
-        assert_eq!(activity_count(&conn, None).unwrap(), 3);
+        assert_eq!(activity_count(&conn, None).unwrap(), 4);
         assert_eq!(
             activity_count(&conn, Some(&HashSet::from([first_project]))).unwrap(),
-            1
+            2
         );
         assert_eq!(
             activity_count(&conn, Some(&HashSet::from([second_project]))).unwrap(),

--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -5,6 +5,7 @@
 //! along, degrading gracefully when the actor's account is gone.
 
 use rusqlite::Connection;
+use std::collections::HashSet;
 
 use crate::db::models::{Activity, ActivityFeed};
 use crate::error::LificError;
@@ -31,6 +32,42 @@ pub enum ActivityScope {
 /// restating it.
 pub const MAX_LIMIT: i64 = 200;
 const DEFAULT_LIMIT: i64 = super::DEFAULT_PAGE_LIMIT;
+
+/// Return the trailing-24-hour activity count for the websocket's initial snapshot.
+/// `None` means unrestricted visibility; `Some` limits rows to visible projects.
+pub fn activity_count(
+    conn: &Connection,
+    visible_project_ids: Option<&HashSet<i64>>,
+) -> Result<i64, LificError> {
+    let Some(project_filter) = project_filter(visible_project_ids) else {
+        return Ok(0);
+    };
+
+    let sql = format!(
+        "SELECT COUNT(*) FROM audit_log a
+         WHERE a.ts >= datetime('now', '-24 hours'){project_filter}"
+    );
+    conn.prepare_cached(&sql)?
+        .query_row(
+            rusqlite::params_from_iter(visible_project_ids.into_iter().flatten()),
+            |row| row.get(0),
+        )
+        .map_err(LificError::Database)
+}
+
+fn project_filter(visible_project_ids: Option<&HashSet<i64>>) -> Option<String> {
+    match visible_project_ids {
+        None => Some(String::new()),
+        Some(ids) if ids.is_empty() => None,
+        Some(ids) => Some(format!(
+            " AND a.project_id IN ({})",
+            (1..=ids.len())
+                .map(|index| format!("?{index}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
 
 /// List activity newest-first. `limit` is clamped to 1..=200 (default 50).
 /// Fetches limit+1 rows internally to compute `has_more` without a COUNT.

--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -299,7 +299,7 @@ mod tests {
                 &UpdateIssue {
                     title: Some("Renamed first".into()),
                     description: Some("Changed too".into()),
-                    ..no_update()
+                    ..Default::default()
                 },
             )
             .unwrap();

--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -254,6 +254,57 @@ mod tests {
             .items
     }
 
+    #[test]
+    fn activity_count_filters_to_last_day_and_visible_projects() {
+        let pool = crate::db::open_memory().expect("test db");
+        let (first_project, second_project) = {
+            let conn = pool.write().unwrap();
+            let first = queries::create_project(
+                &conn,
+                &CreateProject {
+                    name: "First".into(),
+                    identifier: "FIRST".into(),
+                    description: String::new(),
+                    emoji: None,
+                    lead_user_id: None,
+                },
+            )
+            .unwrap();
+            let second = queries::create_project(
+                &conn,
+                &CreateProject {
+                    name: "Second".into(),
+                    identifier: "SECND".into(),
+                    description: String::new(),
+                    emoji: None,
+                    lead_user_id: None,
+                },
+            )
+            .unwrap();
+
+            // Exclude setup activity so the fresh issue rows below are the
+            // only events inside the rolling 24-hour window.
+            conn.execute("UPDATE audit_log SET ts = datetime('now', '-25 hours')", [])
+                .unwrap();
+            queries::create_issue(&conn, &new_issue(first.id, "Fresh first")).unwrap();
+            queries::create_issue(&conn, &new_issue(second.id, "Fresh second one")).unwrap();
+            queries::create_issue(&conn, &new_issue(second.id, "Fresh second two")).unwrap();
+            (first.id, second.id)
+        };
+
+        let conn = pool.read().unwrap();
+        assert_eq!(activity_count(&conn, None).unwrap(), 3);
+        assert_eq!(
+            activity_count(&conn, Some(&HashSet::from([first_project]))).unwrap(),
+            1
+        );
+        assert_eq!(
+            activity_count(&conn, Some(&HashSet::from([second_project]))).unwrap(),
+            2
+        );
+        assert_eq!(activity_count(&conn, Some(&HashSet::new())).unwrap(), 0);
+    }
+
     // ── Capture: per-field diffs ─────────────────────────
 
     #[test]

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -115,6 +115,13 @@ pub struct RealtimeMessage {
     audience: RealtimeAudience,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum RealtimeRequest {
+    #[serde(rename = "activity.baseline.request")]
+    ActivityBaselineRequest,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum RealtimeEvent {
@@ -149,6 +156,8 @@ pub enum RealtimeEvent {
     IssueLinked { project_id: i64, issue_id: i64 },
     #[serde(rename = "issue.unlinked")]
     IssueUnlinked { project_id: i64, issue_id: i64 },
+    #[serde(rename = "activity.baseline")]
+    ActivityBaseline { day_count: i64 },
 }
 
 pub async fn serve_socket(
@@ -191,7 +200,9 @@ pub async fn serve_socket(
             flow
         },
         event = rx.recv() => forward_event(&mut socket, &db, &auth_user, &mut visible_projects, event).await,
-        message = socket.recv() => handle_client_message(&mut socket, message).await,
+        message = socket.recv() => {
+            handle_client_message(&mut socket, &db, &auth_user, message).await
+        },
     } {}
 }
 
@@ -284,6 +295,8 @@ async fn forward_event(
 
 async fn handle_client_message(
     socket: &mut WebSocket,
+    db: &crate::db::DbPool,
+    auth_user: &crate::db::models::AuthUser,
     message: Option<Result<Message, axum::Error>>,
 ) -> SocketFlow {
     match message {
@@ -291,8 +304,34 @@ async fn handle_client_message(
             SocketFlow::from_send(socket.send(Message::Pong(payload)).await)
         }
         Some(Ok(Message::Close(_))) | Some(Err(_)) | None => SocketFlow::Close,
+        Some(Ok(Message::Text(text))) => {
+            if matches!(
+                serde_json::from_str::<RealtimeRequest>(&text),
+                Ok(RealtimeRequest::ActivityBaselineRequest)
+            ) {
+                match activity_baseline(db, auth_user) {
+                    Ok(event) => send_event(socket, &event).await,
+                    Err(error) => {
+                        warn!(error = %error, "failed to load websocket activity baseline");
+                        SocketFlow::Open
+                    }
+                }
+            } else {
+                SocketFlow::Open
+            }
+        }
         Some(Ok(Message::Pong(_))) | Some(Ok(_)) => SocketFlow::Open,
     }
+}
+
+fn activity_baseline(
+    db: &crate::db::DbPool,
+    auth_user: &crate::db::models::AuthUser,
+) -> Result<RealtimeEvent, crate::error::LificError> {
+    let visible_projects = crate::authz::visible_project_ids(db, &Some(auth_user.clone()))?;
+    let conn = db.read()?;
+    let day_count = crate::db::queries::activity::activity_count(&conn, visible_projects.as_ref())?;
+    Ok(RealtimeEvent::ActivityBaseline { day_count })
 }
 
 async fn send_event(socket: &mut WebSocket, event: &RealtimeEvent) -> SocketFlow {
@@ -416,7 +455,10 @@ impl RealtimeEvent {
             | Self::IssueDeleted { project_id, .. }
             | Self::IssueLinked { project_id, .. }
             | Self::IssueUnlinked { project_id, .. } => Some(*project_id),
-            Self::ResyncRequired | Self::ProjectsReordered | Self::ProjectGroupsChanged => None,
+            Self::ResyncRequired
+            | Self::ProjectsReordered
+            | Self::ProjectGroupsChanged
+            | Self::ActivityBaseline { .. } => None,
         }
     }
 }

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -328,7 +328,11 @@ fn activity_baseline(
     db: &crate::db::DbPool,
     auth_user: &crate::db::models::AuthUser,
 ) -> Result<RealtimeEvent, crate::error::LificError> {
-    let visible_projects = crate::authz::visible_project_ids(db, &Some(auth_user.clone()))?;
+    let identity = crate::resolve_caller::ResolvedIdentity {
+        user: auth_user.clone(),
+        transport: crate::actor::Transport::Web,
+    };
+    let visible_projects = crate::authz::visible_project_ids(db, &Some(identity))?;
     let conn = db.read()?;
     let day_count = crate::db::queries::activity::activity_count(&conn, visible_projects.as_ref())?;
     Ok(RealtimeEvent::ActivityBaseline { day_count })
@@ -501,8 +505,8 @@ mod tests {
                     project_id,
                     title: "Visible activity".into(),
                     description: String::new(),
-                    status: "backlog".into(),
-                    priority: "none".into(),
+                    status: crate::db::models::Status::Backlog,
+                    priority: crate::db::models::Priority::None,
                     module_id: None,
                     start_date: None,
                     target_date: None,

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -479,6 +479,56 @@ mod tests {
         assert_eq!(json["issue_id"], 42);
     }
 
+    #[test]
+    fn activity_baseline_serializes_with_day_count() {
+        let event = RealtimeEvent::ActivityBaseline { day_count: 123 };
+        let json = serde_json::to_value(&event).unwrap();
+
+        assert_eq!(json["type"], "activity.baseline");
+        assert_eq!(json["day_count"], 123);
+    }
+
+    #[test]
+    fn activity_baseline_rechecks_current_project_visibility() {
+        let (db, auth_user, project_id, _) = visibility_fixture(true);
+        {
+            let conn = db.write().unwrap();
+            conn.execute("UPDATE audit_log SET ts = datetime('now', '-25 hours')", [])
+                .unwrap();
+            crate::db::queries::create_issue(
+                &conn,
+                &crate::db::models::CreateIssue {
+                    project_id,
+                    title: "Visible activity".into(),
+                    description: String::new(),
+                    status: "backlog".into(),
+                    priority: "none".into(),
+                    module_id: None,
+                    start_date: None,
+                    target_date: None,
+                    labels: vec![],
+                    source: None,
+                },
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            activity_baseline(&db, &auth_user).unwrap(),
+            RealtimeEvent::ActivityBaseline { day_count: 1 }
+        );
+
+        {
+            let conn = db.write().unwrap();
+            crate::db::queries::members::remove_member(&conn, project_id, auth_user.id).unwrap();
+        }
+
+        assert_eq!(
+            activity_baseline(&db, &auth_user).unwrap(),
+            RealtimeEvent::ActivityBaseline { day_count: 0 }
+        );
+    }
+
     #[tokio::test]
     async fn lagged_receiver_requests_resync() {
         let hub = RealtimeHub::with_capacity(1);

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -28,6 +28,7 @@
     routeWithCommentTarget,
     splitResourcePath,
   } from "./lib/commentLinks";
+  import { createActivityRateCounter } from "./lib/activityRate";
   import { motionReduced } from "./lib/theme";
   import { fade } from "svelte/transition";
   import { onDestroy, onMount } from "svelte";
@@ -71,6 +72,7 @@
   let realtimeDelayMs = 1000;
   let realtimeNeedsResync = false;
   let realtimeDisposed = false;
+  const realtimeActivity = createActivityRateCounter();
 
   onMount(async () => {
     // Probe the instance once; its auto-login flag decides single-user mode.
@@ -167,6 +169,7 @@
     }
     realtimeDelayMs = 1000;
     realtimeNeedsResync = false;
+    realtimeActivity.reset();
     const socket = realtimeSocket;
     realtimeSocket = null;
     if (socket) {
@@ -245,6 +248,9 @@
       try {
         const event = JSON.parse(message.data) as RealtimeEvent;
         if (typeof event?.type === "string") {
+          if (event.type !== "resync.required") {
+            realtimeActivity.record(Date.now());
+          }
           dispatchRealtimeEvent(event);
         }
       } catch {
@@ -502,7 +508,7 @@
     {#key routeTransitionKey}
     <div class="h-full" in:fade={routeFadeParams()}>
     {#if parsed.page === "home"}
-      <Home {navigate} />
+      <Home {navigate} realtimeActivityCounts={realtimeActivity.counts} />
     {:else if parsed.page === "settings"}
       <Settings {navigate} />
     {:else if parsed.page === "instance-settings"}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -28,7 +28,11 @@
     routeWithCommentTarget,
     splitResourcePath,
   } from "./lib/commentLinks";
-  import { createActivityRateCounter } from "./lib/activityRate";
+  import {
+    createActivityRateCounter,
+    isActivityRealtimeEvent,
+    parseActivityBaseline,
+  } from "./lib/activityRate";
   import { motionReduced } from "./lib/theme";
   import { fade } from "svelte/transition";
   import { onDestroy, onMount } from "svelte";
@@ -73,6 +77,35 @@
   let realtimeNeedsResync = false;
   let realtimeDisposed = false;
   const realtimeActivity = createActivityRateCounter();
+  let realtimeActivityReady = $state(false);
+  let realtimeActivityRevision = $state(0);
+  let realtimeActivityRefresh: ReturnType<typeof setTimeout> | null = null;
+  let realtimeActivityBaselineRefresh: ReturnType<typeof setInterval> | null = null;
+  const REALTIME_ACTIVITY_BASELINE_REFRESH_MS = 3_600_000;
+
+  function refreshRealtimeActivity() {
+    realtimeActivityRefresh = null;
+    realtimeActivityRevision += 1;
+  }
+
+  function scheduleRealtimeActivityRefresh() {
+    if (realtimeActivityRefresh) clearTimeout(realtimeActivityRefresh);
+    realtimeActivityRefresh = setTimeout(refreshRealtimeActivity, 100);
+  }
+
+  function resetRealtimeActivity() {
+    if (realtimeActivityRefresh) {
+      clearTimeout(realtimeActivityRefresh);
+      realtimeActivityRefresh = null;
+    }
+    if (realtimeActivityBaselineRefresh) {
+      clearInterval(realtimeActivityBaselineRefresh);
+      realtimeActivityBaselineRefresh = null;
+    }
+    realtimeActivity.reset();
+    realtimeActivityReady = false;
+    realtimeActivityRevision += 1;
+  }
 
   onMount(async () => {
     // Probe the instance once; its auto-login flag decides single-user mode.
@@ -169,7 +202,7 @@
     }
     realtimeDelayMs = 1000;
     realtimeNeedsResync = false;
-    realtimeActivity.reset();
+    resetRealtimeActivity();
     const socket = realtimeSocket;
     realtimeSocket = null;
     if (socket) {
@@ -213,6 +246,24 @@
     );
   }
 
+  function requestRealtimeActivityBaseline() {
+    const socket = realtimeSocket;
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: "activity.baseline.request" }));
+    }
+  }
+
+  function startRealtimeActivityBaselineRefresh() {
+    if (realtimeActivityBaselineRefresh) {
+      clearInterval(realtimeActivityBaselineRefresh);
+    }
+    requestRealtimeActivityBaseline();
+    realtimeActivityBaselineRefresh = setInterval(
+      requestRealtimeActivityBaseline,
+      REALTIME_ACTIVITY_BASELINE_REFRESH_MS,
+    );
+  }
+
   async function reconnectAfterFailedRealtimeAttempt(sessionToken: string | null) {
     const session = await me();
 
@@ -240,18 +291,37 @@
       realtimeDelayMs = 1000;
       if (realtimeNeedsResync) {
         realtimeNeedsResync = false;
+        resetRealtimeActivity();
         dispatchRealtimeEvent({ type: "resync.required" });
       }
+      startRealtimeActivityBaselineRefresh();
     });
     socket.addEventListener("message", (message) => {
-      if (typeof message.data !== "string") return;
+      if (
+        realtimeSocket !== socket ||
+        realtimeDisposed ||
+        typeof message.data !== "string"
+      ) return;
       try {
         const event = JSON.parse(message.data) as RealtimeEvent;
         if (typeof event?.type === "string") {
-          if (event.type !== "resync.required") {
-            realtimeActivity.record(Date.now());
+          if (event.type === "activity.baseline") {
+            const baseline = parseActivityBaseline(event.day_count);
+            if (!baseline) return;
+            realtimeActivity.seed(baseline, Date.now());
+            realtimeActivityReady = true;
+            scheduleRealtimeActivityRefresh();
+          } else if (event.type === "resync.required") {
+            resetRealtimeActivity();
+            dispatchRealtimeEvent(event);
+            startRealtimeActivityBaselineRefresh();
+          } else {
+            if (realtimeActivityReady && isActivityRealtimeEvent(event.type)) {
+              realtimeActivity.record(Date.now());
+              scheduleRealtimeActivityRefresh();
+            }
+            dispatchRealtimeEvent(event);
           }
-          dispatchRealtimeEvent(event);
         }
       } catch {
         // HTTP refresh remains source of truth.
@@ -260,6 +330,7 @@
     socket.addEventListener("close", () => {
       if (realtimeSocket === socket) {
         realtimeSocket = null;
+        resetRealtimeActivity();
         realtimeNeedsResync = true;
         if (opened) {
           scheduleRealtimeReconnect();
@@ -508,7 +579,12 @@
     {#key routeTransitionKey}
     <div class="h-full" in:fade={routeFadeParams()}>
     {#if parsed.page === "home"}
-      <Home {navigate} realtimeActivityCounts={realtimeActivity.counts} />
+      <Home
+        {navigate}
+        realtimeActivityCounts={realtimeActivity.counts}
+        {realtimeActivityReady}
+        {realtimeActivityRevision}
+      />
     {:else if parsed.page === "settings"}
       <Settings {navigate} />
     {:else if parsed.page === "instance-settings"}

--- a/web/src/lib/activityRate.ts
+++ b/web/src/lib/activityRate.ts
@@ -1,0 +1,88 @@
+export type ActivityCounts = {
+  perSecond: number;
+  perMinute: number;
+  perHour: number;
+  perDay: number;
+};
+
+export type ActivityCountsReader = (now: number) => ActivityCounts;
+
+export type ActivityRate = {
+  value: number;
+  unit: "updates/s" | "updates/min" | "updates/hr" | "updates/day";
+};
+
+const EVENT_COMPACTION_THRESHOLD = 4_096;
+
+export function createActivityRateCounter() {
+  const eventTimes: number[] = [];
+  let eventHead = 0;
+  const minuteBuckets: { minute: number; count: number }[] = [];
+
+  function prune(now: number) {
+    const minuteAgo = now - 60_000;
+    while (eventHead < eventTimes.length && eventTimes[eventHead] < minuteAgo) {
+      eventHead += 1;
+    }
+    if (eventHead > EVENT_COMPACTION_THRESHOLD && eventHead * 2 > eventTimes.length) {
+      eventTimes.splice(0, eventHead);
+      eventHead = 0;
+    }
+
+    const dayAgo = now - 86_400_000;
+    while (minuteBuckets.length > 0 && (minuteBuckets[0].minute + 1) * 60_000 <= dayAgo) {
+      minuteBuckets.shift();
+    }
+  }
+
+  function record(now: number) {
+    prune(now);
+    eventTimes.push(now);
+    const minute = Math.floor(now / 60_000);
+    const bucket = minuteBuckets.at(-1);
+    if (bucket?.minute === minute) {
+      bucket.count += 1;
+    } else {
+      minuteBuckets.push({ minute, count: 1 });
+    }
+  }
+
+  function counts(now: number): ActivityCounts {
+    prune(now);
+    let perSecond = 0;
+    for (let i = eventTimes.length - 1; i >= eventHead; i -= 1) {
+      if (eventTimes[i] < now - 1_000) break;
+      perSecond += 1;
+    }
+    let perHour = 0;
+    const hourAgo = now - 3_600_000;
+    for (let i = minuteBuckets.length - 1; i >= 0; i -= 1) {
+      const bucket = minuteBuckets[i];
+      if ((bucket.minute + 1) * 60_000 <= hourAgo) break;
+      perHour += bucket.count;
+    }
+    return {
+      perSecond,
+      perMinute: eventTimes.length - eventHead,
+      perHour,
+      perDay: minuteBuckets.reduce((total, bucket) => total + bucket.count, 0),
+    };
+  }
+
+  function reset() {
+    eventTimes.length = 0;
+    eventHead = 0;
+    minuteBuckets.length = 0;
+  }
+
+  return { record, counts, reset };
+}
+
+export function selectActivityRate(counts: ActivityCounts): ActivityRate {
+  // Two or more events select the shortest meaningful window; otherwise the
+  // trailing day remains the conservative fallback.
+  if (counts.perSecond >= 2) return { value: counts.perSecond, unit: "updates/s" };
+  if (counts.perMinute >= 2) return { value: counts.perMinute, unit: "updates/min" };
+  if (counts.perHour >= 2) return { value: counts.perHour, unit: "updates/hr" };
+  return { value: counts.perDay, unit: "updates/day" };
+}

--- a/web/src/lib/activityRate.ts
+++ b/web/src/lib/activityRate.ts
@@ -7,75 +7,109 @@ export type ActivityCounts = {
 
 export type ActivityCountsReader = (now: number) => ActivityCounts;
 
+type ActivityBucket = {
+  at: number;
+  count: number;
+};
+
+export type ActivityBaseline = {
+  dayCount: number;
+};
+
+export function parseActivityBaseline(dayCount: unknown): ActivityBaseline | null {
+  return typeof dayCount === "number" && Number.isSafeInteger(dayCount) && dayCount >= 0
+    ? { dayCount }
+    : null;
+}
+
 export type ActivityRate = {
   value: number;
   unit: "updates/s" | "updates/min" | "updates/hr" | "updates/day";
 };
 
-const EVENT_COMPACTION_THRESHOLD = 4_096;
+const DAY_MS = 86_400_000;
+const ACTIVITY_REALTIME_EVENT_TYPES = new Set([
+  "project.created",
+  "project.updated",
+  "project.deleted",
+  "issue.created",
+  "issue.updated",
+  "issue.deleted",
+  "issue.linked",
+  "issue.unlinked",
+]);
+
+export function isActivityRealtimeEvent(type: string): boolean {
+  return ACTIVITY_REALTIME_EVENT_TYPES.has(type);
+}
 
 export function createActivityRateCounter() {
-  const eventTimes: number[] = [];
-  let eventHead = 0;
-  const minuteBuckets: { minute: number; count: number }[] = [];
+  const secondBuckets: ActivityBucket[] = [];
+  const minuteBuckets: ActivityBucket[] = [];
+  let baselineDayCount = 0;
+  let baselineAt: number | null = null;
 
   function prune(now: number) {
     const minuteAgo = now - 60_000;
-    while (eventHead < eventTimes.length && eventTimes[eventHead] < minuteAgo) {
-      eventHead += 1;
+    while (secondBuckets.length > 0 && secondBuckets[0].at < minuteAgo) {
+      secondBuckets.shift();
     }
-    if (eventHead > EVENT_COMPACTION_THRESHOLD && eventHead * 2 > eventTimes.length) {
-      eventTimes.splice(0, eventHead);
-      eventHead = 0;
-    }
-
-    const dayAgo = now - 86_400_000;
-    while (minuteBuckets.length > 0 && (minuteBuckets[0].minute + 1) * 60_000 <= dayAgo) {
+    const dayAgo = now - DAY_MS;
+    while (minuteBuckets.length > 0 && minuteBuckets[0].at < dayAgo) {
       minuteBuckets.shift();
+    }
+  }
+
+  function addBucket(buckets: ActivityBucket[], at: number, count = 1) {
+    const bucket = buckets.at(-1);
+    if (bucket?.at === at) {
+      bucket.count += count;
+    } else {
+      buckets.push({ at, count });
     }
   }
 
   function record(now: number) {
     prune(now);
-    eventTimes.push(now);
-    const minute = Math.floor(now / 60_000);
-    const bucket = minuteBuckets.at(-1);
-    if (bucket?.minute === minute) {
-      bucket.count += 1;
-    } else {
-      minuteBuckets.push({ minute, count: 1 });
-    }
+    addBucket(secondBuckets, Math.floor(now / 1_000) * 1_000);
+    addBucket(minuteBuckets, Math.floor(now / 60_000) * 60_000);
+  }
+
+  function seed(baseline: ActivityBaseline, now: number) {
+    secondBuckets.length = 0;
+    minuteBuckets.length = 0;
+    baselineDayCount = baseline.dayCount;
+    baselineAt = now;
+  }
+
+  function sumSince(buckets: ActivityBucket[], now: number, window: number) {
+    const cutoff = now - window;
+    return buckets.reduce(
+      (total, bucket) => total + (bucket.at >= cutoff ? bucket.count : 0),
+      0,
+    );
   }
 
   function counts(now: number): ActivityCounts {
     prune(now);
-    let perSecond = 0;
-    for (let i = eventTimes.length - 1; i >= eventHead; i -= 1) {
-      if (eventTimes[i] < now - 1_000) break;
-      perSecond += 1;
-    }
-    let perHour = 0;
-    const hourAgo = now - 3_600_000;
-    for (let i = minuteBuckets.length - 1; i >= 0; i -= 1) {
-      const bucket = minuteBuckets[i];
-      if ((bucket.minute + 1) * 60_000 <= hourAgo) break;
-      perHour += bucket.count;
-    }
     return {
-      perSecond,
-      perMinute: eventTimes.length - eventHead,
-      perHour,
-      perDay: minuteBuckets.reduce((total, bucket) => total + bucket.count, 0),
+      perSecond: sumSince(secondBuckets, now, 1_000),
+      perMinute: sumSince(secondBuckets, now, 60_000),
+      perHour: sumSince(minuteBuckets, now, 3_600_000),
+      perDay:
+        (baselineAt !== null && now - baselineAt < DAY_MS ? baselineDayCount : 0) +
+        sumSince(minuteBuckets, now, DAY_MS),
     };
   }
 
   function reset() {
-    eventTimes.length = 0;
-    eventHead = 0;
+    secondBuckets.length = 0;
     minuteBuckets.length = 0;
+    baselineDayCount = 0;
+    baselineAt = null;
   }
 
-  return { record, counts, reset };
+  return { record, seed, counts, reset };
 }
 
 export function selectActivityRate(counts: ActivityCounts): ActivityRate {

--- a/web/src/routes/Home.svelte
+++ b/web/src/routes/Home.svelte
@@ -21,6 +21,10 @@
     type Activity,
   } from "../lib/api";
   import { getRecents, type RecentEntry } from "../lib/home/recents";
+  import {
+    selectActivityRate,
+    type ActivityCountsReader,
+  } from "../lib/activityRate";
   import StatusIcon from "../lib/StatusIcon.svelte";
   import PriorityIcon from "../lib/PriorityIcon.svelte";
   import ProjectIcon from "../lib/ProjectIcon.svelte";
@@ -55,13 +59,20 @@
     return () => topbarCtx?.set(undefined);
   });
 
-  let { navigate }: { navigate: (path: string) => void } = $props();
+  let {
+    navigate,
+    realtimeActivityCounts,
+  }: {
+    navigate: (path: string) => void;
+    realtimeActivityCounts: ActivityCountsReader;
+  } = $props();
 
   let user = $state<AuthUser | null>(null);
   let projects = $state<Project[]>([]);
   let myIssues = $state<Issue[]>([]);
   let allPages = $state<Page[]>([]);
   let activityItems = $state<Activity[]>([]);
+  let activityNow = $state(Date.now());
   let recents = $state<RecentEntry[]>([]);
   let loading = $state(true);
   let error = $state("");
@@ -70,6 +81,16 @@
   // reused as the destination for the "New issue" quick action so it lands
   // wherever the user has been most active rather than an arbitrary project.
   let digestProjectIds = $state<number[]>([]);
+
+  // Cadence uses a one-second window, so it needs a finer-grained clock than
+  // the shared 30-second relative-time heartbeat. Keep this timer local to
+  // Home so other timestamp displays do not rerender every second.
+  $effect(() => {
+    const interval = setInterval(() => {
+      activityNow = Date.now();
+    }, 1_000);
+    return () => clearInterval(interval);
+  });
 
   $effect(() => {
     loadData();
@@ -243,6 +264,8 @@
   function activityActor(a: Activity): string {
     return a.actor_display_name || a.actor_username || "system";
   }
+
+  let activityRate = $derived(selectActivityRate(realtimeActivityCounts(activityNow)));
 
   function activityDest(a: Activity): string | null {
     const ident = projectIdent(a.project_id);
@@ -616,12 +639,18 @@
             {#if activityItems.length > 0}
               <section>
                 <div class="flex items-center justify-between mb-3">
-                  <div class="flex items-center gap-2">
+                  <div class="flex items-center gap-2 min-w-0">
                     <ArrowUpRight size={12} class="text-[var(--text-faint)]" />
                     <h2 class="text-micro font-semibold uppercase tracking-widest text-[var(--text-muted)]">
                       Recent activity
                     </h2>
                   </div>
+                  <span
+                    class="text-micro text-[var(--text-faint)] tabular-nums text-right"
+                    title="Live websocket activity observed this session; counts use 1-second, 1-minute, 1-hour, or 1-day windows"
+                  >
+                    {activityRate.value} {activityRate.unit}
+                  </span>
                 </div>
                 <div class="flex flex-col gap-0.5">
                   {#each activityItems as a (a.id)}

--- a/web/src/routes/Home.svelte
+++ b/web/src/routes/Home.svelte
@@ -269,7 +269,7 @@
   }
 
   let activityRate = $derived.by(() => {
-    realtimeActivityRevision;
+    void realtimeActivityRevision;
     return selectActivityRate(realtimeActivityCounts(activityNow));
   });
 

--- a/web/src/routes/Home.svelte
+++ b/web/src/routes/Home.svelte
@@ -62,9 +62,13 @@
   let {
     navigate,
     realtimeActivityCounts,
+    realtimeActivityReady,
+    realtimeActivityRevision,
   }: {
     navigate: (path: string) => void;
     realtimeActivityCounts: ActivityCountsReader;
+    realtimeActivityReady: boolean;
+    realtimeActivityRevision: number;
   } = $props();
 
   let user = $state<AuthUser | null>(null);
@@ -82,9 +86,8 @@
   // wherever the user has been most active rather than an arbitrary project.
   let digestProjectIds = $state<number[]>([]);
 
-  // Cadence uses a one-second window, so it needs a finer-grained clock than
-  // the shared 30-second relative-time heartbeat. Keep this timer local to
-  // Home so other timestamp displays do not rerender every second.
+  // The shortest displayed window is one second, so the shared 30-second
+  // relative-time clock is too coarse. Keep the finer timer local to Home.
   $effect(() => {
     const interval = setInterval(() => {
       activityNow = Date.now();
@@ -265,7 +268,10 @@
     return a.actor_display_name || a.actor_username || "system";
   }
 
-  let activityRate = $derived(selectActivityRate(realtimeActivityCounts(activityNow)));
+  let activityRate = $derived.by(() => {
+    realtimeActivityRevision;
+    return selectActivityRate(realtimeActivityCounts(activityNow));
+  });
 
   function activityDest(a: Activity): string | null {
     const ident = projectIdent(a.project_id);
@@ -645,23 +651,25 @@
                       Recent activity
                     </h2>
                   </div>
-                  <span
-                    class="text-micro text-[var(--text-faint)] tabular-nums text-right"
-                    title="Live websocket activity observed this session; counts use 1-second, 1-minute, 1-hour, or 1-day windows"
-                  >
-                    {activityRate.value} {activityRate.unit}
-                  </span>
+                  {#if realtimeActivityReady}
+                    <span
+                      class="text-micro text-[var(--text-faint)] tabular-nums text-right"
+                      title="Websocket activity rate; the day fallback includes the last 24 hours"
+                    >
+                      {activityRate.value} {activityRate.unit}
+                    </span>
+                  {/if}
                 </div>
                 <div class="flex flex-col gap-0.5">
                   {#each activityItems as a (a.id)}
                     {@const dest = activityDest(a)}
                     {@const ident = projectIdent(a.project_id)}
-                    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-                    <div
+                    <button
+                      type="button"
+                      disabled={!dest}
                       class="flex items-start gap-2 px-2.5 py-1.5 rounded-md text-body-sm leading-snug
-                             {dest ? 'cursor-pointer hover:bg-[var(--bg-subtle)]' : ''} transition-colors"
-                      role={dest ? "button" : undefined}
-                      tabindex={dest ? 0 : undefined}
+                             {dest ? 'hover:bg-[var(--bg-subtle)]' : ''}
+                             transition-colors disabled:cursor-default"
                       onclick={() => dest && navigate(dest)}
                     >
                       <span class="flex-1 min-w-0 text-[var(--text-muted)]">
@@ -673,7 +681,7 @@
                           </span>
                         {/if}
                       </span>
-                    </div>
+                    </button>
                   {/each}
                 </div>
               </section>

--- a/web/tests/activityRate.test.ts
+++ b/web/tests/activityRate.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createActivityRateCounter,
+  isActivityRealtimeEvent,
+  parseActivityBaseline,
+  selectActivityRate,
+} from "../src/lib/activityRate";
+
+describe("activity rate", () => {
+  test("combines a daily baseline with live time buckets", () => {
+    const counter = createActivityRateCounter();
+    const start = 3_600_000;
+
+    counter.seed({ dayCount: 10 }, start);
+    counter.record(start);
+    counter.record(start + 500);
+
+    expect(counter.counts(start + 500)).toEqual({
+      perSecond: 2,
+      perMinute: 2,
+      perHour: 2,
+      perDay: 12,
+    });
+    expect(counter.counts(start + 61_000)).toEqual({
+      perSecond: 0,
+      perMinute: 0,
+      perHour: 2,
+      perDay: 12,
+    });
+  });
+
+  test("seeding and resetting discard stale live buckets", () => {
+    const counter = createActivityRateCounter();
+
+    counter.record(1_000);
+    counter.seed({ dayCount: 4 }, 1_000);
+    expect(counter.counts(1_000)).toEqual({
+      perSecond: 0,
+      perMinute: 0,
+      perHour: 0,
+      perDay: 4,
+    });
+
+    counter.reset();
+    expect(counter.counts(1_000).perDay).toBe(0);
+  });
+
+  test("expires an initial daily baseline without reconnecting", () => {
+    const counter = createActivityRateCounter();
+    const start = 1_000;
+
+    counter.seed({ dayCount: 4 }, start);
+    counter.record(start + 3_600_000);
+
+    expect(counter.counts(start + 86_400_000).perDay).toBe(1);
+  });
+
+  test("excludes buckets that start before each trailing window", () => {
+    const counter = createActivityRateCounter();
+
+    counter.record(0);
+    expect(counter.counts(1_500).perSecond).toBe(0);
+    expect(counter.counts(60_500).perMinute).toBe(0);
+    expect(counter.counts(3_600_500).perHour).toBe(0);
+    expect(counter.counts(86_400_500).perDay).toBe(0);
+  });
+
+  test("counts only audit-backed realtime events", () => {
+    expect(isActivityRealtimeEvent("project.updated")).toBe(true);
+    expect(isActivityRealtimeEvent("issue.linked")).toBe(true);
+    expect(isActivityRealtimeEvent("projects.reordered")).toBe(false);
+    expect(isActivityRealtimeEvent("project_groups.changed")).toBe(false);
+    expect(isActivityRealtimeEvent("future.configuration.changed")).toBe(false);
+  });
+
+  test("accepts only non-negative safe-integer baselines", () => {
+    expect(parseActivityBaseline(4)).toEqual({ dayCount: 4 });
+    for (const invalid of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1, Infinity, "4", null]) {
+      expect(parseActivityBaseline(invalid)).toBeNull();
+    }
+  });
+
+  test("selects the shortest active rate window", () => {
+    expect(
+      selectActivityRate({ perSecond: 2, perMinute: 3, perHour: 4, perDay: 5 }),
+    ).toEqual({ value: 2, unit: "updates/s" });
+    expect(
+      selectActivityRate({ perSecond: 1, perMinute: 3, perHour: 4, perDay: 5 }),
+    ).toEqual({ value: 3, unit: "updates/min" });
+    expect(
+      selectActivityRate({ perSecond: 0, perMinute: 1, perHour: 4, perDay: 5 }),
+    ).toEqual({ value: 4, unit: "updates/hr" });
+    expect(
+      selectActivityRate({ perSecond: 0, perMinute: 1, perHour: 1, perDay: 5 }),
+    ).toEqual({ value: 5, unit: "updates/day" });
+  });
+});


### PR DESCRIPTION
The Home indicator previously had no meaningful trailing-day baseline after page load or reconnect, and could show a misleading zero when realtime data was unavailable.

## Impact

The activity-rate indicator stays hidden until the websocket baseline is ready, uses only activity visible to the current user, and resumes live second/minute/hour/day windows after initialization.

## Root cause

The client counter only observed events from the current session; the websocket had no baseline request/response path to seed its rolling windows.

## Branch-added tests

- `activity_count_filters_to_last_day_and_visible_projects` proves the baseline query excludes activity older than 24 hours and excludes projects outside the callers visible scope.
- `activity_baseline_serializes_with_day_count` locks the websocket response type and `day_count` wire shape.
- `activity_baseline_rechecks_current_project_visibility` proves authorization is resolved again for each baseline request, so losing project membership immediately removes that projects activity.
- `activityRate.test.ts` covers seeded and live time buckets, stale baseline expiry, resets, and adaptive rate selection.