### PR TITLE
Fail closed for proxy headers and bound rate-limit state

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Prefer per-tool **bot identities** (what `lific connect` mints when you have a u
 host = "0.0.0.0"
 port = 3456
 cors_origins = []
-trusted_proxies = ["127.0.0.0/8", "::1/128"]
+trusted_proxies = []
 
 [database]
 path = "lific.db"
@@ -308,7 +308,7 @@ allow_signup = true
 required = true
 ```
 
-CLI flags (`--db`, `--port`, `--host`) override config values. Set `server.public_url` when exposing Lific beyond localhost; it becomes the OAuth issuer and the URL `lific connect` writes into client configs. `server.trusted_proxies` controls which peers may supply `X-Forwarded-For` or `X-Real-IP`; it defaults to loopback for Tailscale Funnel. Add only proxy IPs/CIDRs you operate.
+CLI flags (`--db`, `--port`, `--host`) override config values. Set `server.public_url` when exposing Lific beyond localhost; it becomes the OAuth issuer and the URL `lific connect` writes into client configs. `server.trusted_proxies` controls which peers may supply `X-Forwarded-For` or `X-Real-IP`; it defaults to none. Add only isolated proxy IPs/CIDRs you operate, and prevent direct clients from reaching that ingress.
 
 Config is discovered in standard locations, first match wins:
 

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -48,7 +48,7 @@ This is the built-in default configuration. Optional server keys are omitted bec
 host = "0.0.0.0"
 port = 3456
 cors_origins = []
-trusted_proxies = ["127.0.0.0/8", "::1/128"]
+trusted_proxies = []
 
 [database]
 path = "lific.db"
@@ -75,7 +75,7 @@ required = true
 | `port` | unsigned 16-bit integer | `3456` | TCP port used by `lific start`. |
 | `public_url` | optional string | unset | Public base URL. Lific uses it as the OAuth issuer. `lific connect` uses it to derive the remote MCP URL. |
 | `cors_origins` | array of strings | `[]` | Allowed browser CORS origins. An empty array allows any origin. |
-| `trusted_proxies` | array of strings | `["127.0.0.0/8", "::1/128"]` | IP addresses or CIDR ranges trusted to supply client IP proxy headers. Invalid values stop server startup. |
+| `trusted_proxies` | array of strings | `[]` | Isolated IP addresses or CIDR ranges trusted to supply client IP proxy headers. Invalid values stop server startup. |
 | `mcp_path_token` | optional string | unset | Enables an unauthenticated MCP endpoint at `/mcp/<token>`. The path token is the credential. |
 | `mcp_path_user` | optional string | unset | Selects the username attributed to requests through `mcp_path_token`. When unset, Lific uses the first administrator if one exists. |
 
@@ -145,7 +145,7 @@ host = "127.0.0.1"
 port = 3456
 public_url = "https://lific.example.com"
 cors_origins = ["https://lific.example.com"]
-trusted_proxies = ["127.0.0.0/8", "::1/128"]
+trusted_proxies = []
 
 [database]
 path = "/var/lib/lific/lific.db"

--- a/site/content/docs/self-hosting.mdx
+++ b/site/content/docs/self-hosting.mdx
@@ -147,10 +147,10 @@ host = "127.0.0.1"
 port = 3456
 public_url = "https://lific.example.com"
 cors_origins = ["https://lific.example.com"]
-trusted_proxies = ["127.0.0.0/8", "::1/128"]
+trusted_proxies = []
 ```
 
-When a proxy supplies client IP headers, add only that proxy's addresses or CIDR ranges to `server.trusted_proxies`. Lific validates this configuration at startup. The default trusts loopback proxy addresses only.
+When a proxy supplies client IP headers, add only isolated proxy addresses or CIDR ranges to `server.trusted_proxies`. Lific validates this configuration at startup. The default trusts no proxy addresses.
 
 The proxy must forward `/api/events/ws` as a WebSocket connection, including the `Upgrade` and `Connection` headers, and must allow an idle timeout long enough for the session to remain connected. If ordinary page actions and REST requests work but changes in other tabs or agent writes do not appear live, test the WebSocket Upgrade path and proxy timeout before debugging the application.
 

--- a/site/content/docs/upgrading.mdx
+++ b/site/content/docs/upgrading.mdx
@@ -16,7 +16,7 @@ This guide covers upgrades from Lific 2.0 through 2.6. It assumes an existing 2.
 
    The archive includes a consistent database snapshot, attachments, and `manifest.json`.
 3. Record how clients connect: browser URL, API-key users, OAuth clients, and MCP configuration files. Keep one known-good operator key available for recovery.
-4. If the instance is behind a reverse proxy, review `server.trusted_proxies` before starting 2.2. Add only proxy networks you operate; the default trusts loopback proxies.
+4. If the instance is behind a reverse proxy, review `server.trusted_proxies` before starting 2.2. Add only isolated proxy networks you operate; the default trusts no proxies.
 5. Confirm that `lific.toml` parses before rolling out 2.6. From 2.6 a config file that exists but cannot be read or parsed stops startup instead of falling back to defaults, and unknown keys are rejected. Run `lific doctor`, which reports the configuration as one check and continues through the rest.
 
 Stop the background service before replacing the binary or restoring a backup. Keep the same `lific.toml`, database path, attachments directory, and public URL unless you are intentionally relocating the instance.

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -105,15 +105,15 @@ pub(super) async fn auth_signup(
     if let Some(Extension(ref rl)) = limiter {
         if !rl.check(&ip_key) {
             let retry = rl.retry_after(&ip_key);
-            return Err(LificError::BadRequest(format!(
-                "too many signup attempts — try again in {retry} seconds"
-            )));
+            return Err(LificError::BadRequest(
+                crate::ratelimit::retry_after_message("too many signup attempts", retry),
+            ));
         }
         if !rl.check(&email_key) {
             let retry = rl.retry_after(&email_key);
-            return Err(LificError::BadRequest(format!(
-                "too many signup attempts — try again in {retry} seconds"
-            )));
+            return Err(LificError::BadRequest(
+                crate::ratelimit::retry_after_message("too many signup attempts", retry),
+            ));
         }
     }
 
@@ -266,9 +266,9 @@ pub(super) async fn auth_login(
         && (!rl.peek(&ip_key) || !rl.peek(&id_key))
     {
         let retry = rl.retry_after(&id_key).max(rl.retry_after(&ip_key));
-        return Err(LificError::BadRequest(format!(
-            "too many login attempts — try again in {retry} seconds"
-        )));
+        return Err(LificError::BadRequest(
+            crate::ratelimit::retry_after_message("too many login attempts", retry),
+        ));
     }
 
     let user = match authenticate_off_writer(&db, &input.identity, &input.password).await {

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -262,13 +262,13 @@ pub(super) async fn auth_login(
         "login_ip:{}",
         crate::ratelimit::client_ip(peer.ip(), &headers, &trusted_proxies)
     );
-    if let Some(Extension(ref rl)) = limiter {
-        if !rl.peek(&ip_key) || !rl.peek(&id_key) {
-            let retry = rl.retry_after(&id_key).max(rl.retry_after(&ip_key));
-            return Err(LificError::BadRequest(format!(
-                "too many login attempts — try again in {retry} seconds"
-            )));
-        }
+    if let Some(Extension(ref rl)) = limiter
+        && (!rl.peek(&ip_key) || !rl.peek(&id_key))
+    {
+        let retry = rl.retry_after(&id_key).max(rl.retry_after(&ip_key));
+        return Err(LificError::BadRequest(format!(
+            "too many login attempts — try again in {retry} seconds"
+        )));
     }
 
     let user = match authenticate_off_writer(&db, &input.identity, &input.password).await {

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -94,22 +94,27 @@ pub(super) async fn auth_signup(
 ) -> Result<impl IntoResponse, LificError> {
     // Rate limit signups to prevent Argon2 CPU exhaustion. Key on TWO things
     // (LIF-138): the email AND the source IP. The attacker chooses the email,
-    // so an email-only key is bypassed by rotating addresses — each request
-    // still costing a full Argon2 hash. The per-IP key (same helper login
-    // uses) is what actually caps the DoS. `check` records on pass and the
-    // `||` short-circuits, so a rejected attempt never double-charges.
+    // so an email-only key is bypassed by rotating addresses. Check the IP
+    // first: a blocked source must not be able to allocate unlimited identity
+    // keys while short-circuiting the later check.
     let email_key = format!("signup:{}", input.email.to_lowercase());
     let ip_key = format!(
         "signup_ip:{}",
         crate::ratelimit::client_ip(peer.ip(), &headers, &trusted_proxies)
     );
-    if let Some(Extension(ref rl)) = limiter
-        && (!rl.check(&email_key) || !rl.check(&ip_key))
-    {
-        let retry = rl.retry_after(&email_key).max(rl.retry_after(&ip_key));
-        return Err(LificError::BadRequest(format!(
-            "too many signup attempts — try again in {retry} seconds"
-        )));
+    if let Some(Extension(ref rl)) = limiter {
+        if !rl.check(&ip_key) {
+            let retry = rl.retry_after(&ip_key);
+            return Err(LificError::BadRequest(format!(
+                "too many signup attempts — try again in {retry} seconds"
+            )));
+        }
+        if !rl.check(&email_key) {
+            let retry = rl.retry_after(&email_key);
+            return Err(LificError::BadRequest(format!(
+                "too many signup attempts — try again in {retry} seconds"
+            )));
+        }
     }
 
     // The instance's signup policy. Read on a pooled connection so a closed
@@ -257,13 +262,13 @@ pub(super) async fn auth_login(
         "login_ip:{}",
         crate::ratelimit::client_ip(peer.ip(), &headers, &trusted_proxies)
     );
-    if let Some(Extension(ref rl)) = limiter
-        && (!rl.peek(&id_key) || !rl.peek(&ip_key))
-    {
-        let retry = rl.retry_after(&id_key).max(rl.retry_after(&ip_key));
-        return Err(LificError::BadRequest(format!(
-            "too many login attempts — try again in {retry} seconds"
-        )));
+    if let Some(Extension(ref rl)) = limiter {
+        if !rl.peek(&ip_key) || !rl.peek(&id_key) {
+            let retry = rl.retry_after(&id_key).max(rl.retry_after(&ip_key));
+            return Err(LificError::BadRequest(format!(
+                "too many login attempts — try again in {retry} seconds"
+            )));
+        }
     }
 
     let user = match authenticate_off_writer(&db, &input.identity, &input.password).await {
@@ -1963,6 +1968,25 @@ mod tests {
             .layer(axum::Extension(limiter))
     }
 
+    fn signup_app_with_limiter(
+        max: usize,
+        peer: std::net::SocketAddr,
+    ) -> (axum::Router, std::sync::Arc<crate::ratelimit::RateLimiter>) {
+        let db = crate::db::open_memory().expect("test db");
+        let limiter = std::sync::Arc::new(crate::ratelimit::RateLimiter::new(
+            max,
+            std::time::Duration::from_secs(15 * 60),
+        ));
+        let app = with_client_ip_test_layers(crate::api::router(db, &[]), peer)
+            .layer(axum::Extension(crate::config::AuthConfig {
+                allow_signup: true,
+                required: true,
+                secure_cookies: false,
+            }))
+            .layer(axum::Extension(limiter.clone()));
+        (app, limiter)
+    }
+
     /// Fire one wrong-password login for `identity` from source IP `xff`.
     /// Returns the status and parsed JSON body so callers can distinguish an
     /// ordinary auth failure from a rate-limit rejection (both are 400).
@@ -2177,6 +2201,18 @@ mod tests {
             StatusCode::OK,
             "distinct IP should not be limited: {other}"
         );
+    }
+
+    #[tokio::test]
+    async fn blocked_signup_does_not_allocate_a_new_email_key() {
+        let (app, limiter) = signup_app_with_limiter(1, test_peer());
+        let (status, _) = signup_attempt(&app, 0, "203.0.113.10").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, body) = signup_attempt(&app, 1, "203.0.113.10").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(is_signup_rate_limited(&body));
+        assert!(!limiter.contains_key("signup:user1@test.com"));
     }
 
     // ── Instance-admin roster management (LIF-214) ───────────

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -608,8 +608,8 @@ pub(crate) mod test_helpers {
 
     /// The loopback peer supplied to test routers. `MockConnectInfo` mirrors
     /// production's `into_make_service_with_connect_info` path for handlers
-    /// that need the TCP peer, while the matching trusted range keeps explicit
-    /// XFF test headers meaningful.
+    /// that need the TCP peer. Tests that exercise forwarded headers opt into
+    /// an explicit trusted range here; production defaults trust none.
     pub fn test_peer() -> SocketAddr {
         SocketAddr::from(([127, 0, 0, 1], 4242))
     }
@@ -618,9 +618,8 @@ pub(crate) mod test_helpers {
     /// Callers can provide an untrusted peer to test spoofing defenses.
     pub fn with_client_ip_test_layers(router: Router, peer: SocketAddr) -> Router {
         let trusted_proxies = Arc::<[crate::ratelimit::IpNetwork]>::from(
-            crate::config::ServerConfig::default()
-                .trusted_proxy_ranges()
-                .expect("default trusted proxy ranges must parse"),
+            crate::ratelimit::parse_trusted_proxies(&["127.0.0.0/8".into()])
+                .expect("test trusted proxy range must parse"),
         );
         router
             .layer(Extension(trusted_proxies))

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,9 +199,9 @@ pub struct ServerConfig {
     /// Example: ["https://your-app.example.com"]
     pub cors_origins: Vec<String>,
     /// IP addresses or CIDR ranges allowed to supply client-IP proxy headers.
-    /// Plain IPs are allowed; defaults to loopback so Tailscale Funnel keeps
-    /// working while directly exposed listeners ignore spoofed X-Forwarded-For.
-    /// Example: ["127.0.0.0/8", "::1/128", "10.0.0.0/8"]
+    /// Plain IPs are allowed; defaults to no trusted peers. Configure only
+    /// isolated reverse-proxy addresses that cannot be reached directly.
+    /// Example: ["10.0.0.0/8"]
     pub trusted_proxies: Vec<String>,
     /// If set, exposes an authless MCP endpoint at `/mcp/<token>` that skips the
     /// OAuth flow entirely — the path secret itself is the credential. This is an
@@ -258,7 +258,7 @@ impl Default for ServerConfig {
             port: 3456,
             public_url: None,
             cors_origins: Vec::new(),
-            trusted_proxies: vec!["127.0.0.0/8".into(), "::1/128".into()],
+            trusted_proxies: Vec::new(),
             mcp_path_token: None,
             mcp_path_user: None,
         }
@@ -497,7 +497,7 @@ mod tests {
         assert_eq!(config.server.port, 3456);
         assert_eq!(
             config.server.trusted_proxies,
-            vec!["127.0.0.0/8", "::1/128"]
+            Vec::<String>::new()
         );
         assert_eq!(config.database.path, PathBuf::from("lific.db"));
         assert!(config.backup.enabled);
@@ -699,7 +699,7 @@ enabled = false
         let toml_str = Config::default_toml();
         let parsed: Config = toml::from_str(&toml_str).expect("default toml should parse");
         assert_eq!(parsed.server.port, 3456);
-        assert_eq!(parsed.server.trusted_proxies, vec!["127.0.0.0/8", "::1/128"]);
+        assert!(parsed.server.trusted_proxies.is_empty());
     }
 
     #[test]

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1871,9 +1871,8 @@ mod tests {
 
     fn default_trusted_proxies() -> Arc<[crate::ratelimit::IpNetwork]> {
         Arc::<[crate::ratelimit::IpNetwork]>::from(
-            crate::config::ServerConfig::default()
-                .trusted_proxy_ranges()
-                .expect("default trusted proxy ranges must parse"),
+            crate::ratelimit::parse_trusted_proxies(&["127.0.0.0/8".into()])
+                .expect("test trusted proxy range must parse"),
         )
     }
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -331,11 +331,14 @@ async fn register_client(
             StatusCode::TOO_MANY_REQUESTS,
             Json(serde_json::json!({
                 "error": "too_many_requests",
-                "error_description": format!("too many client registrations — try again in {retry} seconds")
+                "error_description": crate::ratelimit::retry_after_message(
+                    "too many client registrations",
+                    retry,
+                )
             })),
         )
             .into_response();
-        if let Ok(v) = retry.to_string().parse() {
+        if retry > 0 && let Ok(v) = retry.to_string().parse() {
             resp.headers_mut().insert("retry-after", v);
         }
         return resp;
@@ -944,11 +947,14 @@ async fn device_authorization(
             StatusCode::TOO_MANY_REQUESTS,
             Json(serde_json::json!({
                 "error": "too_many_requests",
-                "error_description": format!("too many device authorization requests — try again in {retry} seconds")
+                "error_description": crate::ratelimit::retry_after_message(
+                    "too many device authorization requests",
+                    retry,
+                )
             })),
         )
             .into_response();
-        if let Ok(v) = retry.to_string().parse() {
+        if retry > 0 && let Ok(v) = retry.to_string().parse() {
             resp.headers_mut().insert("retry-after", v);
         }
         return resp;

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -184,19 +184,19 @@ impl RateLimiter {
 
     /// Keep the bounded table available to new identities. Expired entries are
     /// removed first; if an attacker has filled the table with live keys, evict
-    /// the key whose oldest attempt will expire first instead of permanently
-    /// denying every new identity.
+    /// the least-recently-active key based on its newest attempt. This preserves
+    /// identities that are still actively making attempts.
     fn make_room(map: &mut HashMap<String, Vec<Instant>>, now: Instant, window: Duration) {
         Self::sweep(map, now, window);
         if map.len() < MAX_KEYS {
             return;
         }
-        if let Some(oldest_key) = map
+        if let Some(least_recently_active_key) = map
             .iter()
-            .min_by_key(|(_, entries)| entries.first().copied().unwrap_or(now))
+            .min_by_key(|(_, entries)| entries.last().copied().unwrap_or(now))
             .map(|(key, _)| key.clone())
         {
-            map.remove(&oldest_key);
+            map.remove(&least_recently_active_key);
         }
     }
 
@@ -333,6 +333,39 @@ mod tests {
             assert!(rl.check(&format!("identity-{index}")));
         }
         assert!(rl.check("new-identity"));
+    }
+
+    #[test]
+    fn full_table_evicts_least_recently_active_key() {
+        let now = Instant::now();
+        let window = Duration::from_secs(60);
+        let mut map = HashMap::new();
+
+        // This identity has the oldest attempt, but its newest attempt is
+        // recent and should keep it in the bounded table.
+        map.insert(
+            "high-rate".to_string(),
+            vec![
+                now.checked_sub(Duration::from_secs(30)).unwrap(),
+                now.checked_sub(Duration::from_secs(1)).unwrap(),
+            ],
+        );
+        map.insert(
+            "least-active".to_string(),
+            vec![now.checked_sub(Duration::from_secs(5)).unwrap()],
+        );
+        for index in 0..(MAX_KEYS - 2) {
+            map.insert(
+                format!("active-{index}"),
+                vec![now.checked_sub(Duration::from_secs(2)).unwrap()],
+            );
+        }
+
+        RateLimiter::make_room(&mut map, now, window);
+
+        assert!(map.contains_key("high-rate"));
+        assert!(!map.contains_key("least-active"));
+        assert_eq!(map.len(), MAX_KEYS - 1);
     }
 
     // ── LIF-75: peek() is non-recording ──────────────────────

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -9,6 +9,16 @@ use axum::http::HeaderMap;
 const MAX_KEYS: usize = 10_000;
 const MAX_KEY_BYTES: usize = 1024;
 
+/// Format a rate-limit response without claiming that an unavailable retry
+/// delay is zero seconds.
+pub(crate) fn retry_after_message(prefix: &str, retry_after: u64) -> String {
+    if retry_after == 0 {
+        format!("{prefix} — try again later")
+    } else {
+        format!("{prefix} — try again in {retry_after} seconds")
+    }
+}
+
 /// A validated IP address or CIDR range trusted to supply client-IP headers.
 ///
 /// Plain IPs represent a single host (`/32` for IPv4 or `/128` for IPv6).
@@ -242,11 +252,11 @@ impl RateLimiter {
         if key.len() > MAX_KEY_BYTES {
             return false;
         }
-        let now = Instant::now();
         let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let now = Instant::now();
         match state.attempts.get_mut(key) {
             Some(entry) => {
-                entry.retain(|t| now.duration_since(*t) < self.window);
+                entry.retain(|t| now.saturating_duration_since(*t) < self.window);
                 entry.len() < self.max_attempts
             }
             None => true,
@@ -274,12 +284,12 @@ impl RateLimiter {
 
     /// How many seconds until the oldest attempt in the window expires.
     pub fn retry_after(&self, key: &str) -> u64 {
-        let now = Instant::now();
         let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let now = Instant::now();
         match state.attempts.get(key) {
             Some(entries) if !entries.is_empty() => {
                 let oldest = entries[0];
-                let elapsed = now.duration_since(oldest);
+                let elapsed = now.saturating_duration_since(oldest);
                 if elapsed < self.window {
                     (self.window - elapsed).as_secs() + 1
                 } else {
@@ -303,6 +313,18 @@ impl RateLimiter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retry_after_message_omits_zero_delay() {
+        assert_eq!(
+            retry_after_message("too many requests", 0),
+            "too many requests — try again later"
+        );
+        assert_eq!(
+            retry_after_message("too many requests", 3),
+            "too many requests — try again in 3 seconds"
+        );
+    }
 
     #[test]
     fn allows_under_limit() {

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -5,8 +5,9 @@ use std::time::{Duration, Instant};
 
 use axum::http::HeaderMap;
 
-/// Maximum number of keys before a forced full sweep is triggered.
+/// Maximum number of live keys retained by one limiter.
 const MAX_KEYS: usize = 10_000;
+const MAX_KEY_BYTES: usize = 1024;
 
 /// A validated IP address or CIDR range trusted to supply client-IP headers.
 ///
@@ -157,18 +158,26 @@ pub fn client_ip(peer: IpAddr, headers: &HeaderMap, trusted_proxies: &[IpNetwork
 /// Expired keys are evicted periodically to prevent unbounded memory growth.
 #[derive(Debug)]
 pub struct RateLimiter {
-    /// (key -> list of attempt timestamps)
-    attempts: Mutex<HashMap<String, Vec<Instant>>>,
+    state: Mutex<RateLimitState>,
     /// Maximum attempts allowed within the window.
     max_attempts: usize,
     /// Window duration.
     window: Duration,
 }
 
+#[derive(Debug)]
+struct RateLimitState {
+    attempts: HashMap<String, Vec<Instant>>,
+    last_sweep: Instant,
+}
+
 impl RateLimiter {
     pub fn new(max_attempts: usize, window: Duration) -> Self {
         Self {
-            attempts: Mutex::new(HashMap::new()),
+            state: Mutex::new(RateLimitState {
+                attempts: HashMap::new(),
+                last_sweep: Instant::now(),
+            }),
             max_attempts,
             window,
         }
@@ -183,34 +192,32 @@ impl RateLimiter {
     }
 
     /// Keep the bounded table available to new identities. Expired entries are
-    /// removed first; if an attacker has filled the table with live keys, evict
-    /// the least-recently-active key based on its newest attempt. This preserves
-    /// identities that are still actively making attempts.
-    fn make_room(map: &mut HashMap<String, Vec<Instant>>, now: Instant, window: Duration) {
-        Self::sweep(map, now, window);
-        if map.len() < MAX_KEYS {
-            return;
+    /// removed periodically; live entries are never evicted, so saturation
+    /// cannot reset another identity's security state.
+    fn make_room(state: &mut RateLimitState, now: Instant, window: Duration) -> bool {
+        if now.saturating_duration_since(state.last_sweep) >= window {
+            Self::sweep(&mut state.attempts, now, window);
+            state.last_sweep = now;
         }
-        if let Some(least_recently_active_key) = map
-            .iter()
-            .min_by_key(|(_, entries)| entries.last().copied().unwrap_or(now))
-            .map(|(key, _)| key.clone())
-        {
-            map.remove(&least_recently_active_key);
-        }
+        state.attempts.len() < MAX_KEYS
     }
 
     /// Record an attempt for the given key.
     /// Returns `true` if the attempt is allowed, `false` if rate-limited.
     pub fn check(&self, key: &str) -> bool {
+        if key.len() > MAX_KEY_BYTES {
+            return false;
+        }
         let now = Instant::now();
-        let mut map = self.attempts.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
 
-        if !map.contains_key(key) && map.len() >= MAX_KEYS {
-            Self::make_room(&mut map, now, self.window);
+        if !state.attempts.contains_key(key)
+            && !Self::make_room(&mut state, now, self.window)
+        {
+            return false;
         }
 
-        let entry = map.entry(key.to_string()).or_default();
+        let entry = state.attempts.entry(key.to_string()).or_default();
 
         // Prune expired entries for this key
         entry.retain(|t| now.saturating_duration_since(*t) < self.window);
@@ -232,9 +239,12 @@ impl RateLimiter {
     /// halved the effective limit (LIF-75). Login now `peek()`s, then
     /// records exactly one failure via `record_failure()` on auth failure.
     pub fn peek(&self, key: &str) -> bool {
+        if key.len() > MAX_KEY_BYTES {
+            return false;
+        }
         let now = Instant::now();
-        let mut map = self.attempts.lock().unwrap_or_else(|e| e.into_inner());
-        match map.get_mut(key) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        match state.attempts.get_mut(key) {
             Some(entry) => {
                 entry.retain(|t| now.duration_since(*t) < self.window);
                 entry.len() < self.max_attempts
@@ -245,14 +255,19 @@ impl RateLimiter {
 
     /// Record a failed attempt without checking first (for tracking after auth failure).
     pub fn record_failure(&self, key: &str) {
+        if key.len() > MAX_KEY_BYTES {
+            return;
+        }
         let now = Instant::now();
-        let mut map = self.attempts.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
 
-        if !map.contains_key(key) && map.len() >= MAX_KEYS {
-            Self::make_room(&mut map, now, self.window);
+        if !state.attempts.contains_key(key)
+            && !Self::make_room(&mut state, now, self.window)
+        {
+            return;
         }
 
-        let entry = map.entry(key.to_string()).or_default();
+        let entry = state.attempts.entry(key.to_string()).or_default();
         entry.retain(|t| now.saturating_duration_since(*t) < self.window);
         entry.push(now);
     }
@@ -260,8 +275,8 @@ impl RateLimiter {
     /// How many seconds until the oldest attempt in the window expires.
     pub fn retry_after(&self, key: &str) -> u64 {
         let now = Instant::now();
-        let map = self.attempts.lock().unwrap_or_else(|e| e.into_inner());
-        match map.get(key) {
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        match state.attempts.get(key) {
             Some(entries) if !entries.is_empty() => {
                 let oldest = entries[0];
                 let elapsed = now.duration_since(oldest);
@@ -273,6 +288,15 @@ impl RateLimiter {
             }
             _ => 0,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_key(&self, key: &str) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .attempts
+            .contains_key(key)
     }
 }
 
@@ -327,45 +351,38 @@ mod tests {
     }
 
     #[test]
-    fn full_table_evicts_old_identity_for_new_key() {
+    fn full_table_rejects_new_identity_without_evicting_existing_state() {
         let rl = RateLimiter::new(1, Duration::from_secs(60));
         for index in 0..MAX_KEYS {
             assert!(rl.check(&format!("identity-{index}")));
         }
-        assert!(rl.check("new-identity"));
+        assert!(!rl.check("new-identity"));
+        assert!(!rl.check("identity-0"));
     }
 
     #[test]
-    fn full_table_evicts_least_recently_active_key() {
-        let now = Instant::now();
-        let window = Duration::from_secs(60);
-        let mut map = HashMap::new();
+    fn expired_keys_are_swept_before_admitting_new_identity() {
+        let rl = RateLimiter::new(1, Duration::ZERO);
+        assert!(rl.check("expired"));
+        assert!(rl.check("new"));
+    }
 
-        // This identity has the oldest attempt, but its newest attempt is
-        // recent and should keep it in the bounded table.
-        map.insert(
-            "high-rate".to_string(),
-            vec![
-                now.checked_sub(Duration::from_secs(30)).unwrap(),
-                now.checked_sub(Duration::from_secs(1)).unwrap(),
-            ],
-        );
-        map.insert(
-            "least-active".to_string(),
-            vec![now.checked_sub(Duration::from_secs(5)).unwrap()],
-        );
-        for index in 0..(MAX_KEYS - 2) {
-            map.insert(
-                format!("active-{index}"),
-                vec![now.checked_sub(Duration::from_secs(2)).unwrap()],
-            );
-        }
+    #[test]
+    fn oversized_keys_are_rejected_without_allocation() {
+        let rl = RateLimiter::new(1, Duration::from_secs(60));
+        let oversized = "x".repeat(MAX_KEY_BYTES + 1);
+        assert!(!rl.check(&oversized));
+        assert!(!rl.peek(&oversized));
+        rl.record_failure(&oversized);
+        assert_eq!(rl.retry_after(&oversized), 0);
+    }
 
-        RateLimiter::make_room(&mut map, now, window);
-
-        assert!(map.contains_key("high-rate"));
-        assert!(!map.contains_key("least-active"));
-        assert_eq!(map.len(), MAX_KEYS - 1);
+    #[test]
+    fn default_proxy_configuration_does_not_trust_loopback_headers() {
+        let peer = "127.0.0.1".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "198.51.100.9".parse().unwrap());
+        assert_eq!(client_ip(peer, &headers, &[]), "127.0.0.1");
     }
 
     // ── LIF-75: peek() is non-recording ──────────────────────

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -175,12 +175,29 @@ impl RateLimiter {
     }
 
     /// Remove all keys whose attempt lists are empty or fully expired.
-    fn sweep(map: &mut HashMap<String, Vec<Instant>>, window: Duration) {
-        let now = Instant::now();
+    fn sweep(map: &mut HashMap<String, Vec<Instant>>, now: Instant, window: Duration) {
         map.retain(|_, entries| {
-            entries.retain(|t| now.duration_since(*t) < window);
+            entries.retain(|t| now.saturating_duration_since(*t) < window);
             !entries.is_empty()
         });
+    }
+
+    /// Keep the bounded table available to new identities. Expired entries are
+    /// removed first; if an attacker has filled the table with live keys, evict
+    /// the key whose oldest attempt will expire first instead of permanently
+    /// denying every new identity.
+    fn make_room(map: &mut HashMap<String, Vec<Instant>>, now: Instant, window: Duration) {
+        Self::sweep(map, now, window);
+        if map.len() < MAX_KEYS {
+            return;
+        }
+        if let Some(oldest_key) = map
+            .iter()
+            .min_by_key(|(_, entries)| entries.first().copied().unwrap_or(now))
+            .map(|(key, _)| key.clone())
+        {
+            map.remove(&oldest_key);
+        }
     }
 
     /// Record an attempt for the given key.
@@ -189,15 +206,14 @@ impl RateLimiter {
         let now = Instant::now();
         let mut map = self.attempts.lock().unwrap_or_else(|e| e.into_inner());
 
-        // Evict expired keys if map is getting large
-        if map.len() > MAX_KEYS {
-            Self::sweep(&mut map, self.window);
+        if !map.contains_key(key) && map.len() >= MAX_KEYS {
+            Self::make_room(&mut map, now, self.window);
         }
 
         let entry = map.entry(key.to_string()).or_default();
 
         // Prune expired entries for this key
-        entry.retain(|t| now.duration_since(*t) < self.window);
+        entry.retain(|t| now.saturating_duration_since(*t) < self.window);
 
         if entry.len() >= self.max_attempts {
             return false;
@@ -232,12 +248,12 @@ impl RateLimiter {
         let now = Instant::now();
         let mut map = self.attempts.lock().unwrap_or_else(|e| e.into_inner());
 
-        if map.len() > MAX_KEYS {
-            Self::sweep(&mut map, self.window);
+        if !map.contains_key(key) && map.len() >= MAX_KEYS {
+            Self::make_room(&mut map, now, self.window);
         }
 
         let entry = map.entry(key.to_string()).or_default();
-        entry.retain(|t| now.duration_since(*t) < self.window);
+        entry.retain(|t| now.saturating_duration_since(*t) < self.window);
         entry.push(now);
     }
 
@@ -306,8 +322,17 @@ mod tests {
         // Wait for it to expire
         std::thread::sleep(Duration::from_millis(5));
 
-        RateLimiter::sweep(&mut map, window);
+        RateLimiter::sweep(&mut map, Instant::now(), window);
         assert!(map.is_empty(), "expired keys should be evicted");
+    }
+
+    #[test]
+    fn full_table_evicts_old_identity_for_new_key() {
+        let rl = RateLimiter::new(1, Duration::from_secs(60));
+        for index in 0..MAX_KEYS {
+            assert!(rl.check(&format!("identity-{index}")));
+        }
+        assert!(rl.check("new-identity"));
     }
 
     // ── LIF-75: peek() is non-recording ──────────────────────


### PR DESCRIPTION
## Problem

The default configuration trusted loopback peers as proxies, so any local process could forge `X-Forwarded-For` or `X-Real-IP` and rotate per-IP login, signup, and OAuth limiter keys. Signup also allocated attacker-controlled email keys before discovering that the source IP was already blocked. The limiter accepted oversized caller-controlled keys and performed repeated full-table work at capacity.

## Changes

- Default `server.trusted_proxies` to an empty list. Forwarded headers are honored only for explicitly configured proxy ranges; test fixtures opt in explicitly.
- Check the signup IP bucket before allocating the email bucket.
- Bound limiter keys to 1024 bytes and retain at most 10,000 live keys.
- Sweep expired keys periodically and reject new live keys at saturation instead of evicting another identity's security state.
- Keep explicit trusted-proxy chain parsing behavior and update configuration documentation.
- Add regressions for default loopback spoofing, blocked-signup allocation, oversized keys, expired-key admission, and live-state preservation.

## Tests

- `cargo check`
- `cargo nextest run 'api::auth::tests' config::tests ratelimit` (96 tests passed)