### PR TITLE
Require authentication for the public user-roster endpoint

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -859,10 +859,50 @@ mod tests {
 
     #[tokio::test]
     async fn user_roster_requires_admin_authentication() {
-        assert!(super::require_admin(&None).is_err());
+        let unauthenticated = {
+            let db = crate::db::open_memory().expect("test db");
+            with_client_ip_test_layers(crate::api::router(db, &[]), test_peer())
+                .layer(axum::Extension(crate::config::AuthConfig {
+                    allow_signup: true,
+                    required: true,
+                    secure_cookies: false,
+                }))
+                .layer(axum::Extension(
+                    None::<crate::resolve_caller::ResolvedIdentity>,
+                ))
+        };
+        assert_eq!(
+            json_get(&unauthenticated, "/api/users").await.status(),
+            StatusCode::FORBIDDEN
+        );
 
-        let app = test_app_with_auth(true);
-        assert_eq!(json_get(&app, "/api/users").await.status(), StatusCode::OK);
+        let non_admin = {
+            let db = crate::db::open_memory().expect("test db");
+            with_client_ip_test_layers(crate::api::router(db, &[]), test_peer())
+                .layer(axum::Extension(crate::config::AuthConfig {
+                    allow_signup: true,
+                    required: true,
+                    secure_cookies: false,
+                }))
+                .layer(axum::Extension(Some(
+                    crate::resolve_caller::ResolvedIdentity {
+                        user: crate::db::models::AuthUser {
+                            id: 99,
+                            username: "member".into(),
+                            display_name: "Member".into(),
+                            is_admin: false,
+                        },
+                        transport: crate::actor::Transport::Web,
+                    },
+                )))
+        };
+        assert_eq!(
+            json_get(&non_admin, "/api/users").await.status(),
+            StatusCode::FORBIDDEN
+        );
+
+        let admin = test_app_with_auth(true);
+        assert_eq!(json_get(&admin, "/api/users").await.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -728,9 +728,9 @@ pub(super) struct UserListItem {
 
 pub(super) async fn list_users(
     State(db): State<DbPool>,
-    Extension(auth_user): Extension<Option<AuthUser>>,
+    Extension(identity): Extension<Option<crate::resolve_caller::ResolvedIdentity>>,
 ) -> Result<Json<Vec<UserListItem>>, LificError> {
-    require_admin(&auth_user)?;
+    require_admin(&identity)?;
     with_read(&db, |conn| {
         let users = crate::db::queries::users::list_users(conn)?;
         Ok(users

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -728,7 +728,9 @@ pub(super) struct UserListItem {
 
 pub(super) async fn list_users(
     State(db): State<DbPool>,
+    Extension(auth_user): Extension<Option<AuthUser>>,
 ) -> Result<Json<Vec<UserListItem>>, LificError> {
+    require_admin(&auth_user)?;
     with_read(&db, |conn| {
         let users = crate::db::queries::users::list_users(conn)?;
         Ok(users
@@ -853,6 +855,14 @@ mod tests {
         let data = parse_json(resp).await;
         assert_eq!(data["allow_signup"], true);
         assert_eq!(data["has_users"], true, "seeded admin counts as a human");
+    }
+
+    #[tokio::test]
+    async fn user_roster_requires_admin_authentication() {
+        assert!(super::require_admin(&None).is_err());
+
+        let app = test_app_with_auth(true);
+        assert_eq!(json_get(&app, "/api/users").await.status(), StatusCode::OK);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

GET /api/users exposed usernames, display names, admin flags, and creation timestamps without a session, enabling account enumeration before password-spray or phishing attempts.

## Change

Gate the roster behind the intended authenticated administrator boundary while preserving the aggregate instance signal used where an account-existence check is needed.

## Acceptance focus

- Anonymous roster requests are denied.
- Ordinary authenticated users are denied.
- Administrators can retrieve the roster.
- No account-level data is reintroduced through the public instance endpoint.

## Checks

The branch retains REST authorization coverage for anonymous, ordinary-user, and administrator callers.
