### PR TITLE
Restrict attachment references to authorized project scope

### DIFF
--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -165,6 +165,17 @@ pub(super) async fn upload_attachment(
         )));
     }
 
+    // An upload may link immediately only when the caller can mutate the
+    // target entity. Do this before writing the blob/metadata so a denied
+    // cross-project target cannot leave an orphaned upload behind.
+    if let (Some(entity), Some(entity_id)) = (link_entity, link_entity_id) {
+        authorize_link_target(&db, &identity, entity, entity_id)?;
+    } else if link_entity.is_some() || link_entity_id.is_some() {
+        return Err(LificError::BadRequest(
+            "entity_type and entity_id must be provided together".into(),
+        ));
+    }
+
     let size = bytes.len() as i64;
     // Store bytes first (content-addressed), then record metadata.
     let sha = store.write(&bytes)?;
@@ -225,6 +236,38 @@ pub(super) async fn upload_attachment(
         has_thumbnail: attachment.has_thumbnail,
     };
     Ok((StatusCode::OK, axum::Json(resp)).into_response())
+}
+
+fn authorize_link_target(
+    db: &DbPool,
+    identity: &Option<crate::resolve_caller::ResolvedIdentity>,
+    entity: AttachmentEntity,
+    entity_id: i64,
+) -> Result<(), LificError> {
+    match entity {
+        AttachmentEntity::Issue => {
+            let project_id = with_read(db, |conn| {
+                Ok(queries::get_issue(conn, entity_id)?.project_id)
+            })?;
+            authz::require_role(db, identity, project_id, Role::Maintainer)
+        }
+        AttachmentEntity::Page => {
+            let project_id = with_read(db, |conn| {
+                queries::get_page(conn, entity_id).map(|p| p.project_id)
+            })?;
+            match project_id {
+                Some(pid) => authz::require_role(db, identity, pid, Role::Maintainer),
+                None => authz::require_workspace_admin(db, identity),
+            }
+        }
+        AttachmentEntity::Comment => {
+            let project_id = resolve_entity_project(db, entity, entity_id)?;
+            match project_id {
+                Some(pid) => authz::require_role(db, identity, pid, Role::Viewer),
+                None => authz::require_workspace_admin(db, identity),
+            }
+        }
+    }
 }
 
 /// Query params for `GET /api/attachments?entity_type=&entity_id=` — lists the

--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -946,6 +946,28 @@ fn linked_attachment_events(
 
 // ── Authorization helpers ────────────────────────────────────
 
+/// Re-scan markdown references while preserving the caller's ownership and
+/// project scope for newly introduced attachment links.
+pub(crate) fn sync_links_scoped(
+    conn: &rusqlite::Connection,
+    entity: AttachmentEntity,
+    entity_id: i64,
+    markdown: &str,
+    user: &AuthUser,
+    project_id: Option<i64>,
+) -> Result<(), LificError> {
+    let ids = q::parse_referenced_ids(markdown);
+    q::sync_entity_links(
+        conn,
+        entity,
+        entity_id,
+        &ids,
+        user.id,
+        user.is_admin,
+        project_id,
+    )
+}
+
 /// Resolve every distinct project id an attachment is linked into (via its
 /// issue/page/comment links). Empty when the attachment is unlinked.
 fn owning_project_ids(

--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -80,14 +80,6 @@ fn create_for_parent(
             content,
             member_scoped,
         )?;
-        super::attachments::sync_links_scoped(
-            conn,
-            crate::db::models::AttachmentEntity::Comment,
-            comment.id,
-            &comment.content,
-            &user,
-            project_id,
-        )?;
         Ok((comment, project_id))
     })?;
     if let Some(project_id) = project_id {
@@ -206,14 +198,6 @@ pub(super) async fn update_comment_handler(
             CommentActor::from(&user),
             &input.content,
             member_scoped,
-        )?;
-        super::attachments::sync_links_scoped(
-            conn,
-            crate::db::models::AttachmentEntity::Comment,
-            comment.id,
-            &comment.content,
-            &user,
-            project_id,
         )?;
         Ok((comment, context))
     })?;

--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -10,7 +10,6 @@ use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
 use super::{require_user, with_read};
-
 fn require_comment_viewer(
     db: &DbPool,
     identity: &Option<crate::resolve_caller::ResolvedIdentity>,
@@ -81,9 +80,16 @@ fn create_for_parent(
             content,
             member_scoped,
         )?;
+        super::attachments::sync_links_scoped(
+            conn,
+            crate::db::models::AttachmentEntity::Comment,
+            comment.id,
+            &comment.content,
+            &user,
+            project_id,
+        )?;
         Ok((comment, project_id))
     })?;
-
     if let Some(project_id) = project_id {
         realtime.send(match parent {
             CommentParent::Issue(issue_id) => issue_updated_event(project_id, issue_id),
@@ -200,6 +206,14 @@ pub(super) async fn update_comment_handler(
             CommentActor::from(&user),
             &input.content,
             member_scoped,
+        )?;
+        super::attachments::sync_links_scoped(
+            conn,
+            crate::db::models::AttachmentEntity::Comment,
+            comment.id,
+            &comment.content,
+            &user,
+            project_id,
         )?;
         Ok((comment, context))
     })?;

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -57,14 +57,17 @@ pub(super) async fn create_issue(
     Json(input): Json<CreateIssue>,
 ) -> Result<Json<Issue>, LificError> {
     authz::require_role(&db, &identity, input.project_id, Role::Maintainer)?;
+    let user = super::require_user(&identity)?;
     let issue = with_write(&db, |conn| {
         let issue = crate::db::queries::create_issue(conn, &input)?;
         // LIF-262: link any attachments the description references.
-        crate::db::queries::attachments::sync_links(
+        super::attachments::sync_links_scoped(
             conn,
             AttachmentEntity::Issue,
             issue.id,
             &issue.description,
+            &user,
+            Some(issue.project_id),
         )?;
         Ok(issue)
     })?;
@@ -84,14 +87,17 @@ pub(super) async fn update_issue(
 ) -> Result<Json<Issue>, LificError> {
     let project_id = with_read(&db, |conn| crate::db::queries::get_issue(conn, id))?.project_id;
     authz::require_role(&db, &identity, project_id, Role::Maintainer)?;
+    let user = super::require_user(&identity)?;
     let issue = with_write(&db, |conn| {
         let issue = crate::db::queries::update_issue(conn, id, &input)?;
         // LIF-262: re-scan the (possibly edited) description and reconcile links.
-        crate::db::queries::attachments::sync_links(
+        super::attachments::sync_links_scoped(
             conn,
             AttachmentEntity::Issue,
             issue.id,
             &issue.description,
+            &user,
+            Some(issue.project_id),
         )?;
         Ok(issue)
     })?;

--- a/src/api/pages.rs
+++ b/src/api/pages.rs
@@ -120,14 +120,17 @@ pub(super) async fn create_page(
     Json(input): Json<CreatePage>,
 ) -> Result<Json<Page>, LificError> {
     require_page_role(&db, &identity, input.project_id, Role::Maintainer)?;
+    let user = super::require_user(&identity)?;
     let page = with_write(&db, |conn| {
         let page = crate::db::queries::create_page(conn, &input)?;
         // LIF-262: link any attachments the content references.
-        crate::db::queries::attachments::sync_links(
+        super::attachments::sync_links_scoped(
             conn,
             AttachmentEntity::Page,
             page.id,
             &page.content,
+            &user,
+            page.project_id,
         )?;
         Ok(page)
     })?;
@@ -146,14 +149,17 @@ pub(super) async fn update_page(
 ) -> Result<Json<Page>, LificError> {
     let project_id = with_read(&db, |conn| crate::db::queries::get_page(conn, id))?.project_id;
     require_page_role(&db, &identity, project_id, Role::Maintainer)?;
+    let user = super::require_user(&identity)?;
     let page = with_write(&db, |conn| {
         let page = crate::db::queries::update_page(conn, id, &input)?;
         // LIF-262: re-scan the (possibly edited) content and reconcile links.
-        crate::db::queries::attachments::sync_links(
+        super::attachments::sync_links_scoped(
             conn,
             AttachmentEntity::Page,
             page.id,
             &page.content,
+            &user,
+            page.project_id,
         )?;
         Ok(page)
     })?;

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -271,6 +271,9 @@ pub fn sync_entity_links(
     entity: AttachmentEntity,
     entity_id: i64,
     referenced_ids: &[i64],
+    user_id: i64,
+    is_admin: bool,
+    project_id: Option<i64>,
 ) -> Result<(), LificError> {
     // Current links for this entity.
     let mut stmt = conn.prepare_cached(
@@ -290,11 +293,65 @@ pub fn sync_entity_links(
     // attachment row — a stale/typo reference in the text shouldn't create a
     // dangling link).
     for id in referenced_ids {
-        if !current.contains(id) && attachment_exists(conn, *id)? {
+        if !current.contains(id)
+            && attachment_allowed_for_entity(conn, *id, user_id, is_admin, project_id)?
+        {
             link_attachment(conn, *id, entity, entity_id)?;
         }
     }
     Ok(())
+}
+
+/// An attachment may be introduced into a document only by its uploader (or
+/// an administrator), or when it is already linked to another entity in the
+/// same project. This prevents a user who can edit one document from guessing
+/// another user's unlinked attachment id and importing it into that document.
+fn attachment_allowed_for_entity(
+    conn: &Connection,
+    attachment_id: i64,
+    user_id: i64,
+    is_admin: bool,
+    project_id: Option<i64>,
+) -> Result<bool, LificError> {
+    if is_admin {
+        return attachment_exists(conn, attachment_id);
+    }
+    let owned: Option<Option<i64>> = conn
+        .query_row(
+            "SELECT uploader_id FROM attachments WHERE id = ?1",
+            params![attachment_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if owned == Some(Some(user_id)) {
+        return Ok(true);
+    }
+    let Some(project_id) = project_id else {
+        return Ok(false);
+    };
+    let linked: Option<i64> = conn
+        .query_row(
+            "SELECT 1
+             FROM attachment_links l
+             WHERE l.attachment_id = ?1
+               AND (
+                 (l.entity_type = 'issue' AND EXISTS
+                    (SELECT 1 FROM issues i WHERE i.id = l.entity_id AND i.project_id = ?2))
+                 OR (l.entity_type = 'page' AND EXISTS
+                    (SELECT 1 FROM pages p WHERE p.id = l.entity_id AND p.project_id = ?2))
+                 OR (l.entity_type = 'comment' AND EXISTS
+                    (SELECT 1 FROM comments c
+                     LEFT JOIN issues i ON i.id = c.issue_id
+                     LEFT JOIN pages p ON p.id = c.page_id
+                     WHERE c.id = l.entity_id
+                       AND (i.project_id = ?2 OR p.project_id = ?2)))
+               )
+             LIMIT 1",
+            params![attachment_id, project_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(linked.is_some())
 }
 
 fn attachment_exists(conn: &Connection, id: i64) -> Result<bool, LificError> {
@@ -1064,7 +1121,7 @@ pub fn sync_links(
     markdown: &str,
 ) -> Result<(), LificError> {
     let ids = parse_referenced_ids(markdown);
-    sync_entity_links(conn, entity, entity_id, &ids)
+    sync_entity_links(conn, entity, entity_id, &ids, 0, false, None)
 }
 
 /// Reconcile attachment links without allowing references to import an
@@ -1238,7 +1295,8 @@ mod tests {
         let c = create_attachment(&conn, "c", "c.png", "image/png", 1, None).unwrap();
 
         // Start linking a + b.
-        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[a.id, b.id]).unwrap();
+        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[a.id, b.id], 0, true, Some(1))
+            .unwrap();
         let ids: Vec<i64> = list_for_entity(&conn, AttachmentEntity::Issue, issue)
             .unwrap()
             .into_iter()
@@ -1247,7 +1305,8 @@ mod tests {
         assert_eq!(ids, vec![a.id, b.id]);
 
         // Re-sync to b + c: a is unlinked, c is added.
-        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[b.id, c.id]).unwrap();
+        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[b.id, c.id], 0, true, Some(1))
+            .unwrap();
         let mut ids: Vec<i64> = list_for_entity(&conn, AttachmentEntity::Issue, issue)
             .unwrap()
             .into_iter()
@@ -1265,11 +1324,74 @@ mod tests {
         let conn = pool.write().unwrap();
         let issue = seed_issue(&conn);
         // 99999 doesn't exist — must not create a dangling link.
-        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[99999]).unwrap();
+        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[99999], 0, true, Some(1))
+            .unwrap();
         assert!(
             list_for_entity(&conn, AttachmentEntity::Issue, issue)
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn sync_does_not_import_unlinked_attachment_from_another_user() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let owner = seed_user(&conn, "owner");
+        let editor = seed_user(&conn, "editor");
+        let issue = seed_issue(&conn);
+        let att = create_attachment(&conn, "foreign", "f.png", "image/png", 1, Some(owner))
+            .unwrap();
+
+        sync_entity_links(
+            &conn,
+            AttachmentEntity::Issue,
+            issue,
+            &[att.id],
+            editor,
+            false,
+            Some(1),
+        )
+        .unwrap();
+        assert!(list_for_entity(&conn, AttachmentEntity::Issue, issue)
+            .unwrap()
+            .is_empty());
+
+        // Once the owner has placed the attachment in the same project, a
+        // maintainer editing another entity in that project may reference it.
+        link_attachment(&conn, att.id, AttachmentEntity::Issue, issue).unwrap();
+        let second = queries::create_issue(
+            &conn,
+            &crate::db::models::CreateIssue {
+                project_id: queries::get_issue(&conn, issue).unwrap().project_id,
+                title: "second".into(),
+                description: String::new(),
+                status: "todo".into(),
+                priority: "medium".into(),
+                module_id: None,
+                start_date: None,
+                target_date: None,
+                labels: vec![],
+                source: None,
+            },
+        )
+        .unwrap()
+        .id;
+        sync_entity_links(
+            &conn,
+            AttachmentEntity::Issue,
+            second,
+            &[att.id],
+            editor,
+            false,
+            Some(1),
+        )
+        .unwrap();
+        assert_eq!(
+            list_for_entity(&conn, AttachmentEntity::Issue, second)
+                .unwrap()
+                .len(),
+            1
         );
     }
 

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -1119,9 +1119,12 @@ pub fn sync_links(
     entity: AttachmentEntity,
     entity_id: i64,
     markdown: &str,
+    user_id: i64,
+    is_admin: bool,
+    project_id: Option<i64>,
 ) -> Result<(), LificError> {
     let ids = parse_referenced_ids(markdown);
-    sync_entity_links(conn, entity, entity_id, &ids, 0, false, None)
+    sync_entity_links(conn, entity, entity_id, &ids, user_id, is_admin, project_id)
 }
 
 /// Reconcile attachment links without allowing references to import an
@@ -1140,7 +1143,15 @@ pub fn sync_links_scoped(
             allowed.push(attachment_id);
         }
     }
-    sync_entity_links(conn, entity, entity_id, &allowed)
+    sync_entity_links(
+        conn,
+        entity,
+        entity_id,
+        &allowed,
+        actor.user_id,
+        actor.is_admin,
+        project_id,
+    )
 }
 
 #[cfg(test)]
@@ -1366,8 +1377,8 @@ mod tests {
                 project_id: queries::get_issue(&conn, issue).unwrap().project_id,
                 title: "second".into(),
                 description: String::new(),
-                status: "todo".into(),
-                priority: "medium".into(),
+                status: crate::db::models::Status::Todo,
+                priority: crate::db::models::Priority::Medium,
                 module_id: None,
                 start_date: None,
                 target_date: None,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1307,6 +1307,11 @@ impl LificMcp {
         require_page_role_mcp(&self.db, project_id, minimum_role)
     }
 
+    fn resolve_mcp_actor(&self) -> Result<(i64, bool), String> {
+        self.read(resolve_comment_actor_conn)
+            .map(|identity| (identity.user.id, identity.user.is_admin))
+    }
+
     /// LIF-198: if `step_id` has a linked issue, require `min` role on that
     /// issue's own project too — the same "both sides" check `link_issues`
     /// applies, since a step's issue can live in a different project than
@@ -1907,6 +1912,7 @@ impl LificMcp {
             Some(name) => Some(resolve_module(&conn, pid, name)?),
             None => None,
         };
+        let (actor_id, actor_is_admin) = self.resolve_mcp_actor()?;
         drop(conn);
         let issue = self.write(|conn| {
             let issue = queries::create_issue(
@@ -1935,6 +1941,9 @@ impl LificMcp {
                 models::AttachmentEntity::Issue,
                 issue.id,
                 &issue.description,
+                actor_id,
+                actor_is_admin,
+                Some(issue.project_id),
             )?;
             Ok(issue)
         })?;
@@ -1968,6 +1977,7 @@ impl LificMcp {
             Ok((id, project_id))
         })?;
         require_role_mcp(&self.db, project_id, models::Role::Maintainer)?;
+        let (actor_id, actor_is_admin) = self.resolve_mcp_actor()?;
         let (issue, cascade_action, cascaded_steps) = self.write(|conn| {
             // Migration 020's cascades key exclusively on transitions to or
             // from `done`, not on the broader cancelled/open distinction.
@@ -2018,6 +2028,9 @@ impl LificMcp {
                 models::AttachmentEntity::Issue,
                 issue.id,
                 &issue.description,
+                actor_id,
+                actor_is_admin,
+                Some(issue.project_id),
             )?;
             let cascade_action = match (previous_issue.status.as_str(), issue.status.as_str()) {
                 (previous, "done") if previous != "done" => {
@@ -2155,6 +2168,7 @@ impl LificMcp {
             Ok((id, project_id))
         })?;
         require_role_mcp(&self.db, project_id, models::Role::Maintainer)?;
+        let (actor_id, actor_is_admin) = self.resolve_mcp_actor()?;
         let issue = self.write(|conn| {
             let issue = queries::get_issue(conn, id)?;
 
@@ -2201,6 +2215,9 @@ impl LificMcp {
                 models::AttachmentEntity::Issue,
                 issue.id,
                 &issue.description,
+                actor_id,
+                actor_is_admin,
+                Some(issue.project_id),
             )?;
             Ok(issue)
         })?;
@@ -2512,6 +2529,7 @@ impl LificMcp {
             None => None,
         };
         require_page_role_mcp(&self.db, project_id, models::Role::Maintainer)?;
+        let (actor_id, actor_is_admin) = self.resolve_mcp_actor()?;
         let folder_id = match (&input.folder, project_id) {
             (Some(name), Some(pid)) => Some(resolve_folder(&conn, pid, name)?),
             (Some(_), None) => return Err("folder requires a project".into()),
@@ -2537,6 +2555,9 @@ impl LificMcp {
                 models::AttachmentEntity::Page,
                 page.id,
                 &page.content,
+                actor_id,
+                actor_is_admin,
+                page.project_id,
             )?;
             Ok(page)
         })?;
@@ -2566,6 +2587,7 @@ impl LificMcp {
             Ok((id, project_id))
         })?;
         require_page_role_mcp(&self.db, project_id, models::Role::Maintainer)?;
+        let (actor_id, actor_is_admin) = self.resolve_mcp_actor()?;
         let page = self.write(|conn| {
             // LIF-145 sentinel: field omitted (None) = skip, empty string = clear
             // (move page to root), non-empty = resolve folder + set.
@@ -2602,6 +2624,9 @@ impl LificMcp {
                 models::AttachmentEntity::Page,
                 page.id,
                 &page.content,
+                actor_id,
+                actor_is_admin,
+                page.project_id,
             )?;
             Ok(page)
         })?;
@@ -2633,6 +2658,7 @@ impl LificMcp {
             Ok((id, project_id))
         })?;
         require_page_role_mcp(&self.db, project_id, models::Role::Maintainer)?;
+        let (actor_id, actor_is_admin) = self.resolve_mcp_actor()?;
         let page = self.write(|conn| {
             let page = queries::get_page(conn, id)?;
 
@@ -2678,6 +2704,9 @@ impl LificMcp {
                 models::AttachmentEntity::Page,
                 page.id,
                 &page.content,
+                actor_id,
+                actor_is_admin,
+                page.project_id,
             )?;
             Ok(page)
         })?;


### PR DESCRIPTION
## Summary

Prevent issue, page, and comment Markdown updates from importing an attachment solely by knowing its numeric ID. Newly introduced references are accepted when the caller uploaded the attachment, is an administrator, or the attachment is already linked within the destination project.

## Implementation

- Carry caller identity and destination-project context into attachment-link reconciliation.
- Apply the same ownership and project-scope rule to REST and MCP issue/page create, update, and edit paths; comment writes continue through the scoped transaction path.
- Preserve removal of stale links while filtering unauthorized newly introduced references.
- Reject an immediate REST upload when only one successfully parsed target field is present, before writing attachment bytes or metadata.

## Tests

The added reconciliation test creates an attachment owned by one user and verifies that another user cannot introduce it while it is unlinked. It then links the attachment within the project and verifies that the second user can reuse it on another issue in that same project.