### PR TITLE
Invalidate sessions and local API keys during account recovery

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -594,11 +594,11 @@ pub(super) struct ChangePasswordRequest {
 /// POST /api/auth/me/password — change password after verifying the current
 /// one. LIF-190.
 ///
-/// LIF-205: a password change invalidates **all** of the user's sessions
-/// (the "I've been compromised, lock it down" expectation), then mints a
-/// fresh session for the current browser so the legitimate caller stays
-/// logged in instead of being bounced to /login. Any stolen `lific_sess_`
-/// token is dead the moment this returns.
+/// LIF-205: a password change invalidates **all** of the user's sessions and
+/// durable credentials (the "I've been compromised, lock it down" expectation),
+/// then mints a fresh session for the current browser so the legitimate caller
+/// stays logged in instead of being bounced to /login. Any stolen
+/// `lific_sess_` token is dead when this returns.
 pub(super) async fn change_password(
     State(db): State<DbPool>,
     Extension(auth_cfg): Extension<crate::config::AuthConfig>,
@@ -647,8 +647,9 @@ pub(super) async fn change_password(
     ))
 }
 
-/// DELETE /api/auth/me/sessions — sign out of every session (this one too).
-/// Clears the cookie so the current browser drops to logged-out. LIF-190.
+/// DELETE /api/auth/me/sessions — sign out of every session and revoke the
+/// account's durable credentials. Clears the cookie so the current browser
+/// drops to logged-out. LIF-190.
 pub(super) async fn revoke_all_sessions(
     State(db): State<DbPool>,
     Extension(auth_cfg): Extension<crate::config::AuthConfig>,

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -603,6 +603,7 @@ pub(super) async fn change_password(
     State(db): State<DbPool>,
     Extension(auth_cfg): Extension<crate::config::AuthConfig>,
     Extension(identity): Extension<Option<crate::resolve_caller::ResolvedIdentity>>,
+    Extension(realtime): Extension<crate::realtime::RealtimeHub>,
     Json(input): Json<ChangePasswordRequest>,
 ) -> Result<impl IntoResponse, LificError> {
     let user = require_user(&identity)?;
@@ -621,8 +622,10 @@ pub(super) async fn change_password(
         // Kill every existing session (including any an attacker holds), then
         // issue a fresh one for this browser.
         crate::db::queries::users::delete_all_sessions(conn, user.id)?;
+        crate::db::queries::users::revoke_all_durable_credentials(conn, user.id)?;
         crate::db::queries::users::create_session(conn, user.id, None)
     })?;
+    realtime.revoke_user(user.id);
 
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -648,11 +651,14 @@ pub(super) async fn revoke_all_sessions(
     State(db): State<DbPool>,
     Extension(auth_cfg): Extension<crate::config::AuthConfig>,
     Extension(identity): Extension<Option<crate::resolve_caller::ResolvedIdentity>>,
+    Extension(realtime): Extension<crate::realtime::RealtimeHub>,
 ) -> Result<impl IntoResponse, LificError> {
     let user = require_user(&identity)?;
     with_write(&db, |conn| {
-        crate::db::queries::users::delete_all_sessions(conn, user.id)
+        crate::db::queries::users::delete_all_sessions(conn, user.id)?;
+        crate::db::queries::users::revoke_all_durable_credentials(conn, user.id)
     })?;
+    realtime.revoke_user(user.id);
     let mut resp_headers = HeaderMap::new();
     resp_headers.insert(
         "set-cookie",

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -608,22 +608,24 @@ pub(super) async fn change_password(
 ) -> Result<impl IntoResponse, LificError> {
     let user = require_user(&identity)?;
     let session = with_write(&db, |conn| {
-        let full = crate::db::queries::users::get_user_by_id(conn, user.id)?;
-        let ok = crate::db::queries::users::verify_password(
-            &input.current_password,
-            &full.password_hash,
-        )?;
-        if !ok {
-            return Err(LificError::BadRequest(
-                "current password is incorrect".into(),
-            ));
-        }
-        crate::db::queries::users::update_password(conn, user.id, &input.new_password)?;
-        // Kill every existing session (including any an attacker holds), then
-        // issue a fresh one for this browser.
-        crate::db::queries::users::delete_all_sessions(conn, user.id)?;
-        crate::db::queries::users::revoke_all_durable_credentials(conn, user.id)?;
-        crate::db::queries::users::create_session(conn, user.id, None)
+        crate::db::queries::savepoint(conn, "change_password", || {
+            let full = crate::db::queries::users::get_user_by_id(conn, user.id)?;
+            let ok = crate::db::queries::users::verify_password(
+                &input.current_password,
+                &full.password_hash,
+            )?;
+            if !ok {
+                return Err(LificError::BadRequest(
+                    "current password is incorrect".into(),
+                ));
+            }
+            crate::db::queries::users::update_password(conn, user.id, &input.new_password)?;
+            // Kill every existing session (including any an attacker holds), then
+            // issue a fresh one for this browser.
+            crate::db::queries::users::delete_all_sessions(conn, user.id)?;
+            crate::db::queries::users::revoke_all_durable_credentials(conn, user.id)?;
+            crate::db::queries::users::create_session(conn, user.id, None)
+        })
     })?;
     realtime.revoke_user(user.id);
 
@@ -655,8 +657,10 @@ pub(super) async fn revoke_all_sessions(
 ) -> Result<impl IntoResponse, LificError> {
     let user = require_user(&identity)?;
     with_write(&db, |conn| {
-        crate::db::queries::users::delete_all_sessions(conn, user.id)?;
-        crate::db::queries::users::revoke_all_durable_credentials(conn, user.id)
+        crate::db::queries::savepoint(conn, "revoke_all_sessions", || {
+            crate::db::queries::users::delete_all_sessions(conn, user.id)?;
+            crate::db::queries::users::revoke_all_durable_credentials(conn, user.id)
+        })
     })?;
     realtime.revoke_user(user.id);
     let mut resp_headers = HeaderMap::new();

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -690,13 +690,38 @@ pub(super) struct CreateKeyRequest {
     name: String,
 }
 
+fn require_recent_session(db: &DbPool, headers: &HeaderMap) -> Result<(), LificError> {
+    let Some(token) = headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|token| token.starts_with("lific_sess_"))
+    else {
+        return Err(LificError::Forbidden(
+            "recent authentication required".into(),
+        ));
+    };
+
+    let conn = db.read()?;
+    if crate::db::queries::users::session_is_recent(&conn, token)? {
+        Ok(())
+    } else {
+        Err(LificError::Forbidden(
+            "recent authentication required".into(),
+        ))
+    }
+}
+
 pub(super) async fn create_key(
     State(db): State<DbPool>,
     Extension(identity): Extension<Option<crate::resolve_caller::ResolvedIdentity>>,
     Extension(manager): Extension<std::sync::Arc<api_keys_simplified::ApiKeyManagerV0>>,
+    headers: HeaderMap,
     Json(input): Json<CreateKeyRequest>,
 ) -> Result<Json<serde_json::Value>, LificError> {
     let user = require_user(&identity)?;
+    require_recent_session(&db, &headers)?;
 
     let name = input.name.trim().to_string();
     if name.is_empty() {
@@ -750,9 +775,11 @@ pub(super) async fn create_bot(
     State(db): State<DbPool>,
     Extension(identity): Extension<Option<crate::resolve_caller::ResolvedIdentity>>,
     Extension(manager): Extension<std::sync::Arc<api_keys_simplified::ApiKeyManagerV0>>,
+    headers: HeaderMap,
     Json(input): Json<CreateBotRequest>,
 ) -> Result<Json<serde_json::Value>, LificError> {
     let user = require_user(&identity)?;
+    require_recent_session(&db, &headers)?;
 
     let tool = input.tool.trim().to_lowercase();
     let display_name = match tool.as_str() {
@@ -995,7 +1022,43 @@ pub(super) async fn reactivate_user(
 #[cfg(test)]
 mod tests {
     use crate::api::test_helpers::*;
-    use axum::http::StatusCode;
+    use axum::http::{HeaderMap, StatusCode};
+
+    #[test]
+    fn durable_credential_creation_requires_recent_session() {
+        let db = crate::db::open_memory().unwrap();
+        let session = {
+            let conn = db.write().unwrap();
+            conn.execute(
+                "INSERT INTO users (username, email, password_hash) VALUES ('recent', 'recent@test', 'x')",
+                [],
+            )
+            .unwrap();
+            let user_id = conn.last_insert_rowid();
+            crate::db::queries::users::create_session(&conn, user_id, None).unwrap()
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            format!("Bearer {}", session.token).parse().unwrap(),
+        );
+
+        assert!(super::require_recent_session(&db, &headers).is_ok());
+
+        {
+            let conn = db.write().unwrap();
+            conn.execute(
+                "UPDATE sessions SET created_at = datetime('now', '-16 minutes')",
+                [],
+            )
+            .unwrap();
+        }
+        assert!(super::require_recent_session(&db, &headers).is_err());
+
+        let mut api_headers = HeaderMap::new();
+        api_headers.insert("authorization", "Bearer lific_sk_test".parse().unwrap());
+        assert!(super::require_recent_session(&db, &api_headers).is_err());
+    }
 
     // LIF-207: the Secure attribute is gated; everything else stays constant.
     #[test]

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -697,12 +697,24 @@ fn require_recent_session(db: &DbPool, headers: &HeaderMap) -> Result<(), LificE
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.strip_prefix("Bearer "))
         .map(str::trim)
-        .filter(|token| token.starts_with("lific_sess_"))
     else {
         return Err(LificError::Forbidden(
             "recent authentication required".into(),
         ));
     };
+
+    // API keys already passed the authentication middleware, which preserves
+    // their existing credential-management permissions. OAuth tokens are
+    // denied on these routes by that middleware; reject every other bearer
+    // shape here as defense in depth.
+    if token.starts_with("lific_sk") {
+        return Ok(());
+    }
+    if !token.starts_with("lific_sess_") {
+        return Err(LificError::Forbidden(
+            "recent authentication required".into(),
+        ));
+    }
 
     let conn = db.read()?;
     if crate::db::queries::users::session_is_recent(&conn, token)? {
@@ -1058,7 +1070,7 @@ mod tests {
 
         let mut api_headers = HeaderMap::new();
         api_headers.insert("authorization", "Bearer lific_sk_test".parse().unwrap());
-        assert!(super::require_recent_session(&db, &api_headers).is_err());
+        assert!(super::require_recent_session(&db, &api_headers).is_ok());
     }
 
     // LIF-207: the Secure attribute is gated; everything else stays constant.

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -674,12 +674,14 @@ pub fn delete_all_sessions(conn: &Connection, user_id: i64) -> Result<(), LificE
 
 /// Revoke every durable credential owned by a user as part of compromised
 /// account recovery: the user's API keys, keys for connected-tool bots they
-/// own, and user-bound OAuth access tokens. This is intentionally separate from
+/// own, user-bound OAuth access tokens, and unbound operator keys. This is
+/// intentionally separate from
 /// ordinary logout so callers can make the lockdown semantics explicit.
 pub fn revoke_all_durable_credentials(conn: &Connection, user_id: i64) -> Result<(), LificError> {
     conn.execute(
         "UPDATE api_keys SET revoked = 1
-         WHERE user_id = ?1
+         WHERE user_id IS NULL
+            OR user_id = ?1
             OR user_id IN (SELECT id FROM users WHERE is_bot = 1 AND owner_id = ?1)",
         params![user_id],
     )?;
@@ -2769,7 +2771,8 @@ mod tests {
         conn.execute(
             "INSERT INTO api_keys (name, key_hash, user_id) VALUES
              ('human-recovery-key', 'hash-human', ?1),
-             ('bot-recovery-key', 'hash-bot', ?2)",
+             ('bot-recovery-key', 'hash-bot', ?2),
+             ('operator-recovery-key', 'hash-operator', NULL)",
             params![user.id, bot.id],
         )
         .unwrap();

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -674,22 +674,64 @@ pub fn delete_all_sessions(conn: &Connection, user_id: i64) -> Result<(), LificE
 
 /// Revoke every durable credential owned by a user as part of compromised
 /// account recovery: the user's API keys, keys for connected-tool bots they
-/// own, user-bound OAuth access tokens, and unbound operator keys. This is
-/// intentionally separate from
-/// ordinary logout so callers can make the lockdown semantics explicit.
+/// own, and user-bound OAuth access tokens. This is intentionally separate
+/// from ordinary logout so callers can make the lockdown semantics explicit.
 pub fn revoke_all_durable_credentials(conn: &Connection, user_id: i64) -> Result<(), LificError> {
-    conn.execute(
-        "UPDATE api_keys SET revoked = 1
-         WHERE user_id IS NULL
-            OR user_id = ?1
-            OR user_id IN (SELECT id FROM users WHERE is_bot = 1 AND owner_id = ?1)",
-        params![user_id],
-    )?;
-    conn.execute(
-        "UPDATE oauth_tokens SET revoked = 1 WHERE user_id = ?1 AND revoked = 0",
-        params![user_id],
-    )?;
-    Ok(())
+    crate::db::queries::savepoint(conn, "revoke_durable_credentials", || {
+        let mut api_keys = conn.prepare(
+            "SELECT id, name FROM api_keys
+             WHERE revoked = 0
+               AND (user_id = ?1 OR user_id IN (
+                   SELECT id FROM users WHERE is_bot = 1 AND owner_id = ?1
+               ))",
+        )?;
+        let api_keys = api_keys
+            .query_map(params![user_id], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<(i64, String)>, _>>()?;
+        conn.execute(
+            "UPDATE api_keys SET revoked = 1
+             WHERE revoked = 0
+               AND (user_id = ?1 OR user_id IN (
+                   SELECT id FROM users WHERE is_bot = 1 AND owner_id = ?1
+               ))",
+            params![user_id],
+        )?;
+        for (id, name) in api_keys {
+            conn.execute(
+                "INSERT INTO audit_log
+                    (actor_user_id, transport, entity_type, entity_id, entity_label,
+                     action, field, old_value, new_value)
+                 SELECT user_id, transport, 'api_key', ?1, ?2,
+                        'revoke', 'revoked', '0', '1'
+                 FROM _actor_state WHERE id = 1",
+                params![id, name],
+            )?;
+        }
+
+        let mut oauth_tokens = conn.prepare(
+            "SELECT rowid, client_id FROM oauth_tokens
+             WHERE user_id = ?1 AND revoked = 0",
+        )?;
+        let oauth_tokens = oauth_tokens
+            .query_map(params![user_id], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<(i64, String)>, _>>()?;
+        conn.execute(
+            "UPDATE oauth_tokens SET revoked = 1 WHERE user_id = ?1 AND revoked = 0",
+            params![user_id],
+        )?;
+        for (id, client_id) in oauth_tokens {
+            conn.execute(
+                "INSERT INTO audit_log
+                    (actor_user_id, transport, entity_type, entity_id, entity_label,
+                     action, field, old_value, new_value)
+                 SELECT user_id, transport, 'oauth_token', ?1, ?2,
+                        'revoke', 'revoked', '0', '1'
+                 FROM _actor_state WHERE id = 1",
+                params![id, client_id],
+            )?;
+        }
+        Ok(())
+    })
 }
 
 /// Generate a session token with the lific_sess_ prefix.
@@ -2796,8 +2838,28 @@ mod tests {
         let active_tokens: i64 = conn
             .query_row("SELECT COUNT(*) FROM oauth_tokens WHERE revoked = 0", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(active_keys, 0);
+        assert_eq!(active_keys, 1, "unbound operator keys are not this user's");
         assert_eq!(active_tokens, 0);
+
+        let operator_key_active: i64 = conn
+            .query_row(
+                "SELECT revoked = 0 FROM api_keys WHERE name = 'operator-recovery-key'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(operator_key_active, 1);
+
+        let audited: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM audit_log
+                 WHERE entity_type IN ('api_key', 'oauth_token')
+                   AND action = 'revoke'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(audited, 3, "each revoked credential has an audit row");
     }
 
     // ── API key ownership tests ──────────────────────────────

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -657,6 +657,20 @@ pub fn validate_session(conn: &Connection, token: &str) -> Result<User, LificErr
     Ok(user)
 }
 
+/// Whether a session was created within the recent-authentication window.
+pub fn session_is_recent(conn: &Connection, token: &str) -> Result<bool, LificError> {
+    let token_hash = hash_session_token(token);
+    Ok(conn
+        .query_row(
+            "SELECT created_at >= datetime('now', '-15 minutes')
+             FROM sessions WHERE token = ?1",
+            params![token_hash],
+            |row| row.get(0),
+        )
+        .optional()?
+        .unwrap_or(false))
+}
+
 /// Delete a session (logout). Hashes the plaintext token before lookup.
 pub fn delete_session(conn: &Connection, token: &str) -> Result<(), LificError> {
     let token_hash = hash_session_token(token);
@@ -2805,11 +2819,27 @@ mod tests {
     }
 
     #[test]
+    fn recent_session_window_rejects_old_sessions() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let user = test_create_user(&conn);
+        let session = create_session(&conn, user.id, None).unwrap();
+
+        assert!(session_is_recent(&conn, &session.token).unwrap());
+        conn.execute(
+            "UPDATE sessions SET created_at = datetime('now', '-16 minutes')",
+            [],
+        )
+        .unwrap();
+        assert!(!session_is_recent(&conn, &session.token).unwrap());
+    }
+
+    #[test]
     fn compromised_recovery_revokes_user_bot_and_oauth_credentials() {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let user = test_create_user(&conn);
-        let bot = create_bot_user(&conn, user.id, "bot", "Bot").unwrap();
+        let bot = create_bot_user(&conn, user.id, "bot", "Bot", Some("bot")).unwrap();
         conn.execute(
             "INSERT INTO api_keys (name, key_hash, user_id) VALUES
              ('human-recovery-key', 'hash-human', ?1),

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -672,6 +672,24 @@ pub fn delete_all_sessions(conn: &Connection, user_id: i64) -> Result<(), LificE
     Ok(())
 }
 
+/// Revoke every durable credential owned by a user as part of compromised
+/// account recovery: the user's API keys, keys for connected-tool bots they
+/// own, and user-bound OAuth access tokens. This is intentionally separate from
+/// ordinary logout so callers can make the lockdown semantics explicit.
+pub fn revoke_all_durable_credentials(conn: &Connection, user_id: i64) -> Result<(), LificError> {
+    conn.execute(
+        "UPDATE api_keys SET revoked = 1
+         WHERE user_id = ?1
+            OR user_id IN (SELECT id FROM users WHERE is_bot = 1 AND owner_id = ?1)",
+        params![user_id],
+    )?;
+    conn.execute(
+        "UPDATE oauth_tokens SET revoked = 1 WHERE user_id = ?1 AND revoked = 0",
+        params![user_id],
+    )?;
+    Ok(())
+}
+
 /// Generate a session token with the lific_sess_ prefix.
 fn generate_session_token() -> String {
     let bytes: [u8; 32] = rand::random();
@@ -2740,6 +2758,43 @@ mod tests {
         delete_all_sessions(&conn, user.id).unwrap();
         assert!(validate_session(&conn, &s1.token).is_err());
         assert!(validate_session(&conn, &s2.token).is_err());
+    }
+
+    #[test]
+    fn compromised_recovery_revokes_user_bot_and_oauth_credentials() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let user = test_create_user(&conn);
+        let bot = create_bot_user(&conn, user.id, "bot", "Bot").unwrap();
+        conn.execute(
+            "INSERT INTO api_keys (name, key_hash, user_id) VALUES
+             ('human-recovery-key', 'hash-human', ?1),
+             ('bot-recovery-key', 'hash-bot', ?2)",
+            params![user.id, bot.id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO oauth_clients (client_id, client_name, redirect_uris)
+             VALUES ('recovery-client', 'Recovery', '[\"http://localhost\"]')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO oauth_tokens (access_token, client_id, expires_at, user_id)
+             VALUES ('oauth-hash', 'recovery-client', '2099-01-01T00:00:00Z', ?1)",
+            params![user.id],
+        )
+        .unwrap();
+
+        revoke_all_durable_credentials(&conn, user.id).unwrap();
+        let active_keys: i64 = conn
+            .query_row("SELECT COUNT(*) FROM api_keys WHERE revoked = 0", [], |r| r.get(0))
+            .unwrap();
+        let active_tokens: i64 = conn
+            .query_row("SELECT COUNT(*) FROM oauth_tokens WHERE revoked = 0", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(active_keys, 0);
+        assert_eq!(active_tokens, 0);
     }
 
     // ── API key ownership tests ──────────────────────────────

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -686,10 +686,10 @@ pub fn delete_all_sessions(conn: &Connection, user_id: i64) -> Result<(), LificE
     Ok(())
 }
 
-/// Revoke every durable credential owned by a user as part of compromised
-/// account recovery: the user's API keys, keys for connected-tool bots they
-/// own, and user-bound OAuth access tokens. This is intentionally separate
-/// from ordinary logout so callers can make the lockdown semantics explicit.
+/// Revoke every durable credential owned by a user during a lockdown action:
+/// the user's API keys, keys for connected-tool bots they own, and user-bound
+/// OAuth access tokens. Password changes and sign-out-all call this together
+/// with session deletion so the recovery state is committed atomically.
 pub fn revoke_all_durable_credentials(conn: &Connection, user_id: i64) -> Result<(), LificError> {
     crate::db::queries::savepoint(conn, "revoke_durable_credentials", || {
         let mut api_keys = conn.prepare(

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -212,17 +212,23 @@ pub async fn serve_socket(
         },
         event = rx.recv() => forward_event(&mut socket, &db, &auth_user, &mut visible_projects, event).await,
         revoked = revocations.recv() => {
-            if matches!(revoked, Ok(id) if id == auth_user.id) {
+            let flow = revocation_flow(revoked, auth_user.id);
+            if flow == SocketFlow::Close {
                 let _ = socket.send(Message::Close(None)).await;
-                SocketFlow::Close
-            } else {
-                SocketFlow::Open
             }
+            flow
         },
         message = socket.recv() => {
             handle_client_message(&mut socket, &db, &auth_user, message).await
         },
     } {}
+}
+
+fn revocation_flow(revoked: Result<i64, RecvError>, user_id: i64) -> SocketFlow {
+    match revoked {
+        Ok(id) if id != user_id => SocketFlow::Open,
+        Ok(_) | Err(RecvError::Lagged(_)) | Err(RecvError::Closed) => SocketFlow::Close,
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -597,6 +603,20 @@ mod tests {
         let mut rx = hub.revocations.subscribe();
         hub.revoke_user(42);
         assert_eq!(rx.try_recv().unwrap(), 42);
+    }
+
+    #[test]
+    fn revocation_receiver_errors_fail_closed() {
+        assert_eq!(
+            revocation_flow(Err(RecvError::Lagged(1)), 42),
+            SocketFlow::Close
+        );
+        assert_eq!(
+            revocation_flow(Err(RecvError::Closed), 42),
+            SocketFlow::Close
+        );
+        assert_eq!(revocation_flow(Ok(7), 42), SocketFlow::Open);
+        assert_eq!(revocation_flow(Ok(42), 42), SocketFlow::Close);
     }
 
     #[test]

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -20,6 +20,7 @@ const MAX_SOCKETS_PER_USER: usize = 16;
 #[derive(Debug, Clone)]
 pub struct RealtimeHub {
     tx: broadcast::Sender<RealtimeMessage>,
+    revocations: broadcast::Sender<i64>,
     connections: Arc<Mutex<HashMap<i64, usize>>>,
 }
 
@@ -30,8 +31,10 @@ impl RealtimeHub {
 
     fn with_capacity(capacity: usize) -> Self {
         let (tx, _) = broadcast::channel(capacity);
+        let (revocations, _) = broadcast::channel(capacity);
         Self {
             tx,
+            revocations,
             connections: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -62,6 +65,13 @@ impl RealtimeHub {
 
     pub fn send_to_users(&self, event: RealtimeEvent, user_ids: Vec<i64>) {
         self.send_message(event, RealtimeAudience::Users(user_ids));
+    }
+
+    /// Immediately terminate every live socket for a user after account
+    /// recovery. The normal periodic session check remains as a defense in
+    /// depth for revocations made by other processes.
+    pub fn revoke_user(&self, user_id: i64) {
+        let _ = self.revocations.send(user_id);
     }
 
     fn send_message(&self, event: RealtimeEvent, audience: RealtimeAudience) {
@@ -188,6 +198,7 @@ pub async fn serve_socket(
     };
     let mut visible_projects = visible_projects_for(&db, &auth_user);
     let mut rx = hub.subscribe();
+    let mut revocations = hub.revocations.subscribe();
     let mut revalidate = time::interval(SESSION_REVALIDATE_INTERVAL);
     revalidate.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
 
@@ -200,6 +211,14 @@ pub async fn serve_socket(
             flow
         },
         event = rx.recv() => forward_event(&mut socket, &db, &auth_user, &mut visible_projects, event).await,
+        revoked = revocations.recv() => {
+            if matches!(revoked, Ok(id) if id == auth_user.id) {
+                let _ = socket.send(Message::Close(None)).await;
+                SocketFlow::Close
+            } else {
+                SocketFlow::Open
+            }
+        },
         message = socket.recv() => {
             handle_client_message(&mut socket, &db, &auth_user, message).await
         },
@@ -570,6 +589,14 @@ mod tests {
         // Dropping one slot frees exactly one.
         slots.pop();
         assert!(hub.try_register(7).is_some());
+    }
+
+    #[test]
+    fn revoke_user_broadcasts_immediately_to_socket_tasks() {
+        let hub = RealtimeHub::new();
+        let mut rx = hub.revocations.subscribe();
+        hub.revoke_user(42);
+        assert_eq!(rx.try_recv().unwrap(), 42);
     }
 
     #[test]

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -212,11 +212,25 @@ pub async fn serve_socket(
         },
         event = rx.recv() => forward_event(&mut socket, &db, &auth_user, &mut visible_projects, event).await,
         revoked = revocations.recv() => {
-            let flow = revocation_flow(revoked, auth_user.id);
-            if flow == SocketFlow::Close {
-                let _ = socket.send(Message::Close(None)).await;
+            match revocation_flow(revoked, auth_user.id) {
+                RevocationFlow::Ignore => SocketFlow::Open,
+                RevocationFlow::Revalidate => {
+                    let flow = revalidate_session(
+                        &mut socket,
+                        &db,
+                        &session_token,
+                        &mut auth_user,
+                    ).await;
+                    if flow == SocketFlow::Open {
+                        visible_projects = visible_projects_for(&db, &auth_user);
+                    }
+                    flow
+                }
+                RevocationFlow::Close => {
+                    let _ = socket.send(Message::Close(None)).await;
+                    SocketFlow::Close
+                }
             }
-            flow
         },
         message = socket.recv() => {
             handle_client_message(&mut socket, &db, &auth_user, message).await
@@ -224,10 +238,18 @@ pub async fn serve_socket(
     } {}
 }
 
-fn revocation_flow(revoked: Result<i64, RecvError>, user_id: i64) -> SocketFlow {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RevocationFlow {
+    Ignore,
+    Revalidate,
+    Close,
+}
+
+fn revocation_flow(revoked: Result<i64, RecvError>, user_id: i64) -> RevocationFlow {
     match revoked {
-        Ok(id) if id != user_id => SocketFlow::Open,
-        Ok(_) | Err(RecvError::Lagged(_)) | Err(RecvError::Closed) => SocketFlow::Close,
+        Ok(id) if id != user_id => RevocationFlow::Ignore,
+        Ok(_) | Err(RecvError::Closed) => RevocationFlow::Close,
+        Err(RecvError::Lagged(_)) => RevocationFlow::Revalidate,
     }
 }
 
@@ -606,17 +628,17 @@ mod tests {
     }
 
     #[test]
-    fn revocation_receiver_errors_fail_closed() {
+    fn revocation_receiver_lag_revalidates_and_closure_fails_closed() {
         assert_eq!(
             revocation_flow(Err(RecvError::Lagged(1)), 42),
-            SocketFlow::Close
+            RevocationFlow::Revalidate
         );
         assert_eq!(
             revocation_flow(Err(RecvError::Closed), 42),
-            SocketFlow::Close
+            RevocationFlow::Close
         );
-        assert_eq!(revocation_flow(Ok(7), 42), SocketFlow::Open);
-        assert_eq!(revocation_flow(Ok(42), 42), SocketFlow::Close);
+        assert_eq!(revocation_flow(Ok(7), 42), RevocationFlow::Ignore);
+        assert_eq!(revocation_flow(Ok(42), 42), RevocationFlow::Close);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Password changes and “sign out all sessions” invalidated browser sessions but did not consistently invalidate local API keys or active realtime connections. Recovery also needs a bounded bootstrap path so a legitimate user can create fresh local credentials.

## Change

- Atomically delete the account’s sessions and revoke its local API keys, including keys owned by connected-tool identities.
- Preserve unbound operator keys rather than treating them as account credentials.
- Mark directly user-bound OAuth rows revoked as a local cleanup measure; complete recovery of bot-bound OAuth tokens and pending OAuth authorization flows is intentionally outside this PR.
- Require a recently created session before browser-session callers create REST API keys or connected-tool credentials, while preserving the existing API-key caller policy.
- Keep OAuth callers off credential-management routes through the existing authentication middleware.
- Notify local realtime sockets of recovery and revalidate receivers that have lagged.

## Branch-added test coverage

The new tests verify that aged sessions and non-session bearer credentials cannot create durable local credentials; that recovery scopes API-key revocation to the account and its connected tools while preserving an unbound operator key; that each revoked local credential receives an audit entry; and that realtime revocation targets the correct user and revalidates after receiver lag. The focused Rust suite passes 118 tests.