### PR TITLE
Harden comment authorization, attachment isolation, and mutation atomicity

### DIFF
--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -219,6 +219,11 @@ pub(super) async fn update_comment_handler(
     // (issue_id XOR page_id) — a page comment may have a NULL project
     // (workspace page), which `mention_candidates` handles.
     let project_id = with_read(&db, |conn| resolve_comment_project(conn, &existing))?;
+    // Editing remains subject to the current project membership even when
+    // the caller owns the comment.  This closes the revoked-member path in
+    // which ownership alone was enough to mutate a comment after access was
+    // removed.
+    require_comment_viewer(&db, &identity, project_id)?;
     let member_scoped = authz::authz_enforced(&db)?;
 
     let comment = with_write(&db, |conn| {
@@ -277,6 +282,9 @@ pub(super) async fn delete_comment_handler(
     }
 
     let project_id = with_read(&db, |conn| resolve_comment_project(conn, &existing))?;
+    // Match the edit path: ownership is not a substitute for current access
+    // to the comment's project (or workspace-admin access for workspace pages).
+    require_comment_viewer(&db, &identity, project_id)?;
     with_write(&db, |conn| {
         crate::db::queries::comments::delete_comment(conn, id)
     })?;
@@ -490,6 +498,81 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn revoked_member_cannot_edit_or_delete_own_comment() {
+        let (db, _admin, _lead, _maintainer, viewer, _non_member, project_id) =
+            crate::api::test_helpers::setup_membership_test();
+        let (edit_comment_id, delete_comment_id) = {
+            let conn = db.write().unwrap();
+            let issue = crate::db::queries::create_issue(
+                &conn,
+                &CreateIssue {
+                    project_id,
+                    title: "Revocation test".into(),
+                    status: Status::Todo,
+                    priority: Priority::Medium,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let parent = crate::db::queries::comments::CommentParent::Issue(issue.id);
+            let edit = crate::db::queries::comments::create_comment(
+                &conn,
+                parent,
+                viewer.id,
+                "Keep this comment",
+            )
+            .unwrap();
+            let delete = crate::db::queries::comments::create_comment(
+                &conn,
+                parent,
+                viewer.id,
+                "Keep this one too",
+            )
+            .unwrap();
+            crate::db::queries::members::remove_member(&conn, project_id, viewer.id).unwrap();
+            (edit.id, delete.id)
+        };
+
+        let app = crate::api::test_helpers::app_as_user(db.clone(), &viewer);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/comments/{edit_comment_id}"))
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        serde_json::to_vec(&serde_json::json!({"content": "tampered"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/comments/{delete_comment_id}"))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        let conn = db.read().unwrap();
+        assert_eq!(
+            crate::db::queries::comments::get_comment(&conn, edit_comment_id)
+                .unwrap()
+                .content,
+            "Keep this comment"
+        );
+        assert!(crate::db::queries::comments::get_comment(&conn, delete_comment_id).is_ok());
     }
 
     #[tokio::test]

--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -4,61 +4,20 @@ use axum::{
 };
 
 use crate::authz;
-use crate::db::queries::comments::{self, CommentParent};
+use crate::db::queries::comments::{self, CommentContext, CommentParent};
 use crate::db::{DbPool, models::*};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
-use super::{require_user, with_read, with_write};
+use super::{require_user, with_read};
 
-/// Pool-level adaptor over [`comments::create_comment_with_mentions`]: the
-/// mention set (LIF-263) and the attachment links (LIF-262) are reconciled in
-/// the same write as the insert.
-///
-/// The `authz_enforced` flag is read *before* the write lock is taken (it
-/// opens its own read connection) to avoid nesting the pool's guards.
-fn create_comment_with_mentions(
-    db: &DbPool,
-    parent: CommentParent,
-    project_id: Option<i64>,
-    user_id: i64,
-    content: &str,
-) -> Result<Comment, LificError> {
-    let member_scoped = authz::authz_enforced(db)?;
-    with_write(db, |conn| {
-        comments::create_comment_with_mentions(
-            conn,
-            parent,
-            project_id,
-            user_id,
-            content,
-            member_scoped,
-        )
-    })
-}
-
-/// LIF-197: comments are gated at `Viewer` — anyone who can see a project
-/// can read and post comments on its issues/pages (the actual auth-required
-/// check for *who* the comment is attributed to is separate, below).
-/// Workspace-level pages (`project_id = None`) fall back to admin-only.
 fn require_comment_viewer(
     db: &DbPool,
     identity: &Option<crate::resolve_caller::ResolvedIdentity>,
     project_id: Option<i64>,
 ) -> Result<(), LificError> {
     let conn = db.read()?;
-    require_comment_viewer_conn(&conn, identity, project_id)
-}
-
-fn require_comment_viewer_conn(
-    conn: &rusqlite::Connection,
-    identity: &Option<crate::resolve_caller::ResolvedIdentity>,
-    project_id: Option<i64>,
-) -> Result<(), LificError> {
-    match project_id {
-        Some(pid) => authz::require_role_conn(conn, identity, pid, Role::Viewer),
-        None => authz::require_workspace_admin_conn(conn, identity),
-    }
+    authz::require_project_or_workspace_role_conn(&conn, identity, project_id, Role::Viewer)
 }
 
 #[derive(Default, serde::Deserialize)]
@@ -73,17 +32,9 @@ pub(super) struct ListCommentsQuery {
     offset: Option<i64>,
 }
 
-/// LIF-382: the project a comment's parent belongs to. Issues always have
-/// one; a workspace-level page may not, hence the `Option`.
 fn parent_project_id(db: &DbPool, parent: CommentParent) -> Result<Option<i64>, LificError> {
-    match parent {
-        CommentParent::Issue(issue_id) => Ok(Some(
-            with_read(db, |conn| crate::db::queries::get_issue(conn, issue_id))?.project_id,
-        )),
-        CommentParent::Page(page_id) => {
-            Ok(with_read(db, |conn| crate::db::queries::get_page(conn, page_id))?.project_id)
-        }
-    }
+    let conn = db.read()?;
+    parent.project_id(&conn)
 }
 
 /// LIF-382: listing an issue's comments and listing a page's comments differ
@@ -110,10 +61,6 @@ fn list_for_parent(
     .map(Json)
 }
 
-/// LIF-382: shared body of the two comment-creation routes. Only the
-/// broadcast differs: an issue comment refreshes that issue, a page comment
-/// refreshes the project (and a workspace-level page refreshes nothing,
-/// there being no project to name).
 fn create_for_parent(
     db: &DbPool,
     realtime: &RealtimeHub,
@@ -121,12 +68,22 @@ fn create_for_parent(
     parent: CommentParent,
     content: &str,
 ) -> Result<Json<Comment>, LificError> {
-    let project_id = parent_project_id(db, parent)?;
-    require_comment_viewer(db, identity, project_id)?;
-
     let user = require_user(identity)?;
+    let (comment, project_id) = db.transaction(|conn| {
+        let project_id = parent.project_id(conn)?;
+        authz::require_project_or_workspace_role_conn(conn, identity, project_id, Role::Viewer)?;
+        let member_scoped = authz::authz_enforced_conn(conn)?;
+        let comment = comments::create_comment_with_mentions(
+            conn,
+            parent,
+            project_id,
+            CommentActor::from(&user),
+            content,
+            member_scoped,
+        )?;
+        Ok((comment, project_id))
+    })?;
 
-    let comment = create_comment_with_mentions(db, parent, project_id, user.id, content)?;
     if let Some(project_id) = project_id {
         realtime.send(match parent {
             CommentParent::Issue(issue_id) => issue_updated_event(project_id, issue_id),
@@ -204,51 +161,12 @@ pub(super) async fn mention_candidates(
     .map(Json)
 }
 
-#[derive(Clone, Copy)]
-enum CommentContext {
-    Issue { issue_id: i64, project_id: i64 },
-    Page { project_id: Option<i64> },
-}
-
-impl CommentContext {
-    fn resolve(conn: &rusqlite::Connection, comment: &Comment) -> Result<Self, LificError> {
-        match (comment.issue_id, comment.page_id) {
-            (Some(issue_id), None) => {
-                let project_id = crate::db::queries::get_issue(conn, issue_id)?.project_id;
-                Ok(Self::Issue {
-                    issue_id,
-                    project_id,
-                })
-            }
-            (None, Some(page_id)) => {
-                let project_id = crate::db::queries::get_page(conn, page_id)?.project_id;
-                Ok(Self::Page { project_id })
-            }
-            _ => Err(LificError::Internal(format!(
-                "comment {} has an invalid parent",
-                comment.id
-            ))),
-        }
-    }
-
-    fn project_id(self) -> Option<i64> {
-        match self {
-            Self::Issue { project_id, .. } => Some(project_id),
-            Self::Page { project_id } => project_id,
-        }
-    }
-
-    fn updated_event(self) -> Option<RealtimeEvent> {
-        match self {
-            Self::Issue {
-                issue_id,
-                project_id,
-            } => Some(issue_updated_event(project_id, issue_id)),
-            Self::Page { project_id } => {
-                project_id.map(|project_id| RealtimeEvent::ProjectUpdated { project_id })
-            }
-        }
-    }
+fn comment_updated_event(context: &CommentContext) -> Option<RealtimeEvent> {
+    let project_id = context.project_id()?;
+    Some(match context.parent() {
+        CommentParent::Issue(issue_id) => issue_updated_event(project_id, issue_id),
+        CommentParent::Page(_) => RealtimeEvent::ProjectUpdated { project_id },
+    })
 }
 
 pub(super) async fn update_comment_handler(
@@ -259,28 +177,29 @@ pub(super) async fn update_comment_handler(
     Json(input): Json<UpdateComment>,
 ) -> Result<Json<Comment>, LificError> {
     let user = require_user(&identity)?;
-    let (comment, context) = with_write(&db, |conn| {
+    let (comment, context) = db.transaction(|conn| {
         let existing = comments::get_comment(conn, id)?;
+        let context = CommentContext::resolve(conn, &existing)?;
+        let project_id = context.project_id();
+        authz::require_project_or_workspace_role_conn(conn, &identity, project_id, Role::Viewer)?;
         if existing.user_id != user.id && !user.is_admin {
             return Err(LificError::BadRequest(
                 "you can only edit your own comments".into(),
             ));
         }
 
-        let context = CommentContext::resolve(conn, &existing)?;
-        let project_id = context.project_id();
-        require_comment_viewer_conn(conn, &identity, project_id)?;
         let member_scoped = authz::authz_enforced_conn(conn)?;
         let comment = comments::update_comment_with_mentions(
             conn,
             id,
             project_id,
+            CommentActor::from(&user),
             &input.content,
             member_scoped,
         )?;
         Ok((comment, context))
     })?;
-    if let Some(event) = context.updated_event() {
+    if let Some(event) = comment_updated_event(&context) {
         realtime.send(event);
     }
     Ok(Json(comment))
@@ -293,20 +212,25 @@ pub(super) async fn delete_comment_handler(
     Extension(identity): Extension<Option<crate::resolve_caller::ResolvedIdentity>>,
 ) -> Result<Json<serde_json::Value>, LificError> {
     let user = require_user(&identity)?;
-    let context = with_write(&db, |conn| {
+    let context = db.transaction(|conn| {
         let existing = comments::get_comment(conn, id)?;
+        let context = CommentContext::resolve(conn, &existing)?;
+        authz::require_project_or_workspace_role_conn(
+            conn,
+            &identity,
+            context.project_id(),
+            Role::Viewer,
+        )?;
         if existing.user_id != user.id && !user.is_admin {
             return Err(LificError::BadRequest(
                 "you can only delete your own comments".into(),
             ));
         }
 
-        let context = CommentContext::resolve(conn, &existing)?;
-        require_comment_viewer_conn(conn, &identity, context.project_id())?;
         comments::delete_comment(conn, id)?;
         Ok(context)
     })?;
-    if let Some(event) = context.updated_event() {
+    if let Some(event) = comment_updated_event(&context) {
         realtime.send(event);
     }
     Ok(Json(serde_json::json!({"deleted": true})))
@@ -513,10 +437,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn revoked_member_cannot_edit_or_delete_own_comment() {
-        let (db, _admin, _lead, _maintainer, viewer, _non_member, project_id) =
+    async fn revoked_member_cannot_mutate_comments() {
+        let (db, _admin, lead, _maintainer, viewer, _non_member, project_id) =
             setup_membership_test();
-        let [edit_comment_id, delete_comment_id] = {
+        let [
+            edit_comment_id,
+            delete_comment_id,
+            foreign_edit_id,
+            foreign_delete_id,
+        ] = {
             let conn = db.write().unwrap();
             let issue = crate::db::queries::create_issue(
                 &conn,
@@ -530,8 +459,14 @@ mod tests {
             )
             .unwrap();
             let parent = crate::db::queries::comments::CommentParent::Issue(issue.id);
-            let comment_ids = ["Keep this comment", "Keep this one too"].map(|content| {
-                crate::db::queries::comments::create_comment(&conn, parent, viewer.id, content)
+            let comment_ids = [
+                (viewer.id, "Keep this comment"),
+                (viewer.id, "Keep this one too"),
+                (lead.id, "Do not disclose ownership"),
+                (lead.id, "Do not disclose ownership either"),
+            ]
+            .map(|(user_id, content)| {
+                crate::db::queries::comments::create_comment(&conn, parent, user_id, content)
                     .unwrap()
                     .id
             });
@@ -551,6 +486,17 @@ mod tests {
         let resp = json_delete(&app, &format!("/api/comments/{delete_comment_id}")).await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
+        let resp = json_put(
+            &app,
+            &format!("/api/comments/{foreign_edit_id}"),
+            serde_json::json!({"content": "tampered"}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        let resp = json_delete(&app, &format!("/api/comments/{foreign_delete_id}")).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
         let conn = db.read().unwrap();
         assert_eq!(
             crate::db::queries::comments::get_comment(&conn, edit_comment_id)
@@ -559,6 +505,13 @@ mod tests {
             "Keep this comment"
         );
         assert!(crate::db::queries::comments::get_comment(&conn, delete_comment_id).is_ok());
+        assert_eq!(
+            crate::db::queries::comments::get_comment(&conn, foreign_edit_id)
+                .unwrap()
+                .content,
+            "Do not disclose ownership"
+        );
+        assert!(crate::db::queries::comments::get_comment(&conn, foreign_delete_id).is_ok());
     }
 
     #[tokio::test]
@@ -903,9 +856,7 @@ mod tests {
         let resp = app
             .oneshot(
                 Request::builder()
-                    .uri(format!(
-                        "/api/pages/{page_id}/comments?limit=1&offset=2"
-                    ))
+                    .uri(format!("/api/pages/{page_id}/comments?limit=1&offset=2"))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )

--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -46,9 +46,18 @@ fn require_comment_viewer(
     identity: &Option<crate::resolve_caller::ResolvedIdentity>,
     project_id: Option<i64>,
 ) -> Result<(), LificError> {
+    let conn = db.read()?;
+    require_comment_viewer_conn(&conn, identity, project_id)
+}
+
+fn require_comment_viewer_conn(
+    conn: &rusqlite::Connection,
+    identity: &Option<crate::resolve_caller::ResolvedIdentity>,
+    project_id: Option<i64>,
+) -> Result<(), LificError> {
     match project_id {
-        Some(pid) => authz::require_role(db, identity, pid, Role::Viewer),
-        None => authz::require_workspace_admin(db, identity),
+        Some(pid) => authz::require_role_conn(conn, identity, pid, Role::Viewer),
+        None => authz::require_workspace_admin_conn(conn, identity),
     }
 }
 
@@ -195,6 +204,53 @@ pub(super) async fn mention_candidates(
     .map(Json)
 }
 
+#[derive(Clone, Copy)]
+enum CommentContext {
+    Issue { issue_id: i64, project_id: i64 },
+    Page { project_id: Option<i64> },
+}
+
+impl CommentContext {
+    fn resolve(conn: &rusqlite::Connection, comment: &Comment) -> Result<Self, LificError> {
+        match (comment.issue_id, comment.page_id) {
+            (Some(issue_id), None) => {
+                let project_id = crate::db::queries::get_issue(conn, issue_id)?.project_id;
+                Ok(Self::Issue {
+                    issue_id,
+                    project_id,
+                })
+            }
+            (None, Some(page_id)) => {
+                let project_id = crate::db::queries::get_page(conn, page_id)?.project_id;
+                Ok(Self::Page { project_id })
+            }
+            _ => Err(LificError::Internal(format!(
+                "comment {} has an invalid parent",
+                comment.id
+            ))),
+        }
+    }
+
+    fn project_id(self) -> Option<i64> {
+        match self {
+            Self::Issue { project_id, .. } => Some(project_id),
+            Self::Page { project_id } => project_id,
+        }
+    }
+
+    fn updated_event(self) -> Option<RealtimeEvent> {
+        match self {
+            Self::Issue {
+                issue_id,
+                project_id,
+            } => Some(issue_updated_event(project_id, issue_id)),
+            Self::Page { project_id } => {
+                project_id.map(|project_id| RealtimeEvent::ProjectUpdated { project_id })
+            }
+        }
+    }
+}
+
 pub(super) async fn update_comment_handler(
     State(db): State<DbPool>,
     Extension(realtime): Extension<RealtimeHub>,
@@ -203,64 +259,31 @@ pub(super) async fn update_comment_handler(
     Json(input): Json<UpdateComment>,
 ) -> Result<Json<Comment>, LificError> {
     let user = require_user(&identity)?;
+    let (comment, context) = with_write(&db, |conn| {
+        let existing = comments::get_comment(conn, id)?;
+        if existing.user_id != user.id && !user.is_admin {
+            return Err(LificError::BadRequest(
+                "you can only edit your own comments".into(),
+            ));
+        }
 
-    // Check ownership: only the author or an admin can edit
-    let existing = with_read(&db, |conn| {
-        crate::db::queries::comments::get_comment(conn, id)
-    })?;
-    if existing.user_id != user.id && !user.is_admin {
-        return Err(LificError::BadRequest(
-            "you can only edit your own comments".into(),
-        ));
-    }
-
-    // LIF-263: recompute the mention set against the parent project's
-    // visible members. Resolve the project from the comment's parent
-    // (issue_id XOR page_id) — a page comment may have a NULL project
-    // (workspace page), which `mention_candidates` handles.
-    let project_id = with_read(&db, |conn| resolve_comment_project(conn, &existing))?;
-    // Editing remains subject to the current project membership even when
-    // the caller owns the comment.  This closes the revoked-member path in
-    // which ownership alone was enough to mutate a comment after access was
-    // removed.
-    require_comment_viewer(&db, &identity, project_id)?;
-    let member_scoped = authz::authz_enforced(&db)?;
-
-    let comment = with_write(&db, |conn| {
-        comments::update_comment_with_mentions(
+        let context = CommentContext::resolve(conn, &existing)?;
+        let project_id = context.project_id();
+        require_comment_viewer_conn(conn, &identity, project_id)?;
+        let member_scoped = authz::authz_enforced_conn(conn)?;
+        let comment = comments::update_comment_with_mentions(
             conn,
             id,
             project_id,
             &input.content,
             member_scoped,
-        )
+        )?;
+        Ok((comment, context))
     })?;
-    match (comment.issue_id, project_id) {
-        (Some(issue_id), Some(project_id)) => {
-            realtime.send(issue_updated_event(project_id, issue_id));
-        }
-        (None, Some(project_id)) if comment.page_id.is_some() => {
-            realtime.send(RealtimeEvent::ProjectUpdated { project_id });
-        }
-        _ => {}
+    if let Some(event) = context.updated_event() {
+        realtime.send(event);
     }
     Ok(Json(comment))
-}
-
-/// Resolve the project a comment belongs to, via its issue or page parent.
-fn resolve_comment_project(
-    conn: &rusqlite::Connection,
-    comment: &Comment,
-) -> Result<Option<i64>, LificError> {
-    if let Some(issue_id) = comment.issue_id {
-        Ok(Some(
-            crate::db::queries::get_issue(conn, issue_id)?.project_id,
-        ))
-    } else if let Some(page_id) = comment.page_id {
-        Ok(crate::db::queries::get_page(conn, page_id)?.project_id)
-    } else {
-        Ok(None)
-    }
 }
 
 pub(super) async fn delete_comment_handler(
@@ -270,32 +293,21 @@ pub(super) async fn delete_comment_handler(
     Extension(identity): Extension<Option<crate::resolve_caller::ResolvedIdentity>>,
 ) -> Result<Json<serde_json::Value>, LificError> {
     let user = require_user(&identity)?;
-
-    // Check ownership: only the author or an admin can delete
-    let existing = with_read(&db, |conn| {
-        crate::db::queries::comments::get_comment(conn, id)
-    })?;
-    if existing.user_id != user.id && !user.is_admin {
-        return Err(LificError::BadRequest(
-            "you can only delete your own comments".into(),
-        ));
-    }
-
-    let project_id = with_read(&db, |conn| resolve_comment_project(conn, &existing))?;
-    // Match the edit path: ownership is not a substitute for current access
-    // to the comment's project (or workspace-admin access for workspace pages).
-    require_comment_viewer(&db, &identity, project_id)?;
-    with_write(&db, |conn| {
-        crate::db::queries::comments::delete_comment(conn, id)
-    })?;
-    match (existing.issue_id, project_id) {
-        (Some(issue_id), Some(project_id)) => {
-            realtime.send(issue_updated_event(project_id, issue_id));
+    let context = with_write(&db, |conn| {
+        let existing = comments::get_comment(conn, id)?;
+        if existing.user_id != user.id && !user.is_admin {
+            return Err(LificError::BadRequest(
+                "you can only delete your own comments".into(),
+            ));
         }
-        (None, Some(project_id)) if existing.page_id.is_some() => {
-            realtime.send(RealtimeEvent::ProjectUpdated { project_id });
-        }
-        _ => {}
+
+        let context = CommentContext::resolve(conn, &existing)?;
+        require_comment_viewer_conn(conn, &identity, context.project_id())?;
+        comments::delete_comment(conn, id)?;
+        Ok(context)
+    })?;
+    if let Some(event) = context.updated_event() {
+        realtime.send(event);
     }
     Ok(Json(serde_json::json!({"deleted": true})))
 }
@@ -503,8 +515,8 @@ mod tests {
     #[tokio::test]
     async fn revoked_member_cannot_edit_or_delete_own_comment() {
         let (db, _admin, _lead, _maintainer, viewer, _non_member, project_id) =
-            crate::api::test_helpers::setup_membership_test();
-        let (edit_comment_id, delete_comment_id) = {
+            setup_membership_test();
+        let [edit_comment_id, delete_comment_id] = {
             let conn = db.write().unwrap();
             let issue = crate::db::queries::create_issue(
                 &conn,
@@ -518,51 +530,25 @@ mod tests {
             )
             .unwrap();
             let parent = crate::db::queries::comments::CommentParent::Issue(issue.id);
-            let edit = crate::db::queries::comments::create_comment(
-                &conn,
-                parent,
-                viewer.id,
-                "Keep this comment",
-            )
-            .unwrap();
-            let delete = crate::db::queries::comments::create_comment(
-                &conn,
-                parent,
-                viewer.id,
-                "Keep this one too",
-            )
-            .unwrap();
+            let comment_ids = ["Keep this comment", "Keep this one too"].map(|content| {
+                crate::db::queries::comments::create_comment(&conn, parent, viewer.id, content)
+                    .unwrap()
+                    .id
+            });
             crate::db::queries::members::remove_member(&conn, project_id, viewer.id).unwrap();
-            (edit.id, delete.id)
+            comment_ids
         };
 
-        let app = crate::api::test_helpers::app_as_user(db.clone(), &viewer);
-        let resp = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("PUT")
-                    .uri(format!("/api/comments/{edit_comment_id}"))
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(
-                        serde_json::to_vec(&serde_json::json!({"content": "tampered"})).unwrap(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let app = app_as_user(db.clone(), &viewer);
+        let resp = json_put(
+            &app,
+            &format!("/api/comments/{edit_comment_id}"),
+            serde_json::json!({"content": "tampered"}),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("DELETE")
-                    .uri(format!("/api/comments/{delete_comment_id}"))
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let resp = json_delete(&app, &format!("/api/comments/{delete_comment_id}")).await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
         let conn = db.read().unwrap();

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -113,7 +113,7 @@ fn user_of(identity: &Option<ResolvedIdentity>) -> Option<AuthUser> {
 
 // ── Instance setting read ───────────────────────────────────────
 
-fn authz_enforced_conn(conn: &Connection) -> Result<bool, LificError> {
+pub(crate) fn authz_enforced_conn(conn: &Connection) -> Result<bool, LificError> {
     Ok(queries::settings::get(conn)?.authz_enforced)
 }
 
@@ -172,7 +172,7 @@ pub(crate) fn can_view_project(
     ))
 }
 
-fn require_role_conn(
+pub(crate) fn require_role_conn(
     conn: &Connection,
     identity: &Option<ResolvedIdentity>,
     project_id: i64,
@@ -333,11 +333,18 @@ pub fn require_workspace_admin(
     db: &DbPool,
     identity: &Option<ResolvedIdentity>,
 ) -> Result<(), LificError> {
-    if !authz_enforced(db)? {
+    let conn = db.read()?;
+    require_workspace_admin_conn(&conn, identity)
+}
+
+pub(crate) fn require_workspace_admin_conn(
+    conn: &Connection,
+    identity: &Option<ResolvedIdentity>,
+) -> Result<(), LificError> {
+    if !authz_enforced_conn(conn)? {
         return Ok(());
     }
-    let conn = db.read()?;
-    let effective = effective_user(&conn, &user_of(identity));
+    let effective = effective_user(conn, &user_of(identity));
     match &effective {
         Some(u) if u.is_admin => Ok(()),
         _ => Err(LificError::Forbidden(

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -353,6 +353,18 @@ pub(crate) fn require_workspace_admin_conn(
     }
 }
 
+pub(crate) fn require_project_or_workspace_role_conn(
+    conn: &Connection,
+    identity: &Option<ResolvedIdentity>,
+    project_id: Option<i64>,
+    minimum_role: Role,
+) -> Result<(), LificError> {
+    match project_id {
+        Some(project_id) => require_role_conn(conn, identity, project_id, minimum_role),
+        None => require_workspace_admin_conn(conn, identity),
+    }
+}
+
 // ── visible_project_ids ──────────────────────────────────────────
 
 /// The cross-project read filter for search / project listing / any
@@ -524,7 +536,10 @@ mod tests {
     fn enable_enforcement(conn: &Connection) {
         update_settings(
             conn,
-            InstanceSettingsPatch { authz_enforced: Some(true), ..Default::default() },
+            InstanceSettingsPatch {
+                authz_enforced: Some(true),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -541,7 +556,10 @@ mod tests {
 
         for min in [Role::Viewer, Role::Maintainer, Role::Lead] {
             let err = require_role_conn(&conn, &id(outsider.clone()), project, min).unwrap_err();
-            assert!(matches!(err, LificError::Forbidden(_)), "denied at {min} got {err:?}");
+            assert!(
+                matches!(err, LificError::Forbidden(_)),
+                "denied at {min} got {err:?}"
+            );
         }
     }
 
@@ -569,7 +587,9 @@ mod tests {
         upsert_member(&conn, project, maintainer.id, Role::Maintainer).unwrap();
 
         assert!(require_role_conn(&conn, &id(maintainer.clone()), project, Role::Viewer).is_ok());
-        assert!(require_role_conn(&conn, &id(maintainer.clone()), project, Role::Maintainer).is_ok());
+        assert!(
+            require_role_conn(&conn, &id(maintainer.clone()), project, Role::Maintainer).is_ok()
+        );
         assert!(require_role_conn(&conn, &id(maintainer.clone()), project, Role::Lead).is_err());
     }
 
@@ -686,7 +706,10 @@ mod tests {
         let outsider = seed_user(&conn, "outsider", false);
 
         for min in [Role::Viewer, Role::Maintainer] {
-            assert!(require_role_conn(&conn, &None, project, min).is_ok(), "None user at {min}");
+            assert!(
+                require_role_conn(&conn, &None, project, min).is_ok(),
+                "None user at {min}"
+            );
             assert!(
                 require_role_conn(&conn, &id(outsider.clone()), project, min).is_ok(),
                 "non-member at {min}"
@@ -858,7 +881,10 @@ mod tests {
             let conn = pool.write().unwrap();
             enable_enforcement(&conn);
         }
-        assert_eq!(visible_project_ids(&pool, &None).unwrap(), Some(HashSet::new()));
+        assert_eq!(
+            visible_project_ids(&pool, &None).unwrap(),
+            Some(HashSet::new())
+        );
     }
 
     // LIF-261 / LIFIC-10/14: an operator-trusted unbound key resolves (via
@@ -1116,7 +1142,10 @@ mod tests {
         // Flip it back off: legacy behavior returns immediately.
         update_settings(
             &conn,
-            InstanceSettingsPatch { authz_enforced: Some(false), ..Default::default() },
+            InstanceSettingsPatch {
+                authz_enforced: Some(false),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(require_role_conn(&conn, &id(outsider), project, Role::Viewer).is_ok());

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -192,17 +192,59 @@ pub fn latest_version() -> i64 {
 
 /// Ensure the migrations table exists and apply any pending migrations.
 pub fn run(conn: &Connection) -> Result<(), crate::error::LificError> {
+    let current_version: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM _migrations",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+    let needs_fk_rebuild = MIGRATIONS.iter().any(|(version, name, _)| {
+        *version > current_version && *name == "project identifier nocase"
+    });
+
+    // SQLite ignores PRAGMA foreign_keys changes inside a transaction. Keep
+    // the migration lock, but configure the connection before beginning it
+    // when an upgrade includes the table-rebuild migration from master.
+    if needs_fk_rebuild {
+        conn.execute_batch(
+            "PRAGMA foreign_keys = OFF;
+             PRAGMA legacy_alter_table = ON;",
+        )?;
+    }
+
     // Serialize migration discovery and application across processes. Without
     // an IMMEDIATE transaction, two fresh connections can observe the same
     // version and both execute the next migration, racing on the migrations
     // table (notably on Windows where test/process startup is more concurrent).
-    conn.execute_batch("BEGIN IMMEDIATE")?;
-    match run_inner(conn) {
-        Ok(()) => conn.execute_batch("COMMIT").map_err(Into::into),
-        Err(error) => {
-            let _ = conn.execute_batch("ROLLBACK");
-            Err(error)
+    let transaction_result: Result<(), crate::error::LificError> =
+        match conn.execute_batch("BEGIN IMMEDIATE") {
+            Ok(()) => match run_inner(conn) {
+                Ok(()) => conn.execute_batch("COMMIT").map_err(Into::into),
+                Err(error) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    Err(error)
+                }
+            },
+            Err(error) => Err(error.into()),
+        };
+
+    if needs_fk_rebuild {
+        let restore_result = conn
+            .execute_batch(
+                "PRAGMA foreign_keys = ON;
+                 PRAGMA legacy_alter_table = OFF;",
+            )
+            .map_err(Into::into);
+        match transaction_result {
+            Ok(()) => restore_result,
+            Err(error) => {
+                let _ = restore_result;
+                Err(error)
+            }
         }
+    } else {
+        transaction_result
     }
 }
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -192,6 +192,25 @@ pub fn latest_version() -> i64 {
 
 /// Ensure the migrations table exists and apply any pending migrations.
 pub fn run(conn: &Connection) -> Result<(), crate::error::LificError> {
+    // Serialize migration discovery and application across processes. Without
+    // an IMMEDIATE transaction, two fresh connections can observe the same
+    // version and both execute the next migration, racing on `_migrations`
+    // (notably on Windows where test/process startup is more concurrent).
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let result = run_inner(conn);
+    match result {
+        Ok(()) => {
+            conn.execute_batch("COMMIT")?;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
+}
+
+fn run_inner(conn: &Connection) -> Result<(), crate::error::LificError> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS _migrations (
             version    INTEGER PRIMARY KEY,

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -1,4 +1,4 @@
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
 use tracing::info;
 
 /// Migrations are applied in order and tracked in a `_migrations` table.
@@ -196,18 +196,10 @@ pub fn run(conn: &Connection) -> Result<(), crate::error::LificError> {
     // an IMMEDIATE transaction, two fresh connections can observe the same
     // version and both execute the next migration, racing on `_migrations`
     // (notably on Windows where test/process startup is more concurrent).
-    conn.execute_batch("BEGIN IMMEDIATE")?;
-    let result = run_inner(conn);
-    match result {
-        Ok(()) => {
-            conn.execute_batch("COMMIT")?;
-            Ok(())
-        }
-        Err(error) => {
-            let _ = conn.execute_batch("ROLLBACK");
-            Err(error)
-        }
-    }
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    run_inner(&transaction)?;
+    transaction.commit()?;
+    Ok(())
 }
 
 fn run_inner(conn: &Connection) -> Result<(), crate::error::LificError> {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, Transaction, TransactionBehavior};
+use rusqlite::Connection;
 use tracing::info;
 
 /// Migrations are applied in order and tracked in a `_migrations` table.
@@ -194,12 +194,16 @@ pub fn latest_version() -> i64 {
 pub fn run(conn: &Connection) -> Result<(), crate::error::LificError> {
     // Serialize migration discovery and application across processes. Without
     // an IMMEDIATE transaction, two fresh connections can observe the same
-    // version and both execute the next migration, racing on `_migrations`
-    // (notably on Windows where test/process startup is more concurrent).
-    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    run_inner(&transaction)?;
-    transaction.commit()?;
-    Ok(())
+    // version and both execute the next migration, racing on the migrations
+    // table (notably on Windows where test/process startup is more concurrent).
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    match run_inner(conn) {
+        Ok(()) => conn.execute_batch("COMMIT").map_err(Into::into),
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
 }
 
 fn run_inner(conn: &Connection) -> Result<(), crate::error::LificError> {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3,7 +3,7 @@ pub mod models;
 pub mod queries;
 
 use crossbeam_queue::ArrayQueue;
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -67,6 +67,12 @@ impl DbPool {
         }
     }
 
+    fn lock_writer(&self) -> Result<std::sync::MutexGuard<'_, Connection>, LificError> {
+        self.writer
+            .lock()
+            .map_err(|error| LificError::Internal(format!("write lock poisoned: {error}")))
+    }
+
     /// Acquire the exclusive write connection.
     ///
     /// LIF-155: stamps the current actor context (task-local set by the
@@ -75,12 +81,25 @@ impl DbPool {
     /// exclusive guard makes the stamp race-free: nobody else can write
     /// between the stamp and the mutation.
     pub fn write(&self) -> Result<std::sync::MutexGuard<'_, Connection>, LificError> {
-        let guard = self
-            .writer
-            .lock()
-            .map_err(|e| LificError::Internal(format!("write lock poisoned: {e}")))?;
-        crate::actor::stamp(&guard, &crate::actor::current());
-        Ok(guard)
+        let connection = self.lock_writer()?;
+        crate::actor::stamp(&connection, &crate::actor::current());
+        Ok(connection)
+    }
+
+    /// Run a write operation in an immediate SQLite transaction.
+    ///
+    /// The immediate lock serializes the caller's reads and writes with
+    /// writers in other processes. Errors roll back on drop.
+    pub fn transaction<T>(
+        &self,
+        operation: impl FnOnce(&Transaction<'_>) -> Result<T, LificError>,
+    ) -> Result<T, LificError> {
+        let mut connection = self.lock_writer()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        crate::actor::stamp(&transaction, &crate::actor::current());
+        let result = operation(&transaction)?;
+        transaction.commit()?;
+        Ok(result)
     }
 }
 
@@ -225,4 +244,31 @@ pub fn open(path: &Path) -> Result<DbPool, LificError> {
         readers: Arc::new(readers),
         path: path.to_path_buf(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{models::CreateProject, queries};
+
+    #[test]
+    fn transaction_rolls_back_when_operation_fails() {
+        let db = open_memory().expect("test db");
+
+        let result: Result<(), LificError> = db.transaction(|conn| {
+            queries::create_project(
+                conn,
+                &CreateProject {
+                    name: "Rolled back".into(),
+                    identifier: "RBK".into(),
+                    ..Default::default()
+                },
+            )?;
+            Err(LificError::BadRequest("abort transaction".into()))
+        });
+
+        assert!(matches!(result, Err(LificError::BadRequest(_))));
+        let conn = db.read().unwrap();
+        assert!(queries::list_projects(&conn).unwrap().is_empty());
+    }
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -625,7 +625,10 @@ impl std::str::FromStr for Role {
 
 impl rusqlite::types::FromSql for Role {
     fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        value.as_str()?.parse().map_err(|_| rusqlite::types::FromSqlError::InvalidType)
+        value
+            .as_str()?
+            .parse()
+            .map_err(|_| rusqlite::types::FromSqlError::InvalidType)
     }
 }
 
@@ -720,6 +723,21 @@ pub struct AuthUser {
     pub username: String,
     pub display_name: String,
     pub is_admin: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommentActor {
+    pub user_id: i64,
+    pub is_admin: bool,
+}
+
+impl From<&AuthUser> for CommentActor {
+    fn from(user: &AuthUser) -> Self {
+        Self {
+            user_id: user.id,
+            is_admin: user.is_admin,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -6,9 +6,9 @@
 //! project-role gate. Bytes are content-addressed on disk; a row here just
 //! records the metadata and the `sha256` that points at the blob.
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, named_params, params};
 
-use crate::db::models::{Attachment, AttachmentEntity};
+use crate::db::models::{Attachment, AttachmentEntity, CommentActor};
 use crate::error::LificError;
 
 /// Insert a new attachment metadata row and return it. The caller has already
@@ -171,6 +171,55 @@ fn attachment_exists(conn: &Connection, id: i64) -> Result<bool, LificError> {
     Ok(exists.is_some())
 }
 
+/// Whether a caller may introduce an attachment link into `project_id`.
+/// Uploaders and administrators may place their attachment anywhere they can
+/// edit; other callers may only reuse attachments already linked in the same
+/// project.
+fn attachment_allowed_for_project(
+    conn: &Connection,
+    attachment_id: i64,
+    actor: CommentActor,
+    project_id: Option<i64>,
+) -> Result<bool, LificError> {
+    Ok(conn.query_row(
+        "SELECT EXISTS (
+             SELECT 1
+             FROM attachments a
+             WHERE a.id = :attachment_id
+               AND (
+                   :is_admin
+                   OR a.uploader_id = :actor_id
+                   OR EXISTS (
+                       SELECT 1
+                       FROM attachment_links l
+                       LEFT JOIN issues i
+                         ON l.entity_type = 'issue' AND i.id = l.entity_id
+                       LEFT JOIN pages p
+                         ON l.entity_type = 'page' AND p.id = l.entity_id
+                       LEFT JOIN comments c
+                         ON l.entity_type = 'comment' AND c.id = l.entity_id
+                       LEFT JOIN issues ci ON ci.id = c.issue_id
+                       LEFT JOIN pages cp ON cp.id = c.page_id
+                       WHERE l.attachment_id = a.id
+                         AND :project_id IN (
+                             i.project_id,
+                             p.project_id,
+                             ci.project_id,
+                             cp.project_id
+                         )
+                   )
+               )
+         )",
+        named_params! {
+            ":attachment_id": attachment_id,
+            ":actor_id": actor.user_id,
+            ":is_admin": actor.is_admin,
+            ":project_id": project_id,
+        },
+        |row| row.get(0),
+    )?)
+}
+
 // ── Orphan GC ────────────────────────────────────────────────
 
 /// One collectable orphan: an attachment row with zero links, older than the
@@ -260,6 +309,25 @@ pub fn sync_links(
     sync_entity_links(conn, entity, entity_id, &ids)
 }
 
+/// Reconcile attachment links without allowing references to import an
+/// attachment from another project or another user's unlinked upload.
+pub fn sync_links_scoped(
+    conn: &Connection,
+    entity: AttachmentEntity,
+    entity_id: i64,
+    markdown: &str,
+    actor: CommentActor,
+    project_id: Option<i64>,
+) -> Result<(), LificError> {
+    let mut allowed = Vec::new();
+    for attachment_id in parse_referenced_ids(markdown) {
+        if attachment_allowed_for_project(conn, attachment_id, actor, project_id)? {
+            allowed.push(attachment_id);
+        }
+    }
+    sync_entity_links(conn, entity, entity_id, &allowed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -327,22 +395,68 @@ mod tests {
     }
 
     #[test]
+    fn attachment_scope_uses_actor_identity_and_admin_status() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let uploader_id = seed_user(&conn, "uploader");
+        let attachment = create_attachment(
+            &conn,
+            "owned",
+            "owned.txt",
+            "text/plain",
+            1,
+            Some(uploader_id),
+        )
+        .unwrap();
+
+        let uploader = CommentActor {
+            user_id: uploader_id,
+            is_admin: false,
+        };
+        let stranger = CommentActor {
+            user_id: uploader_id + 1,
+            is_admin: false,
+        };
+        let admin = CommentActor {
+            user_id: uploader_id + 1,
+            is_admin: true,
+        };
+
+        assert!(attachment_allowed_for_project(&conn, attachment.id, uploader, None).unwrap());
+        assert!(!attachment_allowed_for_project(&conn, attachment.id, stranger, None).unwrap());
+        assert!(attachment_allowed_for_project(&conn, attachment.id, admin, None).unwrap());
+        assert!(!attachment_allowed_for_project(&conn, i64::MAX, admin, None).unwrap());
+    }
+
+    #[test]
     fn linking_is_idempotent_and_unlink_clears_it() {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let issue = seed_issue(&conn);
         let att = create_attachment(&conn, "h1", "a.pdf", "application/pdf", 10, None).unwrap();
 
-        assert!(list_for_entity(&conn, AttachmentEntity::Issue, issue).unwrap().is_empty());
+        assert!(
+            list_for_entity(&conn, AttachmentEntity::Issue, issue)
+                .unwrap()
+                .is_empty()
+        );
         link_attachment(&conn, att.id, AttachmentEntity::Issue, issue).unwrap();
         link_attachment(&conn, att.id, AttachmentEntity::Issue, issue).unwrap(); // idempotent
 
         let listed = list_for_entity(&conn, AttachmentEntity::Issue, issue).unwrap();
-        assert_eq!(listed.len(), 1, "the second link must not duplicate the row");
+        assert_eq!(
+            listed.len(),
+            1,
+            "the second link must not duplicate the row"
+        );
         assert_eq!(listed[0].id, att.id);
 
         unlink_attachment(&conn, att.id, AttachmentEntity::Issue, issue).unwrap();
-        assert!(list_for_entity(&conn, AttachmentEntity::Issue, issue).unwrap().is_empty());
+        assert!(
+            list_for_entity(&conn, AttachmentEntity::Issue, issue)
+                .unwrap()
+                .is_empty()
+        );
         // With no links left the attachment is collectable by the orphan GC.
         assert_eq!(find_orphans(&conn, -1).unwrap().len(), 1);
     }
@@ -427,11 +541,20 @@ mod tests {
         let issue = seed_issue(&conn);
         let att = create_attachment(&conn, "h", "a.png", "image/png", 1, None).unwrap();
         link_attachment(&conn, att.id, AttachmentEntity::Issue, issue).unwrap();
-        assert_eq!(list_for_entity(&conn, AttachmentEntity::Issue, issue).unwrap().len(), 1);
+        assert_eq!(
+            list_for_entity(&conn, AttachmentEntity::Issue, issue)
+                .unwrap()
+                .len(),
+            1
+        );
 
         queries::delete_issue(&conn, issue).unwrap();
         // Trigger drops the link; the attachment row itself survives (GC's job).
-        assert!(list_for_entity(&conn, AttachmentEntity::Issue, issue).unwrap().is_empty());
+        assert!(
+            list_for_entity(&conn, AttachmentEntity::Issue, issue)
+                .unwrap()
+                .is_empty()
+        );
         assert_eq!(
             find_orphans(&conn, -1).unwrap().len(),
             1,

--- a/src/db/queries/comments.rs
+++ b/src/db/queries/comments.rs
@@ -1,6 +1,6 @@
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
-use crate::db::models::{AttachmentEntity, Comment};
+use crate::db::models::{AttachmentEntity, Comment, CommentActor};
 use crate::error::LificError;
 
 use super::unescape_text;
@@ -11,25 +11,78 @@ use super::unescape_text;
 /// (enforced by a CHECK constraint added in migration 012). This enum mirrors
 /// that invariant in Rust so callers can't accidentally construct an
 /// orphan or dual-parent comment.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommentParent {
     Issue(i64),
     Page(i64),
 }
 
 impl CommentParent {
-    fn issue_id(&self) -> Option<i64> {
+    fn issue_id(self) -> Option<i64> {
         match self {
-            CommentParent::Issue(id) => Some(*id),
-            CommentParent::Page(_) => None,
+            Self::Issue(id) => Some(id),
+            Self::Page(_) => None,
         }
     }
 
-    fn page_id(&self) -> Option<i64> {
+    fn page_id(self) -> Option<i64> {
         match self {
-            CommentParent::Page(id) => Some(*id),
-            CommentParent::Issue(_) => None,
+            Self::Page(id) => Some(id),
+            Self::Issue(_) => None,
         }
+    }
+
+    pub fn project_id(self, conn: &Connection) -> Result<Option<i64>, LificError> {
+        match self {
+            Self::Issue(issue_id) => Ok(Some(super::get_issue(conn, issue_id)?.project_id)),
+            Self::Page(page_id) => Ok(super::get_page(conn, page_id)?.project_id),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommentContext {
+    parent: CommentParent,
+    project_id: Option<i64>,
+    parent_identifier: String,
+}
+
+impl CommentContext {
+    pub fn resolve(conn: &Connection, comment: &Comment) -> Result<Self, LificError> {
+        match (comment.issue_id, comment.page_id) {
+            (Some(issue_id), None) => {
+                let issue = super::get_issue(conn, issue_id)?;
+                Ok(Self {
+                    parent: CommentParent::Issue(issue.id),
+                    project_id: Some(issue.project_id),
+                    parent_identifier: issue.identifier,
+                })
+            }
+            (None, Some(page_id)) => {
+                let page = super::get_page(conn, page_id)?;
+                Ok(Self {
+                    parent: CommentParent::Page(page.id),
+                    project_id: page.project_id,
+                    parent_identifier: page.identifier,
+                })
+            }
+            _ => Err(LificError::Internal(format!(
+                "comment {} has an invalid parent",
+                comment.id
+            ))),
+        }
+    }
+
+    pub fn parent(&self) -> CommentParent {
+        self.parent
+    }
+
+    pub fn project_id(&self) -> Option<i64> {
+        self.project_id
+    }
+
+    pub fn parent_identifier(&self) -> &str {
+        &self.parent_identifier
     }
 }
 
@@ -398,56 +451,48 @@ pub fn sync_mentions(
 }
 
 /// Create a comment and reconcile everything derived from its body in one
-/// write: the resolved `@mention` rows (LIF-263) and the attachment links its
-/// markdown references (LIF-262).
-///
-/// `member_scoped` is the live `authz_enforced` flag, resolved by the caller
-/// *before* it takes the write connection — reading it here would nest the
-/// pool's guards. `project_id` is the comment parent's project (`None` for a
-/// workspace-level page).
-///
-/// LIF-375: the single implementation behind both the REST handlers and the
-/// MCP `add_comment` tool. Both used to inline their own copy, and the MCP
-/// copies silently skipped attachment link sync (LIF-369).
+/// write: resolved mentions and attachment links.
 pub fn create_comment_with_mentions(
     conn: &Connection,
     parent: CommentParent,
     project_id: Option<i64>,
-    user_id: i64,
+    actor: CommentActor,
     content: &str,
     member_scoped: bool,
 ) -> Result<Comment, LificError> {
     let candidates = mention_candidates(conn, project_id, member_scoped)?;
-    let comment = create_comment(conn, parent, user_id, content)?;
+    let comment = create_comment(conn, parent, actor.user_id, content)?;
     sync_mentions(conn, comment.id, &comment.content, &candidates)?;
-    super::attachments::sync_links(
+    super::attachments::sync_links_scoped(
         conn,
         AttachmentEntity::Comment,
         comment.id,
         &comment.content,
+        actor,
+        project_id,
     )?;
     Ok(comment)
 }
 
-/// Edit a comment's content and re-derive its mentions and attachment links,
-/// the update-side twin of [`create_comment_with_mentions`]. An edit that
-/// drops a mention or an attachment reference removes the corresponding row,
-/// so authorization data stays in step with the text.
+/// Edit a comment's content and re-derive its mentions and attachment links.
 pub fn update_comment_with_mentions(
     conn: &Connection,
     comment_id: i64,
     project_id: Option<i64>,
+    actor: CommentActor,
     content: &str,
     member_scoped: bool,
 ) -> Result<Comment, LificError> {
     let candidates = mention_candidates(conn, project_id, member_scoped)?;
     let comment = update_comment(conn, comment_id, content)?;
     sync_mentions(conn, comment.id, &comment.content, &candidates)?;
-    super::attachments::sync_links(
+    super::attachments::sync_links_scoped(
         conn,
         AttachmentEntity::Comment,
         comment.id,
         &comment.content,
+        actor,
+        project_id,
     )?;
     Ok(comment)
 }
@@ -566,7 +611,8 @@ mod tests {
         let (pool, _, page_id, user_id) = setup();
         let conn = pool.write().unwrap();
 
-        let c1 = create_comment(&conn, CommentParent::Page(page_id), user_id, "Hello page").unwrap();
+        let c1 =
+            create_comment(&conn, CommentParent::Page(page_id), user_id, "Hello page").unwrap();
         assert_eq!(c1.content, "Hello page");
         assert_eq!(c1.issue_id, None);
         assert_eq!(c1.page_id, Some(page_id));
@@ -577,6 +623,100 @@ mod tests {
         assert_eq!(comments.len(), 2);
         assert_eq!(comments[0].content, "Hello page");
         assert_eq!(comments[1].content, "Another");
+    }
+
+    #[test]
+    fn comment_attachment_scope_is_independent_of_authz_enforcement() {
+        let (pool, issue_id, _, _) = setup();
+        let conn = pool.write().unwrap();
+        let [editor, owner] =
+            [("editor", "Editor"), ("owner", "Owner")].map(|(username, display_name)| {
+                queries::users::create_user(
+                    &conn,
+                    &CreateUser {
+                        username: username.into(),
+                        email: format!("{username}@test.com"),
+                        password: "testpassword1".into(),
+                        display_name: Some(display_name.into()),
+                        is_admin: false,
+                        is_bot: false,
+                    },
+                )
+                .unwrap()
+            });
+        let editor = CommentActor {
+            user_id: editor.id,
+            is_admin: editor.is_admin,
+        };
+        let other_project = queries::create_project(
+            &conn,
+            &CreateProject {
+                name: "Other".into(),
+                identifier: "OTH".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let other_issue = queries::create_issue(
+            &conn,
+            &CreateIssue {
+                project_id: other_project.id,
+                title: "Other issue".into(),
+                status: Status::Todo,
+                priority: Priority::Medium,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let attachment = queries::attachments::create_attachment(
+            &conn,
+            "foreign",
+            "foreign.txt",
+            "text/plain",
+            7,
+            Some(owner.id),
+        )
+        .unwrap();
+        queries::attachments::link_attachment(
+            &conn,
+            attachment.id,
+            AttachmentEntity::Issue,
+            other_issue.id,
+        )
+        .unwrap();
+
+        let project_id = queries::get_issue(&conn, issue_id).unwrap().project_id;
+        let content = format!("[foreign](/api/attachments/{})", attachment.id);
+        let comment = create_comment_with_mentions(
+            &conn,
+            CommentParent::Issue(issue_id),
+            Some(project_id),
+            editor,
+            &content,
+            true,
+        )
+        .unwrap();
+        assert!(
+            queries::attachments::list_for_entity(&conn, AttachmentEntity::Comment, comment.id,)
+                .unwrap()
+                .is_empty()
+        );
+
+        queries::attachments::link_attachment(
+            &conn,
+            attachment.id,
+            AttachmentEntity::Issue,
+            issue_id,
+        )
+        .unwrap();
+        update_comment_with_mentions(&conn, comment.id, Some(project_id), editor, &content, true)
+            .unwrap();
+        assert_eq!(
+            queries::attachments::list_for_entity(&conn, AttachmentEntity::Comment, comment.id,)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     // ── Author filter + sort direction ────────────────────────
@@ -705,7 +845,9 @@ mod tests {
     fn list_comments_rejects_invalid_order() {
         let (pool, issue_id, _, _) = setup();
         let conn = pool.read().unwrap();
-        assert!(list_comments(&conn, CommentParent::Issue(issue_id), None, Some("newest")).is_err());
+        assert!(
+            list_comments(&conn, CommentParent::Issue(issue_id), None, Some("newest")).is_err()
+        );
     }
 
     #[test]
@@ -713,10 +855,17 @@ mod tests {
         let (pool, issue_id, page_id, user_id) = setup();
         let conn = pool.write().unwrap();
 
-        create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Issue thread").unwrap();
+        create_comment(
+            &conn,
+            CommentParent::Issue(issue_id),
+            user_id,
+            "Issue thread",
+        )
+        .unwrap();
         create_comment(&conn, CommentParent::Page(page_id), user_id, "Page thread").unwrap();
 
-        let issue_comments = list_comments(&conn, CommentParent::Issue(issue_id), None, None).unwrap();
+        let issue_comments =
+            list_comments(&conn, CommentParent::Issue(issue_id), None, None).unwrap();
         let page_comments = list_comments(&conn, CommentParent::Page(page_id), None, None).unwrap();
 
         assert_eq!(issue_comments.len(), 1);
@@ -730,7 +879,8 @@ mod tests {
         let (pool, issue_id, _, user_id) = setup();
         let conn = pool.write().unwrap();
 
-        let created = create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Hello").unwrap();
+        let created =
+            create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Hello").unwrap();
         let fetched = get_comment(&conn, created.id).unwrap();
         assert_eq!(fetched.content, "Hello");
         assert_eq!(fetched.author, "blake");
@@ -743,7 +893,8 @@ mod tests {
         let (pool, issue_id, _, user_id) = setup();
         let conn = pool.write().unwrap();
 
-        let created = create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Original").unwrap();
+        let created =
+            create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Original").unwrap();
         let updated = update_comment(&conn, created.id, "Edited").unwrap();
         assert_eq!(updated.content, "Edited");
         assert_eq!(updated.id, created.id);
@@ -754,7 +905,8 @@ mod tests {
         let (pool, issue_id, _, user_id) = setup();
         let conn = pool.write().unwrap();
 
-        let created = create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Delete me").unwrap();
+        let created =
+            create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Delete me").unwrap();
         delete_comment(&conn, created.id).unwrap();
 
         assert!(get_comment(&conn, created.id).is_err());
@@ -794,7 +946,13 @@ mod tests {
         let (pool, issue_id, _, user_id) = setup();
         let conn = pool.write().unwrap();
 
-        let c = create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Will be cascaded").unwrap();
+        let c = create_comment(
+            &conn,
+            CommentParent::Issue(issue_id),
+            user_id,
+            "Will be cascaded",
+        )
+        .unwrap();
         queries::delete_issue(&conn, issue_id).unwrap();
 
         assert!(get_comment(&conn, c.id).is_err());
@@ -822,7 +980,10 @@ mod tests {
              VALUES (?1, ?2, ?3, 'bad')",
             params![issue_id, page_id, user_id],
         );
-        assert!(result.is_err(), "expected CHECK constraint to reject dual-parent row");
+        assert!(
+            result.is_err(),
+            "expected CHECK constraint to reject dual-parent row"
+        );
         let msg = result.unwrap_err().to_string().to_lowercase();
         assert!(
             msg.contains("check") || msg.contains("constraint"),
@@ -840,7 +1001,10 @@ mod tests {
              VALUES (NULL, NULL, ?1, 'orphan')",
             params![user_id],
         );
-        assert!(result.is_err(), "expected CHECK constraint to reject parentless row");
+        assert!(
+            result.is_err(),
+            "expected CHECK constraint to reject parentless row"
+        );
         let msg = result.unwrap_err().to_string().to_lowercase();
         assert!(
             msg.contains("check") || msg.contains("constraint"),
@@ -853,7 +1017,13 @@ mod tests {
         let (pool, issue_id, _, user_id) = setup();
         let conn = pool.write().unwrap();
 
-        let c = create_comment(&conn, CommentParent::Issue(issue_id), user_id, "line1\\nline2").unwrap();
+        let c = create_comment(
+            &conn,
+            CommentParent::Issue(issue_id),
+            user_id,
+            "line1\\nline2",
+        )
+        .unwrap();
         assert_eq!(c.content, "line1\nline2");
     }
 
@@ -996,10 +1166,7 @@ mod tests {
             vec!["ada", "blake"]
         );
         // Duplicates collapse (case-insensitively), first spelling kept.
-        assert_eq!(
-            extract_mention_usernames("@ada @Ada @ADA"),
-            vec!["ada"]
-        );
+        assert_eq!(extract_mention_usernames("@ada @Ada @ADA"), vec!["ada"]);
     }
 
     #[test]
@@ -1123,7 +1290,13 @@ mod tests {
         let conn = pool.write().unwrap();
         // The author "blake" mentions themselves.
         let cands = candidates(&[(user_id, "blake")]);
-        let c = create_comment(&conn, CommentParent::Issue(issue_id), user_id, "note to @blake").unwrap();
+        let c = create_comment(
+            &conn,
+            CommentParent::Issue(issue_id),
+            user_id,
+            "note to @blake",
+        )
+        .unwrap();
         let resolved = sync_mentions(&conn, c.id, &c.content, &cands).unwrap();
         assert_eq!(resolved, vec![user_id]);
     }
@@ -1168,7 +1341,11 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(feed.items.iter().any(|a| a.action == "mention" && a.new_value.as_deref() == Some("ada")));
+        assert!(
+            feed.items
+                .iter()
+                .any(|a| a.action == "mention" && a.new_value.as_deref() == Some("ada"))
+        );
     }
 
     #[test]
@@ -1205,7 +1382,10 @@ mod tests {
         let names: Vec<&str> = cands.iter().map(|c| c.username.as_str()).collect();
         assert!(names.contains(&"blake"));
         assert!(names.contains(&"ada"));
-        assert!(!names.contains(&"botty"), "bots are never mention candidates");
+        assert!(
+            !names.contains(&"botty"),
+            "bots are never mention candidates"
+        );
     }
 
     #[test]
@@ -1250,7 +1430,10 @@ mod tests {
         let cands = mention_candidates(&conn, Some(project.id), true).unwrap();
         let ids: Vec<i64> = cands.iter().map(|c| c.user_id).collect();
         assert!(ids.contains(&member.id));
-        assert!(!ids.contains(&outsider.id), "non-member must not be a candidate");
+        assert!(
+            !ids.contains(&outsider.id),
+            "non-member must not be a candidate"
+        );
 
         // A workspace page (no project) member-scoped yields nothing.
         assert!(mention_candidates(&conn, None, true).unwrap().is_empty());
@@ -1274,8 +1457,20 @@ mod tests {
         )
         .unwrap();
 
-        create_comment(&conn, CommentParent::Issue(issue_id), user1_id, "Blake says hi").unwrap();
-        create_comment(&conn, CommentParent::Issue(issue_id), user2.id, "Ada responds").unwrap();
+        create_comment(
+            &conn,
+            CommentParent::Issue(issue_id),
+            user1_id,
+            "Blake says hi",
+        )
+        .unwrap();
+        create_comment(
+            &conn,
+            CommentParent::Issue(issue_id),
+            user2.id,
+            "Ada responds",
+        )
+        .unwrap();
 
         let comments = list_comments(&conn, CommentParent::Issue(issue_id), None, None).unwrap();
         assert_eq!(comments.len(), 2);

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -142,7 +142,9 @@ pub(crate) fn set_stdio_user(user: Option<AuthUser>) {
 /// gates read `identity.user.is_admin`. The separate operator flag is gone:
 /// every credential that authenticates is trusted as the operator, matching
 /// REST one-for-one (no transport-specific divergence).
-pub(crate) fn current_identity(db: &crate::db::DbPool) -> Option<crate::resolve_caller::ResolvedIdentity> {
+pub(crate) fn current_identity(
+    db: &crate::db::DbPool,
+) -> Option<crate::resolve_caller::ResolvedIdentity> {
     crate::resolve_caller::resolve_caller(db, current_auth_user(), crate::actor::Transport::Mcp)
         .ok()
         .flatten()
@@ -229,26 +231,36 @@ impl LificMcp {
         f(&conn).map_err(|e| e.to_string())
     }
 
+    fn stamp_request_actor(conn: &rusqlite::Connection) {
+        let user = current_auth_user();
+        crate::actor::stamp(
+            conn,
+            &crate::actor::ActorCtx {
+                user_id: user.map(|user| user.id),
+                transport: crate::actor::Transport::Mcp,
+            },
+        );
+    }
+
     fn write<F, T>(&self, f: F) -> Result<T, String>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<T, crate::error::LificError>,
     {
-        let conn = self.db.write().map_err(|e| e.to_string())?;
-        // LIF-155: re-stamp the audit actor from the MCP request-user
-        // global. The task-local stamped by DbPool::write() does NOT
-        // survive rmcp's internal task spawns (verified in production:
-        // tool writes attributed to 'system'), but MCP_REQUEST_USER does
-        // — it's a global guarded by the serialization lock, so it is
-        // exactly this request's identity.
-        let user = current_auth_user();
-        crate::actor::stamp(
-            &conn,
-            &crate::actor::ActorCtx {
-                user_id: user.map(|u| u.id),
-                transport: crate::actor::Transport::Mcp,
-            },
-        );
-        f(&conn).map_err(|e| e.to_string())
+        let conn = self.db.write().map_err(|error| error.to_string())?;
+        Self::stamp_request_actor(&conn);
+        f(&conn).map_err(|error| error.to_string())
+    }
+
+    fn transaction<F, T>(&self, f: F) -> Result<T, String>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<T, crate::error::LificError>,
+    {
+        self.db
+            .transaction(|conn| {
+                Self::stamp_request_actor(conn);
+                f(conn)
+            })
+            .map_err(|error| error.to_string())
     }
 }
 
@@ -492,7 +504,8 @@ mod tests {
             .unwrap();
         }
         let manager = crate::auth::create_key_manager().unwrap();
-        let unbound_key = crate::auth::create_api_key(&pool, &manager, "mcp-operator", None).unwrap();
+        let unbound_key =
+            crate::auth::create_api_key(&pool, &manager, "mcp-operator", None).unwrap();
         let project = {
             let conn = pool.write().unwrap();
             crate::db::queries::settings::update(
@@ -649,7 +662,11 @@ mod tests {
     // token the agent resolves as itself; with none, the operator (first
     // admin) fallback applies.
 
-    fn seed_user(pool: &crate::db::DbPool, username: &str, admin: bool) -> crate::db::models::AuthUser {
+    fn seed_user(
+        pool: &crate::db::DbPool,
+        username: &str,
+        admin: bool,
+    ) -> crate::db::models::AuthUser {
         let conn = pool.write().expect("write conn");
         let u = crate::db::queries::users::create_user(
             &conn,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1251,6 +1251,33 @@ fn require_page_role_mcp(
     }
 }
 
+fn require_page_role_mcp_conn(
+    conn: &rusqlite::Connection,
+    identity: &Option<crate::resolve_caller::ResolvedIdentity>,
+    project_id: Option<i64>,
+    min: models::Role,
+) -> Result<(), crate::error::LificError> {
+    match project_id {
+        Some(pid) => crate::authz::require_role_conn(conn, identity, pid, min),
+        None => crate::authz::require_workspace_admin_conn(conn, identity),
+    }
+}
+
+fn resolve_comment_actor_conn(
+    conn: &rusqlite::Connection,
+) -> Result<crate::resolve_caller::ResolvedIdentity, crate::error::LificError> {
+    crate::resolve_caller::resolve_caller_conn(
+        conn,
+        super::current_auth_user(),
+        crate::actor::Transport::Mcp,
+    )?
+    .ok_or_else(|| {
+        crate::error::LificError::Forbidden(
+            "no admin user exists to attribute comment edits to.".into(),
+        )
+    })
+}
+
 fn visible_project_ids_mcp(
     db: &Arc<DbPool>,
 ) -> Result<Option<std::collections::HashSet<i64>>, String> {
@@ -1289,27 +1316,6 @@ impl LificMcp {
             }
         };
         require_page_role_mcp(&self.db, project_id, min)
-    }
-
-    /// LIF-143: resolve the acting MCP user for a comment edit/delete the
-    /// same way `add_comment` resolves the author: the HTTP-auth user set in
-    /// the task-local, else fall back to the first admin for stdio/local
-    /// sessions. Returns `(user_id, is_admin)` for the author-or-admin
-    /// ownership check.
-    ///
-    /// LIFIC-8: the fallback now routes through `resolve_caller`, the single
-    /// place that decides "no credential → first admin" — replacing the
-    /// direct `first_admin` read.
-    fn resolve_comment_actor(&self) -> Result<(i64, bool), String> {
-        let identity = self.read(|conn| {
-            crate::resolve_caller::resolve_caller_conn(
-                conn,
-                super::current_auth_user(),
-                crate::actor::Transport::Mcp,
-            )
-        })?
-        .ok_or_else(|| "no admin user exists to attribute comment edits to.".to_string())?;
-        Ok((identity.user.id, identity.user.is_admin))
     }
 
     /// LIF-198: if `step_id` has a linked issue, require `min` role on that
@@ -3500,36 +3506,34 @@ impl LificMcp {
     }
 
     fn edit_comment_inner(&self, input: EditCommentInput) -> Result<String, String> {
-        // Resolve the acting user the same way add_comment does: the
-        // task-local HTTP-auth user, else fall back to the first admin for
-        // stdio/local sessions.
-        let (user_id, is_admin) = self.resolve_comment_actor()?;
+        let (c, project_id, parent, parent_identifier) = self.write(|conn| {
+            let actor = resolve_comment_actor_conn(conn)?;
+            let existing = queries::comments::get_comment(conn, input.comment_id)?;
+            if existing.user_id != actor.user.id && !actor.user.is_admin {
+                return Err(crate::error::LificError::BadRequest(
+                    "you can only edit your own comments".into(),
+                ));
+            }
 
-        // Ownership: only the author or an admin may edit (mirrors
-        // api::comments::update_comment_handler).
-        let existing = self.read(|conn| queries::comments::get_comment(conn, input.comment_id))?;
-        if existing.user_id != user_id && !is_admin {
-            return Err("you can only edit your own comments".into());
-        }
-
-        // LIF-263: recompute the mention set against the parent project's
-        // visible members, resolving the project from the comment's parent.
-        let (project_id, parent, parent_identifier) =
-            self.read(|conn| resolve_comment_context(conn, &existing))?;
-        require_page_role_mcp(&self.db, project_id, models::Role::Viewer)?;
-        let member_scoped = crate::authz::authz_enforced(&self.db).map_err(|e| e.to_string())?;
-
-        let c = self.write(|conn| {
+            let (project_id, parent, parent_identifier) =
+                resolve_comment_context(conn, &existing)?;
+            require_page_role_mcp_conn(
+                conn,
+                &Some(actor),
+                project_id,
+                models::Role::Viewer,
+            )?;
+            let member_scoped = crate::authz::authz_enforced_conn(conn)?;
             // LIF-375: shared with the REST edit path; re-derives mentions and
             // attachment links from the new body (LIF-369).
-            let c = queries::comments::update_comment_with_mentions(
+            let comment = queries::comments::update_comment_with_mentions(
                 conn,
                 input.comment_id,
                 project_id,
                 &input.content,
                 member_scoped,
             )?;
-            Ok(c)
+            Ok((comment, project_id, parent, parent_identifier))
         })?;
         // Don't echo the new content back — the agent already supplied it
         // (LIF-115). The id is the stable handle.
@@ -3566,21 +3570,26 @@ impl LificMcp {
     }
 
     fn delete_comment_inner(&self, input: DeleteCommentInput) -> Result<String, String> {
-        // Resolve the acting user the same way add_comment does.
-        let (user_id, is_admin) = self.resolve_comment_actor()?;
+        let (existing, project_id, parent, parent_identifier) = self.write(|conn| {
+            let actor = resolve_comment_actor_conn(conn)?;
+            let existing = queries::comments::get_comment(conn, input.comment_id)?;
+            if existing.user_id != actor.user.id && !actor.user.is_admin {
+                return Err(crate::error::LificError::BadRequest(
+                    "you can only delete your own comments".into(),
+                ));
+            }
 
-        // Ownership: only the author or an admin may delete (mirrors
-        // api::comments::delete_comment_handler).
-        let existing = self.read(|conn| queries::comments::get_comment(conn, input.comment_id))?;
-        if existing.user_id != user_id && !is_admin {
-            return Err("you can only delete your own comments".into());
-        }
-
-        let (project_id, parent, parent_identifier) =
-            self.read(|conn| resolve_comment_context(conn, &existing))?;
-        require_page_role_mcp(&self.db, project_id, models::Role::Viewer)?;
-
-        self.write(|conn| queries::comments::delete_comment(conn, input.comment_id))?;
+            let (project_id, parent, parent_identifier) =
+                resolve_comment_context(conn, &existing)?;
+            require_page_role_mcp_conn(
+                conn,
+                &Some(actor),
+                project_id,
+                models::Role::Viewer,
+            )?;
+            queries::comments::delete_comment(conn, input.comment_id)?;
+            Ok((existing, project_id, parent, parent_identifier))
+        })?;
         if let (Some(issue_id), Some(project_id)) = (existing.issue_id, project_id) {
             self.emit(crate::realtime::RealtimeEvent::IssueUpdated {
                 project_id,
@@ -8233,7 +8242,7 @@ mod tests {
     }
 
     /// Extract the "#N" comment id from an `add_comment` success string.
-    fn comment_id_from(result: &str) -> i64 {
+    pub(super) fn comment_id_from(result: &str) -> i64 {
         result
             .split('#')
             .nth(1)
@@ -9608,7 +9617,7 @@ mod tests {
 /// by default and already prove that in full.
 #[cfg(test)]
 mod authz_gating_tests {
-    use super::tests::setup_membership_mcp;
+    use super::tests::{comment_id_from, setup_membership_mcp};
     use super::*;
     use rmcp::handler::server::wrapper::Parameters;
 
@@ -9993,6 +10002,57 @@ mod authz_gating_tests {
             }))
         });
         assert!(is_forbidden(&denied), "got: {denied}");
+    }
+
+    #[test]
+    fn revoked_member_cannot_edit_or_delete_own_comment() {
+        let (m, _admin, lead, _maintainer, viewer, _non_member, project_id, _guard) =
+            setup_membership_mcp();
+        let created = as_user(&lead, || {
+            m.create_issue(Parameters(CreateIssueInput {
+                project: "MEM".into(),
+                title: "Revocation test".into(),
+                ..Default::default()
+            }))
+        });
+        assert!(created.starts_with("Created"), "got: {created}");
+
+        let [edit_comment_id, delete_comment_id] = ["Keep this comment", "Keep this one too"]
+            .map(|content| {
+                comment_id_from(&as_user(&viewer, || {
+                    m.add_comment(Parameters(AddCommentInput {
+                        identifier: "MEM-1".into(),
+                        content: content.into(),
+                    }))
+                }))
+            });
+        m.write(|conn| queries::members::remove_member(conn, project_id, viewer.id))
+            .unwrap();
+
+        let edit = as_user(&viewer, || {
+            m.edit_comment(Parameters(EditCommentInput {
+                comment_id: edit_comment_id,
+                content: "tampered".into(),
+            }))
+        });
+        assert!(is_forbidden(&edit), "got: {edit}");
+
+        let delete = as_user(&viewer, || {
+            m.delete_comment(Parameters(DeleteCommentInput {
+                comment_id: delete_comment_id,
+            }))
+        });
+        assert!(is_forbidden(&delete), "got: {delete}");
+
+        m.read(|conn| {
+            assert_eq!(
+                queries::comments::get_comment(conn, edit_comment_id)?.content,
+                "Keep this comment"
+            );
+            assert!(queries::comments::get_comment(conn, delete_comment_id).is_ok());
+            Ok(())
+        })
+        .unwrap();
     }
 
     // ── Structure endpoints: loosened to Maintainer once enforced ──

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3516,6 +3516,7 @@ impl LificMcp {
         // visible members, resolving the project from the comment's parent.
         let (project_id, parent, parent_identifier) =
             self.read(|conn| resolve_comment_context(conn, &existing))?;
+        require_page_role_mcp(&self.db, project_id, models::Role::Viewer)?;
         let member_scoped = crate::authz::authz_enforced(&self.db).map_err(|e| e.to_string())?;
 
         let c = self.write(|conn| {
@@ -3576,6 +3577,7 @@ impl LificMcp {
 
         let (project_id, parent, parent_identifier) =
             self.read(|conn| resolve_comment_context(conn, &existing))?;
+        require_page_role_mcp(&self.db, project_id, models::Role::Viewer)?;
 
         self.write(|conn| queries::comments::delete_comment(conn, input.comment_id))?;
         if let (Some(issue_id), Some(project_id)) = (existing.issue_id, project_id) {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3522,13 +3522,14 @@ impl LificMcp {
         let c = self.write(|conn| {
             // LIF-375: shared with the REST edit path; re-derives mentions and
             // attachment links from the new body (LIF-369).
-            queries::comments::update_comment_with_mentions(
+            let c = queries::comments::update_comment_with_mentions(
                 conn,
                 input.comment_id,
                 project_id,
                 &input.content,
                 member_scoped,
-            )
+            )?;
+            Ok(c)
         })?;
         // Don't echo the new content back — the agent already supplied it
         // (LIF-115). The id is the stable handle.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -836,25 +836,22 @@ fn looks_like_page_identifier(s: &str) -> bool {
     s.starts_with("DOC-") || s.contains("-DOC-")
 }
 
-/// Resolve an identifier string into a CommentParent (Issue or Page) so MCP
-/// `add_comment` / `list_comments` accept both shapes through one entry point.
-fn resolve_comment_parent(
-    mcp: &LificMcp,
+/// Resolve an issue or page identifier for comment operations.
+fn resolve_comment_parent_conn(
+    conn: &rusqlite::Connection,
     identifier: &str,
-) -> Result<(queries::comments::CommentParent, String, Option<i64>), String> {
+) -> Result<(queries::comments::CommentParent, String, Option<i64>), crate::error::LificError> {
     if looks_like_page_identifier(identifier) {
-        let conn = mcp.db.read().map_err(|e| e.to_string())?;
-        let id = queries::resolve_page_identifier(&conn, identifier).map_err(|e| e.to_string())?;
-        let page = queries::get_page(&conn, id).map_err(|e| e.to_string())?;
+        let page_id = queries::resolve_page_identifier(conn, identifier)?;
+        let page = queries::get_page(conn, page_id)?;
         Ok((
             queries::comments::CommentParent::Page(page.id),
             page.identifier,
             page.project_id,
         ))
     } else {
-        let conn = mcp.db.read().map_err(|e| e.to_string())?;
-        let id = queries::resolve_identifier(&conn, identifier).map_err(|e| e.to_string())?;
-        let issue = queries::get_issue(&conn, id).map_err(|e| e.to_string())?;
+        let issue_id = queries::resolve_identifier(conn, identifier)?;
+        let issue = queries::get_issue(conn, issue_id)?;
         Ok((
             queries::comments::CommentParent::Issue(issue.id),
             issue.identifier,
@@ -863,33 +860,29 @@ fn resolve_comment_parent(
     }
 }
 
-/// Resolve an existing comment's canonical parent and project in one read.
-/// A page comment may have a NULL project (workspace page), which
-/// `mention_candidates` handles.
-fn resolve_comment_context(
-    conn: &rusqlite::Connection,
-    comment: &models::Comment,
-) -> Result<(Option<i64>, queries::comments::CommentParent, String), crate::error::LificError> {
-    if let Some(issue_id) = comment.issue_id {
-        let issue = queries::get_issue(conn, issue_id)?;
-        Ok((
-            Some(issue.project_id),
-            queries::comments::CommentParent::Issue(issue.id),
-            issue.identifier,
-        ))
-    } else if let Some(page_id) = comment.page_id {
-        let page = queries::get_page(conn, page_id)?;
-        Ok((
-            page.project_id,
-            queries::comments::CommentParent::Page(page.id),
-            page.identifier,
-        ))
-    } else {
-        Err(crate::error::LificError::Internal(format!(
-            "comment {} has no parent",
-            comment.id
-        )))
-    }
+fn resolve_comment_parent(
+    mcp: &LificMcp,
+    identifier: &str,
+) -> Result<(queries::comments::CommentParent, String, Option<i64>), String> {
+    mcp.read(|conn| resolve_comment_parent_conn(conn, identifier))
+}
+
+fn comment_updated_event(
+    parent: queries::comments::CommentParent,
+    project_id: Option<i64>,
+) -> Option<crate::realtime::RealtimeEvent> {
+    let project_id = project_id?;
+    Some(match parent {
+        queries::comments::CommentParent::Issue(issue_id) => {
+            crate::realtime::RealtimeEvent::IssueUpdated {
+                project_id,
+                issue_id,
+            }
+        }
+        queries::comments::CommentParent::Page(_) => {
+            crate::realtime::RealtimeEvent::ProjectUpdated { project_id }
+        }
+    })
 }
 
 /// Append a paging hint to `out` if `has_more` is true.
@@ -1251,18 +1244,6 @@ fn require_page_role_mcp(
     }
 }
 
-fn require_page_role_mcp_conn(
-    conn: &rusqlite::Connection,
-    identity: &Option<crate::resolve_caller::ResolvedIdentity>,
-    project_id: Option<i64>,
-    min: models::Role,
-) -> Result<(), crate::error::LificError> {
-    match project_id {
-        Some(pid) => crate::authz::require_role_conn(conn, identity, pid, min),
-        None => crate::authz::require_workspace_admin_conn(conn, identity),
-    }
-}
-
 fn resolve_comment_actor_conn(
     conn: &rusqlite::Connection,
 ) -> Result<crate::resolve_caller::ResolvedIdentity, crate::error::LificError> {
@@ -1273,7 +1254,7 @@ fn resolve_comment_actor_conn(
     )?
     .ok_or_else(|| {
         crate::error::LificError::Forbidden(
-            "no admin user exists to attribute comment edits to.".into(),
+            "no admin user exists to attribute comment mutations to.".into(),
         )
     })
 }
@@ -1298,24 +1279,13 @@ impl LificMcp {
         }
     }
 
-    /// Gate for comment read/create: Viewer (or Maintainer, for edges that
-    /// need it) on the comment parent's project, falling back to
-    /// workspace-admin for a page with no project. Mirrors
-    /// `api::comments::require_comment_viewer`.
     fn require_comment_role_mcp(
         &self,
         parent: queries::comments::CommentParent,
-        min: models::Role,
+        minimum_role: models::Role,
     ) -> Result<(), String> {
-        let project_id: Option<i64> = match parent {
-            queries::comments::CommentParent::Issue(id) => {
-                Some(self.read(|conn| queries::get_issue(conn, id))?.project_id)
-            }
-            queries::comments::CommentParent::Page(id) => {
-                self.read(|conn| queries::get_page(conn, id))?.project_id
-            }
-        };
-        require_page_role_mcp(&self.db, project_id, min)
+        let project_id = self.read(|conn| parent.project_id(conn))?;
+        require_page_role_mcp(&self.db, project_id, minimum_role)
     }
 
     /// LIF-198: if `step_id` has a linked issue, require `min` role on that
@@ -3298,59 +3268,29 @@ impl LificMcp {
     }
 
     fn add_comment_inner(&self, input: AddCommentInput) -> Result<String, String> {
-        let (parent, parent_identifier, project_id) =
-            resolve_comment_parent(self, &input.identifier)?;
-        self.require_comment_role_mcp(parent, models::Role::Viewer)?;
-
-        // Resolve the authenticated user from the task-local set by the HTTP handler.
-        // For stdio/local MCP sessions (no HTTP auth), fall back to the first admin user.
-        //
-        // LIFIC-8: the fallback routes through `resolve_caller`, consolidating the
-        // "no credential → first admin" decision that was previously inline here.
-        let user_id = self
-            .read(|conn| {
-                crate::resolve_caller::resolve_caller_conn(
-                    conn,
-                    super::current_auth_user(),
-                    crate::actor::Transport::Mcp,
-                )
-            })?
-            .ok_or("no admin user exists to attribute comments to.")?
-            .user
-            .id;
-
-        // LIF-263: resolve the parent's project + the enforcement flag up
-        // front (read connections), then record @mentions in the same write
-        // that creates the comment. Same visible-member rules as the REST
-        // path — only tokens matching a visible member resolve.
-        let member_scoped = crate::authz::authz_enforced(&self.db).map_err(|e| e.to_string())?;
-
-        let (c, event) = self.write(|conn| {
-            // LIF-375: one shared implementation with the REST path — it also
-            // reconciles the attachment links the body references (LIF-369).
-            let c = queries::comments::create_comment_with_mentions(
+        let (comment, parent, parent_identifier, event) = self.transaction(|conn| {
+            let (parent, parent_identifier, project_id) =
+                resolve_comment_parent_conn(conn, &input.identifier)?;
+            let actor = resolve_comment_actor_conn(conn)?;
+            crate::authz::require_project_or_workspace_role_conn(
+                conn,
+                &Some(actor.clone()),
+                project_id,
+                models::Role::Viewer,
+            )?;
+            let member_scoped = crate::authz::authz_enforced_conn(conn)?;
+            let comment = queries::comments::create_comment_with_mentions(
                 conn,
                 parent,
                 project_id,
-                user_id,
+                models::CommentActor::from(&actor.user),
                 &input.content,
                 member_scoped,
             )?;
-            let event = match (c.issue_id, project_id) {
-                (Some(issue_id), Some(project_id)) => {
-                    Some(crate::realtime::RealtimeEvent::IssueUpdated {
-                        project_id,
-                        issue_id,
-                    })
-                }
-                (None, Some(project_id)) => {
-                    Some(crate::realtime::RealtimeEvent::ProjectUpdated { project_id })
-                }
-                (_, None) => None,
-            };
-            Ok((c, event))
+            let event = comment_updated_event(parent, project_id);
+            Ok((comment, parent, parent_identifier, event))
         })?;
-        // Don't echo c.content back — the agent already supplied it in the
+        // Don't echo the content back — the agent already supplied it in the
         // tool args, so repeating it just duplicates tokens in context
         // (LIF-115). The comment id is the useful new handle for any
         // follow-up edit/delete.
@@ -3362,21 +3302,21 @@ impl LificMcp {
                     "{} added to {} by {} at {}",
                     reference_with_context(
                         Some(context.as_ref()),
-                        comment_reference_kind(&parent_identifier, parent, c.id),
+                        comment_reference_kind(&parent_identifier, parent, comment.id),
                     ),
                     reference_with_context(
                         Some(context.as_ref()),
                         comment_parent_reference_kind(&parent_identifier, parent),
                     ),
-                    c.author,
-                    c.created_at
+                    comment.author,
+                    comment.created_at
                 )
             }),
             None => render_response(|output| {
                 write!(
                     output,
                     "Comment #{} added to {} by {} at {}",
-                    c.id, parent_identifier, c.author, c.created_at
+                    comment.id, parent_identifier, comment.author, comment.created_at
                 )
             }),
         })
@@ -3506,45 +3446,39 @@ impl LificMcp {
     }
 
     fn edit_comment_inner(&self, input: EditCommentInput) -> Result<String, String> {
-        let (c, project_id, parent, parent_identifier) = self.write(|conn| {
+        let (comment, context) = self.transaction(|conn| {
             let actor = resolve_comment_actor_conn(conn)?;
             let existing = queries::comments::get_comment(conn, input.comment_id)?;
+            let context = queries::comments::CommentContext::resolve(conn, &existing)?;
+            crate::authz::require_project_or_workspace_role_conn(
+                conn,
+                &Some(actor.clone()),
+                context.project_id(),
+                models::Role::Viewer,
+            )?;
             if existing.user_id != actor.user.id && !actor.user.is_admin {
                 return Err(crate::error::LificError::BadRequest(
                     "you can only edit your own comments".into(),
                 ));
             }
-
-            let (project_id, parent, parent_identifier) =
-                resolve_comment_context(conn, &existing)?;
-            require_page_role_mcp_conn(
-                conn,
-                &Some(actor),
-                project_id,
-                models::Role::Viewer,
-            )?;
             let member_scoped = crate::authz::authz_enforced_conn(conn)?;
-            // LIF-375: shared with the REST edit path; re-derives mentions and
-            // attachment links from the new body (LIF-369).
             let comment = queries::comments::update_comment_with_mentions(
                 conn,
                 input.comment_id,
-                project_id,
+                context.project_id(),
+                models::CommentActor::from(&actor.user),
                 &input.content,
                 member_scoped,
             )?;
-            Ok((comment, project_id, parent, parent_identifier))
+            Ok((comment, context))
         })?;
+        let parent = context.parent();
+        let parent_identifier = context.parent_identifier();
+        if let Some(event) = comment_updated_event(parent, context.project_id()) {
+            self.emit(event);
+        }
         // Don't echo the new content back — the agent already supplied it
         // (LIF-115). The id is the stable handle.
-        if let (Some(issue_id), Some(project_id)) = (c.issue_id, project_id) {
-            self.emit(crate::realtime::RealtimeEvent::IssueUpdated {
-                project_id,
-                issue_id,
-            });
-        } else if let Some(project_id) = project_id {
-            self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
-        }
         Ok(match current_issue_link_context() {
             Some(context) => render_response(|output| {
                 write!(
@@ -3552,13 +3486,17 @@ impl LificMcp {
                     "{} edited at {}",
                     reference_with_context(
                         Some(context.as_ref()),
-                        comment_reference_kind(&parent_identifier, parent, c.id),
+                        comment_reference_kind(parent_identifier, parent, comment.id),
                     ),
-                    c.updated_at
+                    comment.updated_at
                 )
             }),
             None => render_response(|output| {
-                write!(output, "Comment #{} edited at {}", c.id, c.updated_at)
+                write!(
+                    output,
+                    "Comment #{} edited at {}",
+                    comment.id, comment.updated_at
+                )
             }),
         })
     }
@@ -3570,33 +3508,28 @@ impl LificMcp {
     }
 
     fn delete_comment_inner(&self, input: DeleteCommentInput) -> Result<String, String> {
-        let (existing, project_id, parent, parent_identifier) = self.write(|conn| {
+        let context = self.transaction(|conn| {
             let actor = resolve_comment_actor_conn(conn)?;
             let existing = queries::comments::get_comment(conn, input.comment_id)?;
+            let context = queries::comments::CommentContext::resolve(conn, &existing)?;
+            crate::authz::require_project_or_workspace_role_conn(
+                conn,
+                &Some(actor.clone()),
+                context.project_id(),
+                models::Role::Viewer,
+            )?;
             if existing.user_id != actor.user.id && !actor.user.is_admin {
                 return Err(crate::error::LificError::BadRequest(
                     "you can only delete your own comments".into(),
                 ));
             }
-
-            let (project_id, parent, parent_identifier) =
-                resolve_comment_context(conn, &existing)?;
-            require_page_role_mcp_conn(
-                conn,
-                &Some(actor),
-                project_id,
-                models::Role::Viewer,
-            )?;
             queries::comments::delete_comment(conn, input.comment_id)?;
-            Ok((existing, project_id, parent, parent_identifier))
+            Ok(context)
         })?;
-        if let (Some(issue_id), Some(project_id)) = (existing.issue_id, project_id) {
-            self.emit(crate::realtime::RealtimeEvent::IssueUpdated {
-                project_id,
-                issue_id,
-            });
-        } else if let Some(project_id) = project_id {
-            self.emit(crate::realtime::RealtimeEvent::ProjectUpdated { project_id });
+        let parent = context.parent();
+        let parent_identifier = context.parent_identifier();
+        if let Some(event) = comment_updated_event(parent, context.project_id()) {
+            self.emit(event);
         }
         Ok(match current_issue_link_context() {
             Some(context) => render_response(|output| {
@@ -3606,7 +3539,7 @@ impl LificMcp {
                     input.comment_id,
                     reference_with_context(
                         Some(context.as_ref()),
-                        comment_parent_reference_kind(&parent_identifier, parent),
+                        comment_parent_reference_kind(parent_identifier, parent),
                     )
                 )
             }),
@@ -10005,7 +9938,7 @@ mod authz_gating_tests {
     }
 
     #[test]
-    fn revoked_member_cannot_edit_or_delete_own_comment() {
+    fn revoked_member_cannot_mutate_comments() {
         let (m, _admin, lead, _maintainer, viewer, _non_member, project_id, _guard) =
             setup_membership_mcp();
         let created = as_user(&lead, || {
@@ -10017,15 +9950,20 @@ mod authz_gating_tests {
         });
         assert!(created.starts_with("Created"), "got: {created}");
 
-        let [edit_comment_id, delete_comment_id] = ["Keep this comment", "Keep this one too"]
-            .map(|content| {
-                comment_id_from(&as_user(&viewer, || {
-                    m.add_comment(Parameters(AddCommentInput {
-                        identifier: "MEM-1".into(),
-                        content: content.into(),
-                    }))
+        let [edit_comment_id, delete_comment_id, foreign_edit_id, foreign_delete_id] = [
+            (&viewer, "Keep this comment"),
+            (&viewer, "Keep this one too"),
+            (&lead, "Do not disclose ownership"),
+            (&lead, "Do not disclose ownership either"),
+        ]
+        .map(|(author, content)| {
+            comment_id_from(&as_user(author, || {
+                m.add_comment(Parameters(AddCommentInput {
+                    identifier: "MEM-1".into(),
+                    content: content.into(),
                 }))
-            });
+            }))
+        });
         m.write(|conn| queries::members::remove_member(conn, project_id, viewer.id))
             .unwrap();
 
@@ -10044,12 +9982,32 @@ mod authz_gating_tests {
         });
         assert!(is_forbidden(&delete), "got: {delete}");
 
+        let foreign_edit = as_user(&viewer, || {
+            m.edit_comment(Parameters(EditCommentInput {
+                comment_id: foreign_edit_id,
+                content: "tampered".into(),
+            }))
+        });
+        assert!(is_forbidden(&foreign_edit), "got: {foreign_edit}");
+
+        let foreign_delete = as_user(&viewer, || {
+            m.delete_comment(Parameters(DeleteCommentInput {
+                comment_id: foreign_delete_id,
+            }))
+        });
+        assert!(is_forbidden(&foreign_delete), "got: {foreign_delete}");
+
         m.read(|conn| {
             assert_eq!(
                 queries::comments::get_comment(conn, edit_comment_id)?.content,
                 "Keep this comment"
             );
             assert!(queries::comments::get_comment(conn, delete_comment_id).is_ok());
+            assert_eq!(
+                queries::comments::get_comment(conn, foreign_edit_id)?.content,
+                "Do not disclose ownership"
+            );
+            assert!(queries::comments::get_comment(conn, foreign_delete_id).is_ok());
             Ok(())
         })
         .unwrap();


### PR DESCRIPTION
## Problem

Comment mutations could authorize ownership and project membership in separate database scopes. A membership revocation could race the write, and checking ownership before project access could reveal whether a comment belonged to the caller. Attachment references could also import an attachment from another project. Migration startup needed an atomic cross-process boundary.

## Changes

- Resolve each comment's parent and project once, then enforce Viewer/workspace-admin access before author-or-admin ownership checks in REST and MCP.
- Execute comment creation, edits, deletions, mention reconciliation, attachment-link reconciliation, and audit actor stamping in one immediate SQLite transaction.
- Introduce a typed `CommentActor` carrying the user ID and admin status through comment and attachment policy APIs, removing adjacent boolean parameters that could be transposed.
- Centralize connection-scoped project/workspace authorization and comment context/event resolution so REST and MCP share the same policy.
- Restrict comment attachment reuse to the acting uploader/admin or attachments already linked within the comment's project.
- Serialize migration discovery and application with an immediate transaction while keeping the migration API compatible with shared connections.

## Tests

- REST and MCP revocation tests cover caller-owned and other-user comments, assert forbidden responses, and verify edits/deletions leave stored comments unchanged.
- Attachment policy tests cover uploader access, admin override, foreign-project rejection, project-local reuse, and nonexistent attachment IDs.
- Transaction rollback coverage proves a failed operation leaves no partial project write.
- Migration tests continue to exercise the shared-connection API used by the current master test suite.