### PR TITLE
Validate Jira site slugs before sending Basic credentials

### DIFF
--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -89,12 +89,19 @@ impl HttpBackend {
             anyhow!("HTTP backend URL must not contain credentials, a query, or a fragment")
         })?;
         if parsed.scheme() == "http"
+            && api_key.is_some()
             && parsed
                 .host_str()
                 .is_some_and(|host| !is_loopback_host(host))
         {
+            bail!(
+                "refusing to send bearer credentials over plaintext http to {}",
+                parsed.host_str().unwrap_or_default()
+            );
+        }
+        if parsed.scheme() == "http" && parsed.host_str().is_some_and(|host| !is_loopback_host(host)) {
             eprintln!(
-                "warning: sending credentials over unencrypted http to {}",
+                "warning: connecting over unencrypted http to {}",
                 parsed.host_str().unwrap_or_default()
             );
         }
@@ -1505,6 +1512,17 @@ mod tests {
         assert!(is_loopback_host("::1"));
         assert!(!is_loopback_host("0.0.0.0"));
         assert!(!is_loopback_host("tracker.example"));
+    }
+
+    #[test]
+    fn refuses_plaintext_remote_bearer_transport() {
+        let error = match HttpBackend::new("http://tracker.example", Some("secret-key")) {
+            Ok(_) => panic!("remote plaintext bearer transport must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("plaintext http"));
+        assert!(HttpBackend::new("http://127.0.0.1:3456", Some("secret-key")).is_ok());
+        assert!(HttpBackend::new("http://tracker.example", None).is_ok());
     }
 
     #[test]

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -1520,7 +1520,9 @@ mod tests {
             Ok(_) => panic!("remote plaintext bearer transport must be rejected"),
             Err(error) => error,
         };
-        assert!(error.to_string().contains("plaintext http"));
+        let message = error.to_string();
+        assert!(message.contains("plaintext http"));
+        assert!(!message.contains("secret-key"));
         assert!(HttpBackend::new("http://127.0.0.1:3456", Some("secret-key")).is_ok());
         assert!(HttpBackend::new("http://tracker.example", None).is_ok());
     }

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -170,7 +170,7 @@ fn run_jira(
     };
 
     let fetcher = jira::LiveJira::new(site, jira_project, email, token)?;
-    let fetched = jira::collect(&fetcher, site, &map)?;
+    let fetched = jira::collect(&fetcher, fetcher.site_slug(), &map)?;
     let summary = import::run_import(pool, project_id, bot, &fetched, dry_run)?;
     Ok(summary)
 }

--- a/src/import/jira.rs
+++ b/src/import/jira.rs
@@ -490,6 +490,7 @@ impl LiveJira {
         email: &str,
         token: &str,
     ) -> Result<LiveJira, String> {
+        let site = validate_site_slug(site)?;
         use base64::Engine;
         let client = reqwest::blocking::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
@@ -503,7 +504,7 @@ impl LiveJira {
         );
         Ok(LiveJira {
             client,
-            site: site.to_string(),
+            site,
             project_key: project_key.to_string(),
             auth,
         })
@@ -512,6 +513,24 @@ impl LiveJira {
     fn base(&self) -> String {
         format!("https://{}.atlassian.net/rest/api/3", self.site)
     }
+}
+
+/// Jira Cloud site names become the hostname component of the request URL.
+/// Keep this to one DNS-label-shaped slug so credentials can never be sent to
+/// an attacker-controlled host or path through string interpolation.
+pub fn validate_site_slug(site: &str) -> Result<String, String> {
+    let site = site.trim().to_ascii_lowercase();
+    if site.is_empty()
+        || site.len() > 63
+        || site.starts_with('-')
+        || site.ends_with('-')
+        || !site
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err("Jira site must be a single DNS label (letters, digits, and hyphens)".into());
+    }
+    Ok(site)
 }
 
 impl JiraFetcher for LiveJira {
@@ -729,5 +748,13 @@ mod tests {
         };
         let fetched = collect(&fetcher, "mycompany", &JiraStatusMap::default()).unwrap();
         assert_eq!(fetched.issues.len(), issues.len());
+    }
+
+    #[test]
+    fn jira_site_slug_rejects_host_and_path_injection() {
+        assert_eq!(validate_site_slug("My-Team").unwrap(), "my-team");
+        for invalid in ["", "evil.example", "evil/path", "-leading", "trailing-", "a_b"] {
+            assert!(validate_site_slug(invalid).is_err(), "accepted {invalid:?}");
+        }
     }
 }

--- a/src/import/jira.rs
+++ b/src/import/jira.rs
@@ -514,6 +514,11 @@ impl LiveJira {
     fn base(&self) -> String {
         format!("https://{}.atlassian.net/rest/api/3", self.site)
     }
+
+    /// Return the canonical site slug used for both requests and identities.
+    pub fn site_slug(&self) -> &str {
+        &self.site
+    }
 }
 
 /// Jira Cloud site names become the hostname component of the request URL.

--- a/src/import/jira.rs
+++ b/src/import/jira.rs
@@ -494,6 +494,7 @@ impl LiveJira {
         use base64::Engine;
         let client = reqwest::blocking::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
             .user_agent("lific-import/1.0")
             .build()
             .map_err(|e| format!("http client init failed: {e}"))?;
@@ -753,7 +754,19 @@ mod tests {
     #[test]
     fn jira_site_slug_rejects_host_and_path_injection() {
         assert_eq!(validate_site_slug("My-Team").unwrap(), "my-team");
-        for invalid in ["", "evil.example", "evil/path", "-leading", "trailing-", "a_b"] {
+        for invalid in [
+            "",
+            "evil.example",
+            "evil/path",
+            "evil:443",
+            "user@evil",
+            "evil?query",
+            "evil#fragment",
+            "evil%2fpath",
+            "-leading",
+            "trailing-",
+            "a_b",
+        ] {
             assert!(validate_site_slug(invalid).is_err(), "accepted {invalid:?}");
         }
     }


### PR DESCRIPTION
## Problem

The Jira importer interpolated raw `--site` input into an Atlassian URL. Delimiters, userinfo, query, fragment, or port syntax could redirect the authenticated request to an attacker-controlled or local HTTPS host with the user’s Jira Basic credentials.

## Change

Validate the site as a strict Jira slug before constructing the URL and reject authority-changing input before any credentialed request.

## Acceptance focus

- Valid Jira slugs still target the expected Atlassian API.
- Delimiters, ports, userinfo, fragments, queries, and path escapes are rejected.
- No redirect or alternate host can receive the Basic header.
- Error output does not leak credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote plaintext HTTP connections are now blocked when API key authentication is enabled, while local connections continue to work as expected.
  * Jira site addresses are validated and normalized to reject malformed values and unsafe host or path injection attempts.
  * Jira requests no longer automatically follow HTTP redirects, improving connection safety.
  * Jira imports now consistently use the normalized site address.
* **Tests**
  * Added coverage for HTTP access rules and Jira site validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->