### PR TITLE
Bound export construction and delivery across HTTP and MCP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ include = [
 # HTTP
 axum = { version = "0.8", features = ["json", "multipart", "ws"] }
 tokio = { version = "1", features = ["full"] }
+futures-util = "0.3"
 tower-http = { version = "0.6", features = ["cors", "compression-gzip", "compression-br"] }
 # HTTP client — used by `lific doctor` to probe a running server (reachability,
 # OAuth discovery, MCP round-trip). rustls-tls (no OpenSSL linkage) so the
@@ -110,7 +111,6 @@ tempfile = "3"
 libc = "0.2"
 
 [dev-dependencies]
-futures-util = "0.3"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 # Scratch directories for tests. Replaces hand-rolled

--- a/src/api/export.rs
+++ b/src/api/export.rs
@@ -179,10 +179,6 @@ async fn stream_response_with_timeouts(
     idle_timeout: Duration,
     max_duration: Duration,
 ) -> Result<axum::response::Response, LificError> {
-    let content_length = tokio::fs::metadata(&prepared.path)
-        .await
-        .map_err(|error| LificError::Internal(format!("stat export file: {error}")))?
-        .len();
     let mut file = tokio::fs::File::open(&prepared.path)
         .await
         .map_err(|error| LificError::Internal(format!("open export file: {error}")))?;
@@ -198,15 +194,12 @@ async fn stream_response_with_timeouts(
                     Ok(read) => {
                         let chunk =
                             Ok::<_, std::io::Error>(Bytes::copy_from_slice(&buffer[..read]));
-                        if !matches!(
-                            tokio::time::timeout(idle_timeout, sender.send(chunk)).await,
-                            Ok(Ok(()))
-                        ) {
+                        if !send_stream_item(&sender, chunk, idle_timeout).await {
                             break;
                         }
                     }
                     Err(error) => {
-                        let _ = sender.try_send(Err(error));
+                        let _ = send_stream_item(&sender, Err(error), idle_timeout).await;
                         break;
                     }
                 }
@@ -223,12 +216,18 @@ async fn stream_response_with_timeouts(
     if let Some(filename) = prepared.download_name {
         headers.insert(header::CONTENT_DISPOSITION, content_disposition(&filename)?);
     }
-    headers.insert(
-        header::CONTENT_LENGTH,
-        HeaderValue::from_str(&content_length.to_string())
-            .map_err(|error| LificError::Internal(format!("invalid export length: {error}")))?,
-    );
     Ok((headers, body).into_response())
+}
+
+async fn send_stream_item(
+    sender: &tokio::sync::mpsc::Sender<Result<Bytes, std::io::Error>>,
+    item: Result<Bytes, std::io::Error>,
+    idle_timeout: Duration,
+) -> bool {
+    matches!(
+        tokio::time::timeout(idle_timeout, sender.send(item)).await,
+        Ok(Ok(()))
+    )
 }
 
 fn content_disposition(filename: &str) -> Result<HeaderValue, LificError> {
@@ -339,6 +338,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use axum::body::Bytes;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
@@ -537,18 +537,35 @@ mod tests {
             resp.headers()[axum::http::header::CONTENT_TYPE],
             "application/zip"
         );
-        let content_length = resp
-            .headers()
-            .get(axum::http::header::CONTENT_LENGTH)
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .parse::<usize>()
-            .unwrap();
-        assert!(content_length > 0);
+        assert!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_LENGTH)
+                .is_none()
+        );
         let body = resp.into_body().collect().await.unwrap().to_bytes();
-        assert_eq!(body.len(), content_length);
+        assert!(!body.is_empty());
         assert_eq!(&body[..2], b"PK");
+    }
+
+    #[tokio::test]
+    async fn stream_error_waits_for_the_queued_chunk() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        sender.send(Ok(Bytes::from_static(b"chunk"))).await.unwrap();
+        let send_error = tokio::spawn(async move {
+            super::send_stream_item(
+                &sender,
+                Err(std::io::Error::other("read failed")),
+                Duration::from_secs(1),
+            )
+            .await
+        });
+
+        assert_eq!(receiver.recv().await.unwrap().unwrap(), "chunk");
+        assert!(send_error.await.unwrap());
+        assert_eq!(
+            receiver.recv().await.unwrap().unwrap_err().to_string(),
+            "read failed"
+        );
     }
 
     #[tokio::test]

--- a/src/api/export.rs
+++ b/src/api/export.rs
@@ -1,7 +1,11 @@
 use axum::Extension;
+use axum::body::{Body, Bytes};
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::IntoResponse;
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
+use tokio::sync::OwnedSemaphorePermit;
 
 use crate::authz;
 use crate::db::DbPool;
@@ -10,42 +14,221 @@ use crate::error::LificError;
 
 use super::with_read;
 
-/// `?format=json` returns the raw [`crate::export::ExportBundle`] instead of
-/// a file body. The CLI's HTTP backend uses it for single-resource exports so
-/// it can write the bundle through the same writer the SQL backend uses, and
-/// so land the file at the same nested path rather than a bare basename
-/// (LIF-341). Project exports keep `zip` as their default.
+const EXPORT_STREAM_CHUNK_BYTES: usize = 64 * 1024;
+const EXPORT_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const EXPORT_STREAM_MAX_DURATION: Duration = Duration::from_secs(30 * 60);
+
 #[derive(serde::Deserialize)]
 pub(super) struct ExportQuery {
     pub format: Option<String>,
 }
 
-/// A single-resource export renders one file; `format=json` hands back the
-/// whole bundle so the caller knows the path it belongs at.
-fn single_file_response(
-    bundle: crate::export::ExportBundle,
-    format: Option<&str>,
-    fallback_name: &str,
-) -> Result<axum::response::Response, LificError> {
-    match format.unwrap_or("markdown") {
-        "json" => Ok(axum::Json(bundle).into_response()),
-        "markdown" => {
-            let file = bundle.files.into_iter().next().ok_or_else(|| {
-                LificError::Internal(format!("export produced no files for {fallback_name}"))
-            })?;
-            let filename = file.path.rsplit('/').next().unwrap_or(fallback_name);
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                header::CONTENT_TYPE,
-                HeaderValue::from_static("text/markdown; charset=utf-8"),
-            );
-            headers.insert(header::CONTENT_DISPOSITION, content_disposition(filename)?);
-            Ok((headers, file.content).into_response())
-        }
-        _ => Err(LificError::BadRequest(
-            "invalid export format. Expected 'markdown' or 'json'".into(),
-        )),
+struct PreparedExport {
+    temp_dir: tempfile::TempDir,
+    path: std::path::PathBuf,
+    content_type: HeaderValue,
+    download_name: Option<String>,
+}
+
+impl PreparedExport {
+    fn json(bundle: &crate::export::ExportBundle) -> Result<Self, LificError> {
+        let temp_dir = export_temp_dir()?;
+        let path = temp_dir.path().join("export.json");
+        crate::export::bundle_to_json_file(bundle, &path)?;
+        Ok(Self {
+            temp_dir,
+            path,
+            content_type: HeaderValue::from_static("application/json"),
+            download_name: None,
+        })
     }
+
+    fn markdown(
+        bundle: crate::export::ExportBundle,
+        fallback_name: &str,
+    ) -> Result<Self, LificError> {
+        let file = bundle.files.into_iter().next().ok_or_else(|| {
+            LificError::Internal(format!("export produced no files for {fallback_name}"))
+        })?;
+        let download_name = file.path.rsplit('/').next().unwrap_or(fallback_name).to_string();
+        let temp_dir = export_temp_dir()?;
+        let path = temp_dir.path().join("export.md");
+        std::fs::write(&path, file.content)
+            .map_err(|error| LificError::Internal(format!("write export file: {error}")))?;
+        Ok(Self {
+            temp_dir,
+            path,
+            content_type: HeaderValue::from_static("text/markdown; charset=utf-8"),
+            download_name: Some(download_name),
+        })
+    }
+
+    fn zip(bundle: &crate::export::ExportBundle) -> Result<Self, LificError> {
+        let download_name = format!("{}-export.zip", bundle.root.to_ascii_lowercase());
+        let temp_dir = export_temp_dir()?;
+        let path = temp_dir.path().join("export.zip");
+        crate::export::bundle_to_zip_file(bundle, &path)?;
+        Ok(Self {
+            temp_dir,
+            path,
+            content_type: HeaderValue::from_static("application/zip"),
+            download_name: Some(download_name),
+        })
+    }
+}
+
+fn export_temp_dir() -> Result<tempfile::TempDir, LificError> {
+    tempfile::tempdir()
+        .map_err(|error| LificError::Internal(format!("create export temp dir: {error}")))
+}
+
+async fn blocking<T>(
+    operation: impl FnOnce() -> Result<T, LificError> + Send + 'static,
+) -> Result<T, LificError>
+where
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|error| LificError::Internal(format!("export worker failed: {error}")))?
+}
+
+#[cfg(test)]
+struct ExportTestGate {
+    started: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+}
+
+#[cfg(test)]
+impl ExportTestGate {
+    fn new(
+        started: tokio::sync::oneshot::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    ) -> Self {
+        Self {
+            started: std::sync::Mutex::new(Some(started)),
+            release: std::sync::Mutex::new(release),
+        }
+    }
+
+    fn wait(&self) {
+        let Some(started) = self.started.lock().unwrap().take() else {
+            return;
+        };
+        let _ = started.send(());
+        self.release.lock().unwrap().recv().unwrap();
+    }
+}
+
+#[cfg(test)]
+tokio::task_local! {
+    static EXPORT_TEST_GATE: std::sync::Arc<ExportTestGate>;
+}
+
+async fn blocking_export<T>(
+    permit: OwnedSemaphorePermit,
+    operation: impl FnOnce() -> Result<T, LificError> + Send + 'static,
+) -> Result<(T, OwnedSemaphorePermit), LificError>
+where
+    T: Send + 'static,
+{
+    #[cfg(test)]
+    let gate = EXPORT_TEST_GATE.try_with(std::sync::Arc::clone).ok();
+    blocking(move || {
+        #[cfg(test)]
+        if let Some(gate) = gate {
+            gate.wait();
+        }
+        Ok((operation()?, permit))
+    })
+    .await
+}
+
+async fn single_file_response(
+    bundle: crate::export::ExportBundle,
+    format: &str,
+    fallback_name: &'static str,
+    permit: OwnedSemaphorePermit,
+) -> Result<axum::response::Response, LificError> {
+    let (prepared, permit) = match format {
+        "json" => blocking_export(permit, move || PreparedExport::json(&bundle)).await?,
+        "markdown" => {
+            blocking_export(permit, move || PreparedExport::markdown(bundle, fallback_name)).await?
+        }
+        _ => unreachable!("format was validated before export"),
+    };
+    stream_response(prepared, permit).await
+}
+
+async fn stream_response(
+    prepared: PreparedExport,
+    permit: OwnedSemaphorePermit,
+) -> Result<axum::response::Response, LificError> {
+    stream_response_with_timeouts(
+        prepared,
+        permit,
+        EXPORT_STREAM_IDLE_TIMEOUT,
+        EXPORT_STREAM_MAX_DURATION,
+    )
+    .await
+}
+
+async fn stream_response_with_timeouts(
+    prepared: PreparedExport,
+    permit: OwnedSemaphorePermit,
+    idle_timeout: Duration,
+    max_duration: Duration,
+) -> Result<axum::response::Response, LificError> {
+    let content_length = tokio::fs::metadata(&prepared.path)
+        .await
+        .map_err(|error| LificError::Internal(format!("stat export file: {error}")))?
+        .len();
+    let mut file = tokio::fs::File::open(&prepared.path)
+        .await
+        .map_err(|error| LificError::Internal(format!("open export file: {error}")))?;
+    let (sender, receiver) = tokio::sync::mpsc::channel(1);
+    tokio::spawn(async move {
+        let _temp_dir = prepared.temp_dir;
+        let _permit = permit;
+        let mut buffer = vec![0; EXPORT_STREAM_CHUNK_BYTES];
+        let _ = tokio::time::timeout(max_duration, async {
+            loop {
+                match file.read(&mut buffer).await {
+                    Ok(0) => break,
+                    Ok(read) => {
+                        let chunk =
+                            Ok::<_, std::io::Error>(Bytes::copy_from_slice(&buffer[..read]));
+                        if !matches!(
+                            tokio::time::timeout(idle_timeout, sender.send(chunk)).await,
+                            Ok(Ok(()))
+                        ) {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        let _ = sender.try_send(Err(error));
+                        break;
+                    }
+                }
+            }
+        })
+        .await;
+    });
+    let body = Body::from_stream(futures_util::stream::unfold(
+        receiver,
+        |mut receiver| async move { receiver.recv().await.map(|chunk| (chunk, receiver)) },
+    ));
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_TYPE, prepared.content_type);
+    if let Some(filename) = prepared.download_name {
+        headers.insert(header::CONTENT_DISPOSITION, content_disposition(&filename)?);
+    }
+    headers.insert(
+        header::CONTENT_LENGTH,
+        HeaderValue::from_str(&content_length.to_string())
+            .map_err(|error| LificError::Internal(format!("invalid export length: {error}")))?,
+    );
+    Ok((headers, body).into_response())
 }
 
 fn content_disposition(filename: &str) -> Result<HeaderValue, LificError> {
@@ -59,13 +242,30 @@ pub(super) async fn export_issue(
     Path(identifier): Path<String>,
     Query(q): Query<ExportQuery>,
 ) -> Result<impl IntoResponse, LificError> {
+    if let Some(format) = q.format.as_deref()
+        && !matches!(format, "json" | "markdown")
+    {
+        return Err(LificError::BadRequest(
+            "invalid export format. Expected 'markdown' or 'json'".into(),
+        ));
+    }
     let project_id = with_read(&db, |conn| {
         let id = crate::db::queries::resolve_identifier(conn, &identifier)?;
         Ok(crate::db::queries::get_issue(conn, id)?.project_id)
     })?;
     authz::require_role(&db, &identity, project_id, Role::Viewer)?;
-    let bundle = with_read(&db, |conn| crate::export::export_issue(conn, &identifier))?;
-    single_file_response(bundle, q.format.as_deref(), "issue.md")
+    let slot = db.acquire_export_slot()?;
+    let (bundle, slot) = blocking_export(slot, move || {
+        with_read(&db, |conn| crate::export::export_issue(conn, &identifier))
+    })
+    .await?;
+    single_file_response(
+        bundle,
+        q.format.as_deref().unwrap_or("markdown"),
+        "issue.md",
+        slot,
+    )
+    .await
 }
 
 pub(super) async fn export_page(
@@ -74,6 +274,13 @@ pub(super) async fn export_page(
     Path(identifier): Path<String>,
     Query(q): Query<ExportQuery>,
 ) -> Result<impl IntoResponse, LificError> {
+    if let Some(format) = q.format.as_deref()
+        && !matches!(format, "json" | "markdown")
+    {
+        return Err(LificError::BadRequest(
+            "invalid export format. Expected 'markdown' or 'json'".into(),
+        ));
+    }
     let project_id = with_read(&db, |conn| {
         let id = crate::db::queries::resolve_page_identifier(conn, &identifier)?;
         Ok(crate::db::queries::get_page(conn, id)?.project_id)
@@ -82,8 +289,18 @@ pub(super) async fn export_page(
         Some(pid) => authz::require_role(&db, &identity, pid, Role::Viewer)?,
         None => authz::require_workspace_admin(&db, &identity)?,
     }
-    let bundle = with_read(&db, |conn| crate::export::export_page(conn, &identifier))?;
-    single_file_response(bundle, q.format.as_deref(), "page.md")
+    let slot = db.acquire_export_slot()?;
+    let (bundle, slot) = blocking_export(slot, move || {
+        with_read(&db, |conn| crate::export::export_page(conn, &identifier))
+    })
+    .await?;
+    single_file_response(
+        bundle,
+        q.format.as_deref().unwrap_or("markdown"),
+        "page.md",
+        slot,
+    )
+    .await
 }
 
 pub(super) async fn export_project(
@@ -92,39 +309,47 @@ pub(super) async fn export_project(
     Path(identifier): Path<String>,
     Query(q): Query<ExportQuery>,
 ) -> Result<impl IntoResponse, LificError> {
+    if let Some(format) = q.format.as_deref()
+        && !matches!(format, "json" | "zip")
+    {
+        return Err(LificError::BadRequest(
+            "invalid export format. Expected 'zip' or 'json'".into(),
+        ));
+    }
     let project_id = with_read(&db, |conn| {
         crate::db::queries::resolve_project_identifier(conn, &identifier)
     })?;
     authz::require_role(&db, &identity, project_id, Role::Viewer)?;
-    let format = q.format.as_deref().unwrap_or("zip");
-    let bundle = with_read(&db, |conn| crate::export::export_project(conn, &identifier))?;
-
-    match format {
-        "json" => Ok(axum::Json(bundle).into_response()),
-        "zip" => {
-            let filename = format!("{}-export.zip", bundle.root.to_ascii_lowercase());
-            let bytes = crate::export::bundle_to_zip(&bundle)?;
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                header::CONTENT_TYPE,
-                HeaderValue::from_static("application/zip"),
-            );
-            headers.insert(header::CONTENT_DISPOSITION, content_disposition(&filename)?);
-            Ok((headers, bytes).into_response())
-        }
-        _ => Err(LificError::BadRequest(
-            "invalid export format. Expected 'zip' or 'json'".into(),
-        )),
-    }
+    let slot = db.acquire_export_slot()?;
+    let format = q.format.unwrap_or_else(|| "zip".into());
+    let (bundle, slot) = blocking_export(slot, move || {
+        with_read(&db, |conn| crate::export::export_project(conn, &identifier))
+    })
+    .await?;
+    let (prepared, slot) = match format.as_str() {
+        "json" => blocking_export(slot, move || PreparedExport::json(&bundle)).await?,
+        "zip" => blocking_export(slot, move || PreparedExport::zip(&bundle)).await?,
+        _ => unreachable!("format was validated before export"),
+    };
+    stream_response(prepared, slot).await
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    use crate::api::test_helpers::{json_post, parse_json, seed_project, test_app};
+    use super::{
+        EXPORT_TEST_GATE, ExportTestGate, PreparedExport, blocking_export, stream_response,
+    };
+    use crate::api::test_helpers::{
+        json_post, parse_json, seed_project, setup_membership_test, test_app,
+    };
+    use crate::error::LificError;
 
     #[tokio::test]
     async fn export_issue_returns_markdown_attachment() {
@@ -312,5 +537,243 @@ mod tests {
             resp.headers()[axum::http::header::CONTENT_TYPE],
             "application/zip"
         );
+        let content_length = resp
+            .headers()
+            .get(axum::http::header::CONTENT_LENGTH)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
+        assert!(content_length > 0);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body.len(), content_length);
+        assert_eq!(&body[..2], b"PK");
+    }
+
+    #[tokio::test]
+    async fn export_slots_are_held_until_response_bodies_are_dropped() {
+        let app = test_app();
+        let (project_id, project) = seed_project(&app).await;
+        json_post(
+            &app,
+            "/api/issues",
+            serde_json::json!({
+                "project_id": project_id,
+                "title": "Large export",
+                "description": "x".repeat(3 * super::EXPORT_STREAM_CHUNK_BYTES)
+            }),
+        )
+        .await;
+        let identifier = project["identifier"].as_str().unwrap();
+        let request = || {
+            Request::builder()
+                .uri(format!("/api/export/projects/{identifier}?format=json"))
+                .body(axum::body::Body::empty())
+                .unwrap()
+        };
+
+        let first = app.clone().oneshot(request()).await.unwrap();
+        let second = app.clone().oneshot(request()).await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(second.status(), StatusCode::OK);
+
+        let blocked = app.clone().oneshot(request()).await.unwrap();
+        assert_eq!(blocked.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(blocked.headers()[axum::http::header::RETRY_AFTER], "1");
+
+        drop(first);
+        drop(second);
+        let retried = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let response = app.clone().oneshot(request()).await.unwrap();
+                if response.status() == StatusCode::OK {
+                    break response;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped responses should release their export slots");
+        assert_eq!(retried.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn denied_exports_do_not_compete_for_slots() {
+        let (db, _, _, _, _, non_member, _) = setup_membership_test();
+        let _first = db.acquire_export_slot().unwrap();
+        let _second = db.acquire_export_slot().unwrap();
+        let identity = crate::resolve_caller::ResolvedIdentity {
+            user: crate::db::models::AuthUser {
+                id: non_member.id,
+                username: non_member.username,
+                display_name: non_member.display_name,
+                is_admin: non_member.is_admin,
+            },
+            transport: crate::actor::Transport::Web,
+        };
+
+        let result = super::export_project(
+            axum::extract::State(db),
+            axum::Extension(Some(identity)),
+            axum::extract::Path("MEM".into()),
+            axum::extract::Query(super::ExportQuery { format: None }),
+        )
+        .await;
+
+        assert!(matches!(result, Err(LificError::Forbidden(_))));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn project_export_leaves_the_runtime_responsive() {
+        let app = test_app();
+        let (_, project) = seed_project(&app).await;
+        let identifier = project["identifier"].as_str().unwrap();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let gate = Arc::new(ExportTestGate::new(started_tx, release_rx));
+        let export = app.clone().oneshot(
+            Request::builder()
+                .uri(format!("/api/export/projects/{identifier}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        );
+        let health = async {
+            started_rx.await.unwrap();
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/health")
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            release_tx.send(()).unwrap();
+        };
+
+        let (response, ()) = tokio::time::timeout(
+            Duration::from_secs(1),
+            EXPORT_TEST_GATE.scope(gate, async { tokio::join!(export, health) }),
+        )
+        .await
+        .expect("export worker blocked the async runtime");
+        assert_eq!(response.unwrap().status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn cancelled_request_keeps_its_slot_until_blocking_work_stops() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let request = tokio::spawn(blocking_export(permit, move || {
+            let _ = started_tx.send(());
+            release_rx.recv().unwrap();
+            Ok(())
+        }));
+
+        started_rx.await.unwrap();
+        request.abort();
+        assert!(semaphore.clone().try_acquire_owned().is_err());
+
+        release_tx.send(()).unwrap();
+        let _permit = tokio::time::timeout(Duration::from_secs(1), semaphore.acquire_owned())
+            .await
+            .expect("blocking worker should release its slot")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropping_a_response_closes_its_file_before_temp_cleanup() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path().to_path_buf();
+        let path = temp_path.join("export.md");
+        std::fs::write(&path, "body").unwrap();
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let response = stream_response(
+            PreparedExport {
+                temp_dir,
+                path,
+                content_type: axum::http::HeaderValue::from_static("text/markdown"),
+                download_name: None,
+            },
+            permit,
+        )
+        .await
+        .unwrap();
+
+        drop(response);
+        let _permit = tokio::time::timeout(Duration::from_secs(1), semaphore.acquire_owned())
+            .await
+            .expect("dropping the response should release its export slot")
+            .unwrap();
+        assert!(!temp_path.exists());
+    }
+
+    #[tokio::test]
+    async fn stalled_response_releases_its_slot_and_temp_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path().to_path_buf();
+        let path = temp_path.join("export.md");
+        std::fs::write(&path, vec![0; 256 * 1024]).unwrap();
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let response = super::stream_response_with_timeouts(
+            PreparedExport {
+                temp_dir,
+                path,
+                content_type: axum::http::HeaderValue::from_static("text/markdown"),
+                download_name: None,
+            },
+            permit,
+            Duration::from_millis(20),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+
+        let _permit = tokio::time::timeout(Duration::from_secs(1), semaphore.acquire_owned())
+            .await
+            .expect("stalled response should release its export slot")
+            .unwrap();
+        assert!(!temp_path.exists());
+        drop(response);
+    }
+
+    #[tokio::test]
+    async fn trickle_response_cannot_hold_an_export_slot_indefinitely() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path().to_path_buf();
+        let path = temp_path.join("export.md");
+        std::fs::write(&path, vec![0; 256 * 1024]).unwrap();
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let response = super::stream_response_with_timeouts(
+            PreparedExport {
+                temp_dir,
+                path,
+                content_type: axum::http::HeaderValue::from_static("text/markdown"),
+                download_name: None,
+            },
+            permit,
+            Duration::from_secs(5),
+            Duration::from_millis(200),
+        )
+        .await
+        .unwrap();
+
+        let mut body = response.into_body();
+        assert!(body.frame().await.unwrap().unwrap().is_data());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(body.frame().await.unwrap().unwrap().is_data());
+
+        let _permit = tokio::time::timeout(Duration::from_secs(1), semaphore.acquire_owned())
+            .await
+            .expect("stream deadline should release the export slot")
+            .unwrap();
+        assert!(!temp_path.exists());
     }
 }

--- a/src/api/export.rs
+++ b/src/api/export.rs
@@ -1,15 +1,15 @@
-use axum::Extension;
 use axum::body::{Body, Bytes};
 use axum::extract::{Path, Query, State};
-use axum::http::{HeaderMap, HeaderValue, header};
+use axum::http::{header, HeaderMap, HeaderValue};
 use axum::response::IntoResponse;
+use axum::Extension;
 use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::sync::OwnedSemaphorePermit;
 
 use crate::authz;
-use crate::db::DbPool;
 use crate::db::models::Role;
+use crate::db::DbPool;
 use crate::error::LificError;
 
 use super::with_read;
@@ -50,7 +50,12 @@ impl PreparedExport {
         let file = bundle.files.into_iter().next().ok_or_else(|| {
             LificError::Internal(format!("export produced no files for {fallback_name}"))
         })?;
-        let download_name = file.path.rsplit('/').next().unwrap_or(fallback_name).to_string();
+        let download_name = file
+            .path
+            .rsplit('/')
+            .next()
+            .unwrap_or(fallback_name)
+            .to_string();
         let temp_dir = export_temp_dir()?;
         let path = temp_dir.path().join("export.md");
         std::fs::write(&path, file.content)
@@ -153,7 +158,10 @@ async fn single_file_response(
     let (prepared, permit) = match format {
         "json" => blocking_export(permit, move || PreparedExport::json(&bundle)).await?,
         "markdown" => {
-            blocking_export(permit, move || PreparedExport::markdown(bundle, fallback_name)).await?
+            blocking_export(permit, move || {
+                PreparedExport::markdown(bundle, fallback_name)
+            })
+            .await?
         }
         _ => unreachable!("format was validated before export"),
     };
@@ -183,34 +191,42 @@ async fn stream_response_with_timeouts(
         .await
         .map_err(|error| LificError::Internal(format!("open export file: {error}")))?;
     let (sender, receiver) = tokio::sync::mpsc::channel(1);
+    let (terminal_sender, terminal_receiver) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         let _temp_dir = prepared.temp_dir;
         let _permit = permit;
         let mut buffer = vec![0; EXPORT_STREAM_CHUNK_BYTES];
-        let _ = tokio::time::timeout(max_duration, async {
+        let result = tokio::time::timeout(max_duration, async {
             loop {
                 match file.read(&mut buffer).await {
-                    Ok(0) => break,
+                    Ok(0) => return Ok(()),
                     Ok(read) => {
-                        let chunk =
-                            Ok::<_, std::io::Error>(Bytes::copy_from_slice(&buffer[..read]));
-                        if !send_stream_item(&sender, chunk, idle_timeout).await {
-                            break;
+                        let chunk = Bytes::copy_from_slice(&buffer[..read]);
+                        match tokio::time::timeout(idle_timeout, sender.send(chunk)).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(_)) => return Ok(()),
+                            Err(_) => {
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut,
+                                    "export stream idle timeout",
+                                ));
+                            }
                         }
                     }
-                    Err(error) => {
-                        let _ = send_stream_item(&sender, Err(error), idle_timeout).await;
-                        break;
-                    }
+                    Err(error) => return Err(error),
                 }
             }
         })
         .await;
+        let result = result.unwrap_or_else(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "export stream deadline exceeded",
+            ))
+        });
+        let _ = terminal_sender.send(result);
     });
-    let body = Body::from_stream(futures_util::stream::unfold(
-        receiver,
-        |mut receiver| async move { receiver.recv().await.map(|chunk| (chunk, receiver)) },
-    ));
+    let body = stream_body(receiver, terminal_receiver);
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_TYPE, prepared.content_type);
     if let Some(filename) = prepared.download_name {
@@ -219,15 +235,24 @@ async fn stream_response_with_timeouts(
     Ok((headers, body).into_response())
 }
 
-async fn send_stream_item(
-    sender: &tokio::sync::mpsc::Sender<Result<Bytes, std::io::Error>>,
-    item: Result<Bytes, std::io::Error>,
-    idle_timeout: Duration,
-) -> bool {
-    matches!(
-        tokio::time::timeout(idle_timeout, sender.send(item)).await,
-        Ok(Ok(()))
-    )
+fn stream_body(
+    receiver: tokio::sync::mpsc::Receiver<Bytes>,
+    terminal: tokio::sync::oneshot::Receiver<std::io::Result<()>>,
+) -> Body {
+    Body::from_stream(futures_util::stream::unfold(
+        (receiver, Some(terminal)),
+        |(mut receiver, mut terminal)| async move {
+            if let Some(chunk) = receiver.recv().await {
+                return Some((Ok::<_, std::io::Error>(chunk), (receiver, terminal)));
+            }
+            let result = terminal.take()?.await.unwrap_or_else(|_| {
+                Err(std::io::Error::other(
+                    "export stream task ended without a result",
+                ))
+            });
+            result.err().map(|error| (Err(error), (receiver, terminal)))
+        },
+    ))
 }
 
 fn content_disposition(filename: &str) -> Result<HeaderValue, LificError> {
@@ -250,7 +275,7 @@ pub(super) async fn export_issue(
     }
     let project_id = with_read(&db, |conn| {
         let id = crate::db::queries::resolve_identifier(conn, &identifier)?;
-        Ok(crate::db::queries::get_issue(conn, id)?.project_id)
+        crate::db::queries::issue_project_id(conn, id)
     })?;
     authz::require_role(&db, &identity, project_id, Role::Viewer)?;
     let slot = db.acquire_export_slot()?;
@@ -282,7 +307,7 @@ pub(super) async fn export_page(
     }
     let project_id = with_read(&db, |conn| {
         let id = crate::db::queries::resolve_page_identifier(conn, &identifier)?;
-        Ok(crate::db::queries::get_page(conn, id)?.project_id)
+        crate::db::queries::page_project_id(conn, id)
     })?;
     match project_id {
         Some(pid) => authz::require_role(&db, &identity, pid, Role::Viewer)?,
@@ -344,7 +369,7 @@ mod tests {
     use tower::ServiceExt;
 
     use super::{
-        EXPORT_TEST_GATE, ExportTestGate, PreparedExport, blocking_export, stream_response,
+        blocking_export, stream_response, ExportTestGate, PreparedExport, EXPORT_TEST_GATE,
     };
     use crate::api::test_helpers::{
         json_post, parse_json, seed_project, setup_membership_test, test_app,
@@ -432,12 +457,10 @@ mod tests {
         let bundle = parse_json(resp).await;
         assert_eq!(bundle["root"], "TST");
         assert_eq!(bundle["files"][0]["path"], "TST/issues/tst-1-export-me.md");
-        assert!(
-            bundle["files"][0]["content"]
-                .as_str()
-                .unwrap()
-                .contains("# Export me")
-        );
+        assert!(bundle["files"][0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("# Export me"));
     }
 
     #[tokio::test]
@@ -537,35 +560,30 @@ mod tests {
             resp.headers()[axum::http::header::CONTENT_TYPE],
             "application/zip"
         );
-        assert!(
-            resp.headers()
-                .get(axum::http::header::CONTENT_LENGTH)
-                .is_none()
-        );
+        assert!(resp
+            .headers()
+            .get(axum::http::header::CONTENT_LENGTH)
+            .is_none());
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         assert!(!body.is_empty());
         assert_eq!(&body[..2], b"PK");
     }
 
     #[tokio::test]
-    async fn stream_error_waits_for_the_queued_chunk() {
-        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
-        sender.send(Ok(Bytes::from_static(b"chunk"))).await.unwrap();
-        let send_error = tokio::spawn(async move {
-            super::send_stream_item(
-                &sender,
-                Err(std::io::Error::other("read failed")),
-                Duration::from_secs(1),
-            )
-            .await
-        });
+    async fn stream_error_follows_the_queued_chunk() {
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
+        let (terminal_sender, terminal_receiver) = tokio::sync::oneshot::channel();
+        sender.send(Bytes::from_static(b"chunk")).await.unwrap();
+        terminal_sender
+            .send(Err(std::io::Error::other("read failed")))
+            .unwrap();
+        drop(sender);
 
-        assert_eq!(receiver.recv().await.unwrap().unwrap(), "chunk");
-        assert!(send_error.await.unwrap());
-        assert_eq!(
-            receiver.recv().await.unwrap().unwrap_err().to_string(),
-            "read failed"
-        );
+        let error = super::stream_body(receiver, terminal_receiver)
+            .collect()
+            .await
+            .unwrap_err();
+        assert_eq!(error.to_string(), "read failed");
     }
 
     #[tokio::test]
@@ -639,6 +657,102 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(LificError::Forbidden(_))));
+    }
+
+    #[tokio::test]
+    async fn issue_authorization_does_not_materialize_metadata_before_capacity() {
+        let (db, _, _, _, viewer, _, project_id) = setup_membership_test();
+        let issue = {
+            let conn = db.write().unwrap();
+            let issue = crate::db::queries::create_issue(
+                &conn,
+                &crate::db::models::CreateIssue {
+                    project_id,
+                    title: "Bound authorization".into(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO labels (project_id, name) VALUES (?1, X'80')",
+                [project_id],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO issue_labels (issue_id, label_id) VALUES (?1, last_insert_rowid())",
+                [issue.id],
+            )
+            .unwrap();
+            issue
+        };
+        let _first = db.acquire_export_slot().unwrap();
+        let _second = db.acquire_export_slot().unwrap();
+
+        let result = super::export_issue(
+            axum::extract::State(db),
+            axum::Extension(Some(crate::resolve_caller::ResolvedIdentity {
+                user: crate::db::models::AuthUser {
+                    id: viewer.id,
+                    username: viewer.username,
+                    display_name: viewer.display_name,
+                    is_admin: viewer.is_admin,
+                },
+                transport: crate::actor::Transport::Web,
+            })),
+            axum::extract::Path(issue.identifier),
+            axum::extract::Query(super::ExportQuery { format: None }),
+        )
+        .await;
+
+        assert!(matches!(result, Err(LificError::TooManyRequests(_))));
+    }
+
+    #[tokio::test]
+    async fn page_authorization_does_not_materialize_metadata_before_capacity() {
+        let (db, _, _, _, viewer, _, project_id) = setup_membership_test();
+        let page = {
+            let conn = db.write().unwrap();
+            let page = crate::db::queries::create_page(
+                &conn,
+                &crate::db::models::CreatePage {
+                    project_id: Some(project_id),
+                    title: "Bound authorization".into(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO labels (project_id, name) VALUES (?1, X'80')",
+                [project_id],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO page_labels (page_id, label_id) VALUES (?1, last_insert_rowid())",
+                [page.id],
+            )
+            .unwrap();
+            page
+        };
+        let _first = db.acquire_export_slot().unwrap();
+        let _second = db.acquire_export_slot().unwrap();
+
+        let result = super::export_page(
+            axum::extract::State(db),
+            axum::Extension(Some(crate::resolve_caller::ResolvedIdentity {
+                user: crate::db::models::AuthUser {
+                    id: viewer.id,
+                    username: viewer.username,
+                    display_name: viewer.display_name,
+                    is_admin: viewer.is_admin,
+                },
+                transport: crate::actor::Transport::Web,
+            })),
+            axum::extract::Path(page.identifier),
+            axum::extract::Query(super::ExportQuery { format: None }),
+        )
+        .await;
+
+        assert!(matches!(result, Err(LificError::TooManyRequests(_))));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -757,7 +871,7 @@ mod tests {
             .expect("stalled response should release its export slot")
             .unwrap();
         assert!(!temp_path.exists());
-        drop(response);
+        assert!(response.into_body().collect().await.is_err());
     }
 
     #[tokio::test]
@@ -792,5 +906,6 @@ mod tests {
             .expect("stream deadline should release the export slot")
             .unwrap();
         assert!(!temp_path.exists());
+        assert!(body.collect().await.is_err());
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -6,6 +6,7 @@ use crossbeam_queue::ArrayQueue;
 use rusqlite::{Connection, Transaction, TransactionBehavior};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::error::LificError;
 
@@ -24,6 +25,7 @@ pub struct DbPool {
     writer: Arc<Mutex<Connection>>,
     readers: Arc<ArrayQueue<Connection>>,
     path: PathBuf,
+    export_slots: Arc<Semaphore>,
 }
 
 /// RAII guard that returns the read connection to the pool on drop.
@@ -49,6 +51,15 @@ impl Drop for ReadConn {
 }
 
 impl DbPool {
+    pub(crate) fn acquire_export_slot(&self) -> Result<OwnedSemaphorePermit, LificError> {
+        self.export_slots
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| {
+                LificError::TooManyRequests("too many exports are already running".into())
+            })
+    }
+
     /// The database file this pool was opened from. Callers that need to
     /// place sidecar data next to the database (attachments, backups) resolve
     /// it from here rather than re-reading the config, so every consumer of a
@@ -220,6 +231,7 @@ pub fn open_memory() -> Result<DbPool, LificError> {
         writer: Arc::new(Mutex::new(writer)),
         readers: Arc::new(readers),
         path: PathBuf::from(&name),
+        export_slots: Arc::new(Semaphore::new(2)),
     })
 }
 
@@ -253,6 +265,7 @@ pub fn open(path: &Path) -> Result<DbPool, LificError> {
         writer: Arc::new(Mutex::new(writer)),
         readers: Arc::new(readers),
         path: path.to_path_buf(),
+        export_slots: Arc::new(Semaphore::new(2)),
     })
 }
 

--- a/src/db/queries/issues.rs
+++ b/src/db/queries/issues.rs
@@ -140,6 +140,18 @@ pub fn get_issue(conn: &Connection, id: i64) -> Result<Issue, LificError> {
     Ok(issue)
 }
 
+pub fn issue_project_id(conn: &Connection, id: i64) -> Result<i64, LificError> {
+    conn.query_row("SELECT project_id FROM issues WHERE id = ?1", [id], |row| {
+        row.get(0)
+    })
+    .map_err(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => {
+            LificError::NotFound(format!("issue {id} not found"))
+        }
+        other => other.into(),
+    })
+}
+
 /// Look up just an issue's current status by id — a lightweight read used to
 /// annotate relation lines (LIF-303) without materializing the whole Issue.
 pub fn issue_status(conn: &Connection, id: i64) -> Result<String, LificError> {
@@ -963,7 +975,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(count, 0, "failed create must not leave a half-created issue");
+        assert_eq!(
+            count, 0,
+            "failed create must not leave a half-created issue"
+        );
     }
 
     #[test]
@@ -1021,7 +1036,13 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         for i in 0..3 {
-            quick_issue(&conn, pid, &format!("Issue {i}"), Status::Backlog, Priority::None);
+            quick_issue(
+                &conn,
+                pid,
+                &format!("Issue {i}"),
+                Status::Backlog,
+                Priority::None,
+            );
         }
         let got = list_issues(
             &conn,
@@ -1032,7 +1053,11 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(got.len(), 1, "limit=-1 must clamp to 1, not return everything");
+        assert_eq!(
+            got.len(),
+            1,
+            "limit=-1 must clamp to 1, not return everything"
+        );
     }
 
     #[test]
@@ -1456,7 +1481,13 @@ mod tests {
         let issue_project_id = seed_project(&conn, "ISS");
         let module_project_id = seed_project(&conn, "MOD");
         let module_id = seed_module(&conn, module_project_id, "Other project");
-        let issue = quick_issue(&conn, issue_project_id, "Wrong module", Status::Backlog, Priority::None);
+        let issue = quick_issue(
+            &conn,
+            issue_project_id,
+            "Wrong module",
+            Status::Backlog,
+            Priority::None,
+        );
 
         let err = update_issue(
             &conn,
@@ -1559,7 +1590,13 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         for i in 0..10 {
-            quick_issue(&conn, pid, &format!("Issue {i}"), Status::Backlog, Priority::None);
+            quick_issue(
+                &conn,
+                pid,
+                &format!("Issue {i}"),
+                Status::Backlog,
+                Priority::None,
+            );
         }
 
         let limited = list_issues(
@@ -1705,8 +1742,18 @@ mod tests {
         let pid = seed_project(&conn, "TST");
         let stale = quick_issue(&conn, pid, "Stale", Status::Todo, Priority::None);
         let fresh = quick_issue(&conn, pid, "Fresh", Status::Todo, Priority::None);
-        pin_timestamps(&conn, stale.id, "2026-01-01 00:00:00", "2026-01-02 00:00:00");
-        pin_timestamps(&conn, fresh.id, "2026-01-01 00:00:00", "2026-06-01 12:00:00");
+        pin_timestamps(
+            &conn,
+            stale.id,
+            "2026-01-01 00:00:00",
+            "2026-01-02 00:00:00",
+        );
+        pin_timestamps(
+            &conn,
+            fresh.id,
+            "2026-01-01 00:00:00",
+            "2026-06-01 12:00:00",
+        );
 
         let recent = list_issues(
             &conn,
@@ -1731,7 +1778,12 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         let issue = quick_issue(&conn, pid, "Edge", Status::Todo, Priority::None);
-        pin_timestamps(&conn, issue.id, "2026-06-01 12:00:00", "2026-06-01 12:00:00");
+        pin_timestamps(
+            &conn,
+            issue.id,
+            "2026-06-01 12:00:00",
+            "2026-06-01 12:00:00",
+        );
 
         let hit = list_issues(
             &conn,
@@ -1742,7 +1794,11 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(hit.len(), 1, "inclusive bound equal to row timestamp must match");
+        assert_eq!(
+            hit.len(),
+            1,
+            "inclusive bound equal to row timestamp must match"
+        );
     }
 
     #[test]

--- a/src/db/queries/pages.rs
+++ b/src/db/queries/pages.rs
@@ -70,8 +70,7 @@ fn populate_page_labels(conn: &Connection, pages: &mut [Page]) -> Result<(), Lif
         .iter()
         .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
         .collect();
-    let params_refs: Vec<&dyn rusqlite::types::ToSql> =
-        params.iter().map(|p| p.as_ref()).collect();
+    let params_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_refs.as_slice(), |row| {
         Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
@@ -242,6 +241,18 @@ pub fn get_page(conn: &Connection, id: i64) -> Result<Page, LificError> {
         })?;
     page.labels = page_labels(conn, id)?;
     Ok(page)
+}
+
+pub fn page_project_id(conn: &Connection, id: i64) -> Result<Option<i64>, LificError> {
+    conn.query_row("SELECT project_id FROM pages WHERE id = ?1", [id], |row| {
+        row.get(0)
+    })
+    .map_err(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => {
+            LificError::NotFound(format!("page {id} not found"))
+        }
+        other => other.into(),
+    })
 }
 
 pub fn resolve_page_identifier(conn: &Connection, identifier: &str) -> Result<i64, LificError> {
@@ -966,7 +977,18 @@ mod tests {
         .unwrap();
         create_page(&conn, &blank_page(Some(pid), "Plain")).unwrap();
 
-        let filtered = list_pages(&conn, Some(pid), None, Some("design"), None, None, None, None, None).unwrap();
+        let filtered = list_pages(
+            &conn,
+            Some(pid),
+            None,
+            Some("design"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].title, "Designy");
     }
@@ -1129,11 +1151,33 @@ mod tests {
         )
         .unwrap();
 
-        let archived = list_pages(&conn, Some(pid), None, None, Some("archived"), None, None, None, None).unwrap();
+        let archived = list_pages(
+            &conn,
+            Some(pid),
+            None,
+            None,
+            Some("archived"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(archived.len(), 1);
         assert_eq!(archived[0].title, "Archived doc");
 
-        let drafts = list_pages(&conn, Some(pid), None, None, Some("draft"), None, None, None, None).unwrap();
+        let drafts = list_pages(
+            &conn,
+            Some(pid),
+            None,
+            None,
+            Some("draft"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(drafts.len(), 1);
         assert_eq!(drafts[0].title, "Drafty");
     }
@@ -1143,7 +1187,12 @@ mod tests {
     /// Pin a page's timestamps so ordering tests don't race the clock.
     /// The `pages_updated` trigger rewrites updated_at to now on every
     /// UPDATE, which would silently overwrite the pin — drop it first.
-    fn pin_page_timestamps(conn: &rusqlite::Connection, page_id: i64, created: &str, updated: &str) {
+    fn pin_page_timestamps(
+        conn: &rusqlite::Connection,
+        page_id: i64,
+        created: &str,
+        updated: &str,
+    ) {
         conn.execute_batch("DROP TRIGGER IF EXISTS pages_updated;")
             .unwrap();
         conn.execute(
@@ -1163,12 +1212,33 @@ mod tests {
         create_page(&conn, &blank_page(Some(pid), "cherry")).unwrap();
 
         // COLLATE NOCASE: "Apple" sorts before "banana" despite case.
-        let asc = list_pages(&conn, Some(pid), None, None, None, Some("title"), None, None, None).unwrap();
+        let asc = list_pages(
+            &conn,
+            Some(pid),
+            None,
+            None,
+            None,
+            Some("title"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         let titles: Vec<&str> = asc.iter().map(|p| p.title.as_str()).collect();
         assert_eq!(titles, vec!["Apple", "banana", "cherry"]);
 
-        let desc =
-            list_pages(&conn, Some(pid), None, None, None, Some("title"), Some("desc"), None, None).unwrap();
+        let desc = list_pages(
+            &conn,
+            Some(pid),
+            None,
+            None,
+            None,
+            Some("title"),
+            Some("desc"),
+            None,
+            None,
+        )
+        .unwrap();
         let titles: Vec<&str> = desc.iter().map(|p| p.title.as_str()).collect();
         assert_eq!(titles, vec!["cherry", "banana", "Apple"]);
     }
@@ -1180,11 +1250,31 @@ mod tests {
         let pid = seed_project(&conn, "TST");
         let stale = create_page(&conn, &blank_page(Some(pid), "Stale")).unwrap();
         let fresh = create_page(&conn, &blank_page(Some(pid), "Fresh")).unwrap();
-        pin_page_timestamps(&conn, stale.id, "2026-01-01 00:00:00", "2026-01-02 00:00:00");
-        pin_page_timestamps(&conn, fresh.id, "2026-01-01 00:00:00", "2026-06-01 00:00:00");
+        pin_page_timestamps(
+            &conn,
+            stale.id,
+            "2026-01-01 00:00:00",
+            "2026-01-02 00:00:00",
+        );
+        pin_page_timestamps(
+            &conn,
+            fresh.id,
+            "2026-01-01 00:00:00",
+            "2026-06-01 00:00:00",
+        );
 
-        let pages =
-            list_pages(&conn, Some(pid), None, None, None, Some("updated"), Some("desc"), None, None).unwrap();
+        let pages = list_pages(
+            &conn,
+            Some(pid),
+            None,
+            None,
+            None,
+            Some("updated"),
+            Some("desc"),
+            None,
+            None,
+        )
+        .unwrap();
         let titles: Vec<&str> = pages.iter().map(|p| p.title.as_str()).collect();
         assert_eq!(titles, vec!["Fresh", "Stale"]);
     }
@@ -1197,10 +1287,32 @@ mod tests {
         create_page(&conn, &blank_page(Some(pid), "P")).unwrap();
 
         assert!(
-            list_pages(&conn, Some(pid), None, None, None, Some("content; --"), None, None, None).is_err(),
+            list_pages(
+                &conn,
+                Some(pid),
+                None,
+                None,
+                None,
+                Some("content; --"),
+                None,
+                None,
+                None
+            )
+            .is_err(),
             "unknown order_by must error, not be interpolated"
         );
-        assert!(list_pages(&conn, Some(pid), None, None, None, None, Some("up"), None, None).is_err());
+        assert!(list_pages(
+            &conn,
+            Some(pid),
+            None,
+            None,
+            None,
+            None,
+            Some("up"),
+            None,
+            None
+        )
+        .is_err());
     }
 
     // ── LIF-183: page pinning ────────────────────────────────

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,9 @@ pub enum LificError {
     #[error("Conflict: {0}")]
     Conflict(String),
 
+    #[error("Too many requests: {0}")]
+    TooManyRequests(String),
+
     #[error("Internal error: {0}")]
     Internal(String),
 }
@@ -39,6 +42,7 @@ impl IntoResponse for LificError {
             LificError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             LificError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
             LificError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
+            LificError::TooManyRequests(msg) => (StatusCode::TOO_MANY_REQUESTS, msg.clone()),
             LificError::Internal(msg) => {
                 error!(error = %msg, "internal error");
                 (
@@ -49,6 +53,13 @@ impl IntoResponse for LificError {
         };
 
         let body = json!({ "error": message });
-        (status, axum::Json(body)).into_response()
+        let mut response = (status, axum::Json(body)).into_response();
+        if matches!(self, LificError::TooManyRequests(_)) {
+            response.headers_mut().insert(
+                axum::http::header::RETRY_AFTER,
+                axum::http::HeaderValue::from_static("1"),
+            );
+        }
+        response
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::io::{Cursor, Read, Write};
+use std::fs::OpenOptions;
+use std::io::{self, Cursor, Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 use rusqlite::Connection;
@@ -26,96 +27,495 @@ pub struct ExportBundle {
     pub files: Vec<ExportFile>,
 }
 
-pub fn export_issue(conn: &Connection, identifier: &str) -> Result<ExportBundle, LificError> {
-    let issue_id = queries::resolve_identifier(conn, identifier)?;
-    let issue = queries::get_issue(conn, issue_id)?;
-    let project = queries::get_project(conn, issue.project_id)?;
-    let comments = queries::comments::list_comments(
-        conn,
-        queries::comments::CommentParent::Issue(issue.id),
-        None,
-        None,
+/// Export limits are on the uncompressed representation. They bound both
+/// query result memory and the amount of data a single request can serialize.
+pub const MAX_EXPORT_FILES: usize = 500;
+pub const MAX_EXPORT_COMMENTS: i64 = 500;
+pub const MAX_EXPORT_FILE_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_EXPORT_TOTAL_BYTES: usize = 128 * 1024 * 1024;
+const MAX_EXPORT_METADATA_ITEMS: i64 = 5_000;
+// A JSON string can encode one source byte as a six-byte `\u00xx` escape.
+// Keep that representation bounded without rejecting a bundle ZIP accepts.
+const MAX_EXPORT_JSON_BYTES: usize = MAX_EXPORT_TOTAL_BYTES * 6 + 64 * 1024;
+
+fn ensure_text_size(label: &str, value: &str) -> Result<(), LificError> {
+    if value.len() > MAX_EXPORT_FILE_BYTES {
+        return Err(LificError::BadRequest(format!(
+            "{label} exceeds the {} byte limit",
+            MAX_EXPORT_FILE_BYTES
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_comment_sizes(conn: &Connection, issue_id: i64) -> Result<(), LificError> {
+    // SQLite's length(TEXT) reports characters, not UTF-8 bytes.  Use the
+    // BLOB form for the limit that protects the rendered file allocation.
+    let (too_large, total_bytes): (i64, i64) = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM comments WHERE issue_id = ?1 AND length(CAST(content AS BLOB)) > ?2),
+                COALESCE(SUM(length(CAST(content AS BLOB))), 0)
+           FROM comments WHERE issue_id = ?1",
+        rusqlite::params![issue_id, MAX_EXPORT_FILE_BYTES],
+        |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
+    if too_large != 0 {
+        return Err(LificError::BadRequest(format!(
+            "an issue comment exceeds the {} byte export limit",
+            MAX_EXPORT_FILE_BYTES
+        )));
+    }
+    if total_bytes > MAX_EXPORT_FILE_BYTES as i64 {
+        return Err(LificError::BadRequest(format!(
+            "issue comments exceed the {} byte aggregate export limit",
+            MAX_EXPORT_FILE_BYTES
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_issue_metadata_size(conn: &Connection, issue_id: i64) -> Result<(), LificError> {
+    let (items, bytes): (i64, i64) = conn.query_row(
+        "SELECT
+            (SELECT COUNT(*) FROM issue_labels WHERE issue_id = ?1) +
+            (SELECT COUNT(*) FROM issue_relations WHERE source_id = ?1 OR target_id = ?1),
+            (SELECT COALESCE(SUM(length(CAST(l.name AS BLOB))), 0)
+               FROM issue_labels il JOIN labels l ON l.id = il.label_id WHERE il.issue_id = ?1) +
+            (SELECT COALESCE(SUM(length(CAST(p.identifier AS BLOB)) + 20), 0)
+               FROM issue_relations ir
+               JOIN issues other ON other.id = CASE WHEN ir.source_id = ?1 THEN ir.target_id ELSE ir.source_id END
+               JOIN projects p ON p.id = other.project_id
+              WHERE ir.source_id = ?1 OR ir.target_id = ?1) +
+            (SELECT COALESCE(SUM(length(CAST(COALESCE(u.display_name, u.username) AS BLOB))), 0)
+               FROM comments c JOIN users u ON u.id = c.user_id WHERE c.issue_id = ?1) +
+            (SELECT COALESCE(length(CAST(m.name AS BLOB)), 0)
+               FROM issues i LEFT JOIN modules m ON m.id = i.module_id WHERE i.id = ?1)",
+        [issue_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    ensure_metadata_size(items, bytes)
+}
+
+fn ensure_page_metadata_size(conn: &Connection, page_id: i64) -> Result<(), LificError> {
+    let (items, bytes): (i64, i64) = conn.query_row(
+        "SELECT COUNT(*), COALESCE(SUM(length(CAST(l.name AS BLOB))), 0)
+           FROM page_labels pl JOIN labels l ON l.id = pl.label_id
+          WHERE pl.page_id = ?1",
+        [page_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    ensure_metadata_size(items, bytes)
+}
+
+fn bounded_folders(conn: &Connection, project_id: i64) -> Result<Vec<Folder>, LificError> {
+    let (items, bytes, oversized): (i64, i64, i64) = conn.query_row(
+        "SELECT COUNT(*),
+                COALESCE(SUM(length(CAST(name AS BLOB))), 0),
+                EXISTS(SELECT 1 FROM folders WHERE project_id = ?1 AND length(CAST(name AS BLOB)) > ?2)
+           FROM folders WHERE project_id = ?1",
+        rusqlite::params![project_id, MAX_EXPORT_FILE_BYTES],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    ensure_metadata_size(items, bytes)?;
+    if oversized != 0 {
+        return Err(LificError::BadRequest(
+            "export folder name exceeds export limit".into(),
+        ));
+    }
+    queries::list_folders(conn, project_id)
+}
+
+fn ensure_metadata_size(items: i64, bytes: i64) -> Result<(), LificError> {
+    if items > MAX_EXPORT_METADATA_ITEMS {
+        return Err(LificError::BadRequest(format!(
+            "export contains too many metadata entries ({items} > {MAX_EXPORT_METADATA_ITEMS})"
+        )));
+    }
+    if bytes > MAX_EXPORT_TOTAL_BYTES as i64 {
+        return Err(LificError::BadRequest(format!(
+            "export metadata exceeds the {} byte total limit",
+            MAX_EXPORT_TOTAL_BYTES
+        )));
+    }
+    Ok(())
+}
+
+fn bounded_project(conn: &Connection, project_id: i64) -> Result<Project, LificError> {
+    let oversized: i64 = conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM projects WHERE id = ?1 AND (
+                 length(CAST(name AS BLOB)) > ?2 OR
+                 length(CAST(identifier AS BLOB)) > ?2 OR
+                 length(CAST(description AS BLOB)) > ?2 OR
+                 length(CAST(COALESCE(emoji, '') AS BLOB)) > ?2
+             )
+         )",
+        rusqlite::params![project_id, MAX_EXPORT_FILE_BYTES],
+        |row| row.get(0),
+    )?;
+    if oversized != 0 {
+        return Err(LificError::BadRequest(
+            "project metadata exceeds export limit".into(),
+        ));
+    }
+    queries::get_project(conn, project_id)
+}
+
+struct ExportBudget {
+    files: usize,
+    bytes: usize,
+}
+
+impl ExportBudget {
+    fn new(root: &str) -> Result<Self, LificError> {
+        ensure_text_size("export root", root)?;
+        Ok(Self {
+            files: 0,
+            bytes: root.len(),
+        })
+    }
+
+    fn add(&mut self, file: &ExportFile) -> Result<(), LificError> {
+        self.files += 1;
+        if self.files > MAX_EXPORT_FILES {
+            return Err(LificError::BadRequest(format!(
+                "export contains too many files ({} > {})",
+                self.files, MAX_EXPORT_FILES
+            )));
+        }
+        let bytes = file
+            .path
+            .len()
+            .checked_add(file.content.len())
+            .ok_or_else(|| LificError::BadRequest("export size overflow".into()))?;
+        if bytes > MAX_EXPORT_FILE_BYTES {
+            return Err(LificError::BadRequest(format!(
+                "export file {} exceeds the {} byte limit",
+                file.path, MAX_EXPORT_FILE_BYTES
+            )));
+        }
+        self.bytes = self
+            .bytes
+            .checked_add(bytes)
+            .ok_or_else(|| LificError::BadRequest("export size overflow".into()))?;
+        if self.bytes > MAX_EXPORT_TOTAL_BYTES {
+            return Err(LificError::BadRequest(format!(
+                "export exceeds the {} byte total limit",
+                MAX_EXPORT_TOTAL_BYTES
+            )));
+        }
+        Ok(())
+    }
+}
+
+struct BundleBuilder {
+    root: String,
+    files: Vec<ExportFile>,
+    budget: ExportBudget,
+}
+
+impl BundleBuilder {
+    fn new(root: String) -> Result<Self, LificError> {
+        let budget = ExportBudget::new(&root)?;
+        Ok(Self {
+            root,
+            files: Vec::new(),
+            budget,
+        })
+    }
+
+    fn push(&mut self, path: String, content: String) -> Result<(), LificError> {
+        let file = ExportFile { path, content };
+        self.budget.add(&file)?;
+        self.files.push(file);
+        Ok(())
+    }
+
+    fn finish(self) -> ExportBundle {
+        ExportBundle {
+            root: self.root,
+            files: self.files,
+        }
+    }
+}
+
+fn validate_bundle(bundle: &ExportBundle) -> Result<(), LificError> {
+    let mut budget = ExportBudget::new(&bundle.root)?;
+    for file in &bundle.files {
+        budget.add(file)?;
+    }
+    Ok(())
+}
+
+fn bounded_issue_comments(
+    conn: &Connection,
+    issue_id: i64,
+) -> Result<Vec<Comment>, LificError> {
+    let parent = queries::comments::CommentParent::Issue(issue_id);
+    ensure_comment_sizes(conn, issue_id)?;
+    if queries::comments::count_comments(conn, parent, None)? > MAX_EXPORT_COMMENTS {
+        return Err(LificError::BadRequest(format!(
+            "issue has more than {MAX_EXPORT_COMMENTS} comments; export it in smaller slices"
+        )));
+    }
+    queries::comments::list_comments_paginated(
+        conn,
+        parent,
+        None,
+        None,
+        Some(MAX_EXPORT_COMMENTS),
+        None,
+    )
+}
+
+pub fn export_issue(conn: &Connection, identifier: &str) -> Result<ExportBundle, LificError> {
+    let transaction = conn.unchecked_transaction()?;
+    let bundle = export_issue_snapshot(&transaction, identifier)?;
+    transaction.commit()?;
+    Ok(bundle)
+}
+
+fn export_issue_snapshot(
+    conn: &Connection,
+    identifier: &str,
+) -> Result<ExportBundle, LificError> {
+    let issue_id = queries::resolve_identifier(conn, identifier)?;
+    let oversized: i64 = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM issues WHERE id = ?1 AND (
+             length(CAST(title AS BLOB)) > ?2 OR
+             length(CAST(description AS BLOB)) > ?2 OR
+             length(CAST(COALESCE(source, '') AS BLOB)) > ?2
+         ))",
+        rusqlite::params![issue_id, MAX_EXPORT_FILE_BYTES],
+        |row| row.get(0),
+    )?;
+    if oversized != 0 {
+        return Err(LificError::BadRequest("issue content exceeds export limit".into()));
+    }
+    ensure_issue_metadata_size(conn, issue_id)?;
+    let project_id = conn.query_row(
+        "SELECT project_id FROM issues WHERE id = ?1",
+        [issue_id],
+        |row| row.get(0),
+    )?;
+    let project = bounded_project(conn, project_id)?;
+    let issue = queries::get_issue(conn, issue_id)?;
+    ensure_text_size("issue title", &issue.title)?;
+    ensure_text_size("issue description", &issue.description)?;
+    let comments = bounded_issue_comments(conn, issue.id)?;
     let path = format!(
         "{}/issues/{}.md",
         project.identifier,
         slugged_issue_name(&issue)
     );
-    Ok(ExportBundle {
-        root: project.identifier.clone(),
-        files: vec![ExportFile {
-            path,
-            content: render_issue_markdown(conn, &project, &issue, &comments)?,
-        }],
-    })
+    let mut bundle = BundleBuilder::new(project.identifier.clone())?;
+    bundle.push(
+        path,
+        render_issue_markdown(conn, &project, &issue, &comments)?,
+    )?;
+    Ok(bundle.finish())
 }
 
 pub fn export_page(conn: &Connection, identifier: &str) -> Result<ExportBundle, LificError> {
+    let transaction = conn.unchecked_transaction()?;
+    let bundle = export_page_snapshot(&transaction, identifier)?;
+    transaction.commit()?;
+    Ok(bundle)
+}
+
+fn export_page_snapshot(
+    conn: &Connection,
+    identifier: &str,
+) -> Result<ExportBundle, LificError> {
     let page_id = queries::resolve_page_identifier(conn, identifier)?;
+    let oversized: i64 = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM pages WHERE id = ?1 AND (length(CAST(title AS BLOB)) > ?2 OR length(CAST(content AS BLOB)) > ?2))",
+        rusqlite::params![page_id, MAX_EXPORT_FILE_BYTES],
+        |row| row.get(0),
+    )?;
+    if oversized != 0 {
+        return Err(LificError::BadRequest("page content exceeds export limit".into()));
+    }
+    ensure_page_metadata_size(conn, page_id)?;
+    let project_id = conn.query_row(
+        "SELECT project_id FROM pages WHERE id = ?1",
+        [page_id],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    let project = project_id
+        .map(|project_id| bounded_project(conn, project_id))
+        .transpose()?;
     let page = queries::get_page(conn, page_id)?;
-    let (project, root) = match page.project_id {
-        Some(project_id) => {
-            let project = queries::get_project(conn, project_id)?;
-            (Some(project.clone()), project.identifier)
-        }
-        None => (None, "workspace".to_string()),
-    };
-    let folders = match page.project_id {
-        Some(project_id) => queries::list_folders(conn, project_id)?,
-        None => Vec::new(),
-    };
+    ensure_text_size("page title", &page.title)?;
+    ensure_text_size("page content", &page.content)?;
+    let root = project
+        .as_ref()
+        .map_or_else(|| "workspace".to_string(), |project| project.identifier.clone());
+    let folders = project_id
+        .map(|project_id| bounded_folders(conn, project_id))
+        .transpose()?
+        .unwrap_or_default();
     let path = build_page_path(&root, &page, &folders);
-    Ok(ExportBundle {
-        root,
-        files: vec![ExportFile {
-            path,
-            content: render_page_markdown(project.as_ref(), &page),
-        }],
-    })
+    let mut bundle = BundleBuilder::new(root)?;
+    bundle.push(path, render_page_markdown(project.as_ref(), &page))?;
+    Ok(bundle.finish())
 }
 
 pub fn export_project(conn: &Connection, identifier: &str) -> Result<ExportBundle, LificError> {
-    let project_id = queries::resolve_project_identifier(conn, identifier)?;
-    let project = queries::get_project(conn, project_id)?;
-    let folders = queries::list_folders(conn, project.id)?;
-    let issues = queries::list_issues(
-        conn,
-        &crate::db::models::ListIssuesQuery {
-            project_id: Some(project.id),
-            limit: Some(10_000),
-            ..Default::default()
+    let transaction = conn.unchecked_transaction()?;
+    let bundle = export_project_snapshot(&transaction, identifier)?;
+    transaction.commit()?;
+    Ok(bundle)
+}
+
+fn ensure_project_preflight(
+    conn: &Connection,
+    project_id: i64,
+    max_total_bytes: i64,
+) -> Result<(), LificError> {
+    let (
+        issue_count,
+        page_count,
+        comment_count,
+        issue_bytes,
+        page_bytes,
+        comment_bytes,
+        metadata_items,
+        metadata_bytes,
+    ): (i64, i64, i64, i64, i64, i64, i64, i64) = conn.query_row(
+        "SELECT
+            (SELECT COUNT(*) FROM issues WHERE project_id = ?1),
+            (SELECT COUNT(*) FROM pages WHERE project_id = ?1),
+            (SELECT COUNT(*) FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.project_id = ?1),
+            (SELECT COALESCE(SUM(length(CAST(title AS BLOB)) + length(CAST(description AS BLOB)) + length(CAST(COALESCE(source, '') AS BLOB))), 0) FROM issues WHERE project_id = ?1),
+            (SELECT COALESCE(SUM(length(CAST(title AS BLOB)) + length(CAST(content AS BLOB))), 0) FROM pages WHERE project_id = ?1),
+            (SELECT COALESCE(SUM(length(CAST(c.content AS BLOB))), 0) FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.project_id = ?1),
+            (SELECT COUNT(*) FROM issue_labels il JOIN issues i ON i.id = il.issue_id WHERE i.project_id = ?1) +
+            (SELECT COUNT(*) FROM page_labels pl JOIN pages p ON p.id = pl.page_id WHERE p.project_id = ?1) +
+            (SELECT COUNT(*) FROM folders WHERE project_id = ?1) +
+            2 * (SELECT COUNT(*) FROM issue_relations ir
+                   JOIN issues source ON source.id = ir.source_id
+                   JOIN issues target ON target.id = ir.target_id
+                  WHERE source.project_id = ?1 OR target.project_id = ?1),
+            (SELECT COALESCE(SUM(length(CAST(l.name AS BLOB))), 0)
+               FROM issue_labels il JOIN issues i ON i.id = il.issue_id JOIN labels l ON l.id = il.label_id
+              WHERE i.project_id = ?1) +
+            (SELECT COALESCE(SUM(length(CAST(l.name AS BLOB))), 0)
+               FROM page_labels pl JOIN pages page ON page.id = pl.page_id JOIN labels l ON l.id = pl.label_id
+              WHERE page.project_id = ?1) +
+            (SELECT COALESCE(SUM(length(CAST(m.name AS BLOB))), 0)
+               FROM issues i JOIN modules m ON m.id = i.module_id WHERE i.project_id = ?1) +
+            (SELECT COALESCE(SUM(length(CAST(name AS BLOB))), 0)
+               FROM folders WHERE project_id = ?1) +
+            (SELECT COALESCE(SUM(length(CAST(COALESCE(u.display_name, u.username) AS BLOB))), 0)
+               FROM comments c JOIN issues i ON i.id = c.issue_id JOIN users u ON u.id = c.user_id
+              WHERE i.project_id = ?1) +
+            2 * (SELECT COALESCE(SUM(length(CAST(source_project.identifier AS BLOB)) +
+                                     length(CAST(target_project.identifier AS BLOB)) + 40), 0)
+                   FROM issue_relations ir
+                   JOIN issues source ON source.id = ir.source_id
+                   JOIN projects source_project ON source_project.id = source.project_id
+                   JOIN issues target ON target.id = ir.target_id
+                   JOIN projects target_project ON target_project.id = target.project_id
+                  WHERE source.project_id = ?1 OR target.project_id = ?1)",
+        [project_id],
+        |row| {
+            Ok((
+                row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?,
+                row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?,
+            ))
         },
     )?;
-    let pages = queries::list_pages(conn, Some(project.id), None, None, None, None, None, None, None)?;
+    if issue_count + page_count > MAX_EXPORT_FILES as i64 {
+        return Err(LificError::BadRequest(format!(
+            "project export contains too many files ({} > {})",
+            issue_count + page_count,
+            MAX_EXPORT_FILES
+        )));
+    }
+    if comment_count > MAX_EXPORT_COMMENTS {
+        return Err(LificError::BadRequest(format!(
+            "project export contains too many comments ({} > {})",
+            comment_count, MAX_EXPORT_COMMENTS
+        )));
+    }
+    ensure_metadata_size(metadata_items, metadata_bytes)?;
+    let source_bytes = issue_bytes
+        .checked_add(page_bytes)
+        .and_then(|bytes| bytes.checked_add(comment_bytes))
+        .and_then(|bytes| bytes.checked_add(metadata_bytes))
+        .ok_or_else(|| LificError::BadRequest("export size overflow".into()))?;
+    if source_bytes > max_total_bytes {
+        return Err(LificError::BadRequest(format!(
+            "project source exceeds the {} byte total export limit",
+            max_total_bytes
+        )));
+    }
+    let oversized: i64 = conn.query_row(
+        "SELECT EXISTS(
+           SELECT 1 FROM issues WHERE project_id = ?1
+             AND (length(CAST(title AS BLOB)) > ?2 OR
+                  length(CAST(description AS BLOB)) > ?2 OR
+                  length(CAST(COALESCE(source, '') AS BLOB)) > ?2)
+           UNION ALL
+           SELECT 1 FROM pages WHERE project_id = ?1
+             AND (length(CAST(title AS BLOB)) > ?2 OR length(CAST(content AS BLOB)) > ?2)
+           UNION ALL
+           SELECT 1 FROM comments c JOIN issues i ON i.id = c.issue_id
+             WHERE i.project_id = ?1 AND length(CAST(c.content AS BLOB)) > ?2
+           UNION ALL
+           SELECT 1 FROM folders WHERE project_id = ?1 AND length(CAST(name AS BLOB)) > ?2
+         )",
+        rusqlite::params![project_id, MAX_EXPORT_FILE_BYTES],
+        |row| row.get(0),
+    )?;
+    if oversized != 0 {
+        return Err(LificError::BadRequest("project content exceeds export limit".into()));
+    }
+    Ok(())
+}
 
-    let mut files = Vec::new();
-    for issue in issues {
-        let comments = queries::comments::list_comments(
-            conn,
-            queries::comments::CommentParent::Issue(issue.id),
-            None,
-            None,
-        )?;
-        files.push(ExportFile {
-            path: format!(
+fn export_project_snapshot(
+    conn: &Connection,
+    identifier: &str,
+) -> Result<ExportBundle, LificError> {
+    let project_id = queries::resolve_project_identifier(conn, identifier)?;
+    let project = bounded_project(conn, project_id)?;
+    ensure_project_preflight(conn, project.id, MAX_EXPORT_TOTAL_BYTES as i64)?;
+    let issue_ids = conn
+        .prepare_cached("SELECT id FROM issues WHERE project_id = ?1 ORDER BY id")?
+        .query_map([project.id], |row| row.get(0))?
+        .collect::<Result<Vec<i64>, _>>()?;
+    let page_ids = conn
+        .prepare_cached("SELECT id FROM pages WHERE project_id = ?1 ORDER BY id")?
+        .query_map([project.id], |row| row.get(0))?
+        .collect::<Result<Vec<i64>, _>>()?;
+
+    let mut bundle = BundleBuilder::new(project.identifier.clone())?;
+    for issue_id in issue_ids {
+        let issue = queries::get_issue(conn, issue_id)?;
+        ensure_text_size("issue title", &issue.title)?;
+        ensure_text_size("issue description", &issue.description)?;
+        let comments = bounded_issue_comments(conn, issue.id)?;
+        bundle.push(
+            format!(
                 "{}/issues/{}.md",
                 project.identifier,
                 slugged_issue_name(&issue)
             ),
-            content: render_issue_markdown(conn, &project, &issue, &comments)?,
-        });
+            render_issue_markdown(conn, &project, &issue, &comments)?,
+        )?;
     }
-    for page in pages {
-        files.push(ExportFile {
-            path: build_page_path(&project.identifier, &page, &folders),
-            content: render_page_markdown(Some(&project), &page),
-        });
+    let folders = queries::list_folders(conn, project.id)?;
+    for page_id in page_ids {
+        let page = queries::get_page(conn, page_id)?;
+        ensure_text_size("page title", &page.title)?;
+        ensure_text_size("page content", &page.content)?;
+        bundle.push(
+            build_page_path(&project.identifier, &page, &folders),
+            render_page_markdown(Some(&project), &page),
+        )?;
     }
-
-    Ok(ExportBundle {
-        root: project.identifier.clone(),
-        files,
-    })
+    Ok(bundle.finish())
 }
 
 /// Write a bundle's files under `target_dir`, one file per
@@ -131,6 +531,7 @@ pub fn write_bundle_to_directory(
     bundle: &ExportBundle,
     target_dir: &Path,
 ) -> Result<Vec<PathBuf>, LificError> {
+    validate_bundle(bundle)?;
     let mut written = Vec::new();
     for file in &bundle.files {
         let full_path = prepare_output_path(target_dir, &file.path)?;
@@ -291,7 +692,9 @@ fn contained_path(name: &str) -> Result<PathBuf, LificError> {
     Ok(contained)
 }
 
+#[cfg(test)]
 pub fn bundle_to_zip(bundle: &ExportBundle) -> Result<Vec<u8>, LificError> {
+    validate_bundle(bundle)?;
     let mut cursor = Cursor::new(Vec::new());
     let mut zip = zip::ZipWriter::new(&mut cursor);
     let options = zip::write::SimpleFileOptions::default()
@@ -303,6 +706,84 @@ pub fn bundle_to_zip(bundle: &ExportBundle) -> Result<Vec<u8>, LificError> {
     }
     zip.finish().map_err(zip_error)?;
     Ok(cursor.into_inner())
+}
+/// Write a validated bundle to a caller-owned temporary file.  Keeping the
+/// archive on disk lets HTTP callers stream it instead of retaining another
+/// complete compressed copy in the response body.
+pub fn bundle_to_zip_file(bundle: &ExportBundle, path: &Path) -> Result<(), LificError> {
+    validate_bundle(bundle)?;
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(io_error)?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+    for file in &bundle.files {
+        zip.start_file(&file.path, options).map_err(zip_error)?;
+        zip.write_all(file.content.as_bytes()).map_err(io_error)?;
+    }
+    zip.finish().map_err(zip_error)?;
+    Ok(())
+}
+
+pub(crate) fn bundle_to_json_file(
+    bundle: &ExportBundle,
+    path: &Path,
+) -> Result<(), LificError> {
+    bundle_to_json_file_with_limit(bundle, path, MAX_EXPORT_JSON_BYTES)
+}
+
+fn bundle_to_json_file_with_limit(
+    bundle: &ExportBundle,
+    path: &Path,
+    limit: usize,
+) -> Result<(), LificError> {
+    validate_bundle(bundle)?;
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(io_error)?;
+    serde_json::to_writer(LimitedWriter::new(file, limit), bundle).map_err(|error| {
+        if error.io_error_kind() == Some(io::ErrorKind::FileTooLarge) {
+            LificError::BadRequest(format!(
+                "JSON export exceeds the {limit} byte encoded-output limit"
+            ))
+        } else {
+            LificError::Internal(format!("serialize export JSON: {error}"))
+        }
+    })
+}
+
+struct LimitedWriter<W> {
+    inner: W,
+    remaining: usize,
+}
+
+impl<W> LimitedWriter<W> {
+    fn new(inner: W, limit: usize) -> Self {
+        Self {
+            inner,
+            remaining: limit,
+        }
+    }
+}
+
+impl<W: Write> Write for LimitedWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if bytes.len() > self.remaining {
+            return Err(io::Error::from(io::ErrorKind::FileTooLarge));
+        }
+        let written = self.inner.write(bytes)?;
+        self.remaining -= written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 fn render_issue_markdown(
@@ -557,6 +1038,7 @@ mod tests {
 
         let bundle = export_project(&conn, "EXP").unwrap();
         assert_eq!(bundle.root, "EXP");
+        assert_eq!(bundle.files.len(), 2);
         assert!(bundle
             .files
             .iter()
@@ -572,6 +1054,7 @@ mod tests {
             .unwrap();
         assert!(issue_file.content.contains("identifier: EXP-1"));
         assert!(issue_file.content.contains("## Comments"));
+        assert_eq!(issue_file.content.matches("First exported comment").count(), 1);
     }
 
     // LIF-136: duplicate relations must appear in exported frontmatter, both
@@ -902,5 +1385,205 @@ mod tests {
             .prefix(&format!("lific-{label}-"))
             .tempdir()
             .unwrap()
+    }
+
+    #[test]
+    fn project_preflight_rejects_aggregate_source_bytes_before_materialization() {
+        let db = open_memory().unwrap();
+        let conn = db.write().unwrap();
+        let project = queries::create_project(
+            &conn,
+            &CreateProject {
+                name: "Source Bound".into(),
+                identifier: "SRC".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        for title in ["First", "Second"] {
+            queries::create_issue(
+                &conn,
+                &CreateIssue {
+                    project_id: project.id,
+                    title: title.into(),
+                    description: "twenty source bytes!".into(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        }
+
+        let error = ensure_project_preflight(&conn, project.id, 32).unwrap_err();
+        assert!(error.to_string().contains("project source exceeds"));
+    }
+
+    #[test]
+    fn project_export_rejects_too_many_comments_in_aggregate() {
+        let db = open_memory().unwrap();
+        let conn = db.write().unwrap();
+        let project = queries::create_project(
+            &conn,
+            &CreateProject {
+                name: "Comment Bound".into(),
+                identifier: "CMT".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let user = queries::users::create_user(
+            &conn,
+            &crate::db::models::CreateUser {
+                username: "commenter".into(),
+                email: "commenter@example.com".into(),
+                password: "password123".into(),
+                display_name: None,
+                is_admin: false,
+                is_bot: false,
+            },
+        )
+        .unwrap();
+        let issues = ["First", "Second"].map(|title| {
+            queries::create_issue(
+                &conn,
+                &CreateIssue {
+                    project_id: project.id,
+                    title: title.into(),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+        });
+        for issue in issues {
+            for _ in 0..251 {
+                queries::comments::create_comment(
+                    &conn,
+                    queries::comments::CommentParent::Issue(issue.id),
+                    user.id,
+                    "bounded",
+                )
+                .unwrap();
+            }
+        }
+
+        let error = export_project(&conn, "CMT").unwrap_err();
+        assert!(error.to_string().contains("too many comments"));
+    }
+
+    #[test]
+    fn project_export_rejects_too_many_folders_before_loading_them() {
+        let db = open_memory().unwrap();
+        let conn = db.write().unwrap();
+        let project = queries::create_project(
+            &conn,
+            &CreateProject {
+                name: "Folder Bound".into(),
+                identifier: "FLD".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        conn.execute(
+            "WITH RECURSIVE sequence(value) AS (
+                 SELECT 1 UNION ALL SELECT value + 1 FROM sequence WHERE value <= ?2
+             )
+             INSERT INTO folders (project_id, name)
+             SELECT ?1, 'folder-' || value FROM sequence",
+            rusqlite::params![project.id, MAX_EXPORT_METADATA_ITEMS],
+        )
+        .unwrap();
+
+        let error = export_project(&conn, "FLD").unwrap_err();
+        assert!(error.to_string().contains("too many metadata entries"));
+    }
+
+    #[test]
+    fn export_file_limit_includes_its_path() {
+        let bundle = ExportBundle {
+            root: "TEST".into(),
+            files: vec![ExportFile {
+                path: "TEST/issues/large.md".into(),
+                content: "x".repeat(MAX_EXPORT_FILE_BYTES),
+            }],
+        };
+
+        let error = validate_bundle(&bundle).unwrap_err();
+        assert!(error.to_string().contains("exceeds"));
+    }
+
+    #[test]
+    fn json_export_bounds_the_encoded_output() {
+        let bundle = ExportBundle {
+            root: "TEST".into(),
+            files: vec![ExportFile {
+                path: "TEST/page.md".into(),
+                content: "\0".repeat(16),
+            }],
+        };
+        let output = scratch_dir("json-byte-cap");
+        let error = bundle_to_json_file_with_limit(
+            &bundle,
+            &output.path().join("export.json"),
+            64,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("encoded-output limit"));
+    }
+
+    #[test]
+    fn json_and_zip_accept_the_same_control_heavy_bundle() {
+        let bundle = ExportBundle {
+            root: "TEST".into(),
+            files: vec![ExportFile {
+                path: "TEST/page.md".into(),
+                content: "\0".repeat(1_024),
+            }],
+        };
+        let output = scratch_dir("json-policy");
+
+        bundle_to_zip(&bundle).unwrap();
+        bundle_to_json_file(&bundle, &output.path().join("export.json")).unwrap();
+    }
+
+    #[test]
+    fn project_export_bounds_metadata_before_materializing_it() {
+        let db = open_memory().unwrap();
+        let conn = db.write().unwrap();
+        let project = queries::create_project(
+            &conn,
+            &CreateProject {
+                name: "Metadata Bound".into(),
+                identifier: "META".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let issue = queries::create_issue(
+            &conn,
+            &CreateIssue {
+                project_id: project.id,
+                title: "Bound labels".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        conn.execute(
+            "WITH RECURSIVE sequence(value) AS (
+                 SELECT 1 UNION ALL SELECT value + 1 FROM sequence WHERE value <= ?2
+             )
+             INSERT INTO labels (project_id, name)
+             SELECT ?1, 'label-' || value FROM sequence",
+            rusqlite::params![project.id, MAX_EXPORT_METADATA_ITEMS],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO issue_labels (issue_id, label_id)
+             SELECT ?1, id FROM labels WHERE project_id = ?2",
+            rusqlite::params![issue.id, project.id],
+        )
+        .unwrap();
+
+        let error = export_project(&conn, "META").unwrap_err();
+        assert!(error.to_string().contains("too many metadata entries"));
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -73,37 +73,82 @@ fn ensure_comment_sizes(conn: &Connection, issue_id: i64) -> Result<(), LificErr
     Ok(())
 }
 
-fn ensure_issue_metadata_size(conn: &Connection, issue_id: i64) -> Result<(), LificError> {
-    let (items, bytes): (i64, i64) = conn.query_row(
+fn ensure_issue_preflight(
+    conn: &Connection,
+    issue_id: i64,
+    max_total_bytes: i64,
+) -> Result<(), LificError> {
+    let (metadata_items, source_bytes): (i64, i64) = conn.query_row(
         "SELECT
             (SELECT COUNT(*) FROM issue_labels WHERE issue_id = ?1) +
             (SELECT COUNT(*) FROM issue_relations WHERE source_id = ?1 OR target_id = ?1),
+            length(CAST(i.title AS BLOB)) +
+            length(CAST(i.description AS BLOB)) +
+            length(CAST(COALESCE(i.source, '') AS BLOB)) +
+            length(CAST(p.name AS BLOB)) +
+            length(CAST(p.identifier AS BLOB)) +
+            length(CAST(p.description AS BLOB)) +
+            length(CAST(COALESCE(p.emoji, '') AS BLOB)) +
+            COALESCE(length(CAST(m.name AS BLOB)), 0) +
+            (SELECT COALESCE(SUM(length(CAST(c.content AS BLOB)) +
+                                 length(CAST(COALESCE(u.display_name, u.username) AS BLOB))), 0)
+               FROM comments c JOIN users u ON u.id = c.user_id WHERE c.issue_id = ?1) +
             (SELECT COALESCE(SUM(length(CAST(l.name AS BLOB))), 0)
                FROM issue_labels il JOIN labels l ON l.id = il.label_id WHERE il.issue_id = ?1) +
-            (SELECT COALESCE(SUM(length(CAST(p.identifier AS BLOB)) + 20), 0)
+            (SELECT COALESCE(SUM(length(CAST(other_project.identifier AS BLOB)) + 20), 0)
                FROM issue_relations ir
                JOIN issues other ON other.id = CASE WHEN ir.source_id = ?1 THEN ir.target_id ELSE ir.source_id END
-               JOIN projects p ON p.id = other.project_id
-              WHERE ir.source_id = ?1 OR ir.target_id = ?1) +
-            (SELECT COALESCE(SUM(length(CAST(COALESCE(u.display_name, u.username) AS BLOB))), 0)
-               FROM comments c JOIN users u ON u.id = c.user_id WHERE c.issue_id = ?1) +
-            (SELECT COALESCE(length(CAST(m.name AS BLOB)), 0)
-               FROM issues i LEFT JOIN modules m ON m.id = i.module_id WHERE i.id = ?1)",
+               JOIN projects other_project ON other_project.id = other.project_id
+              WHERE ir.source_id = ?1 OR ir.target_id = ?1)
+         FROM issues i
+         JOIN projects p ON p.id = i.project_id
+         LEFT JOIN modules m ON m.id = i.module_id
+         WHERE i.id = ?1",
         [issue_id],
         |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
-    ensure_metadata_size(items, bytes)
+    ensure_metadata_size(metadata_items, 0)?;
+    if source_bytes > max_total_bytes {
+        return Err(LificError::BadRequest(format!(
+            "issue source exceeds the {max_total_bytes} byte total export limit"
+        )));
+    }
+    Ok(())
 }
 
-fn ensure_page_metadata_size(conn: &Connection, page_id: i64) -> Result<(), LificError> {
-    let (items, bytes): (i64, i64) = conn.query_row(
-        "SELECT COUNT(*), COALESCE(SUM(length(CAST(l.name AS BLOB))), 0)
-           FROM page_labels pl JOIN labels l ON l.id = pl.label_id
-          WHERE pl.page_id = ?1",
+fn ensure_page_preflight(
+    conn: &Connection,
+    page_id: i64,
+    max_total_bytes: i64,
+) -> Result<(), LificError> {
+    let (metadata_items, source_bytes): (i64, i64) = conn.query_row(
+        "SELECT
+            (SELECT COUNT(*) FROM page_labels WHERE page_id = ?1) +
+            (SELECT COUNT(*) FROM folders WHERE project_id = page.project_id),
+            length(CAST(page.title AS BLOB)) +
+            length(CAST(page.content AS BLOB)) +
+            COALESCE(length(CAST(project.name AS BLOB)) +
+                     length(CAST(project.identifier AS BLOB)) +
+                     length(CAST(project.description AS BLOB)) +
+                     length(CAST(COALESCE(project.emoji, '') AS BLOB)), 0) +
+            (SELECT COALESCE(SUM(length(CAST(label.name AS BLOB))), 0)
+               FROM page_labels JOIN labels label ON label.id = page_labels.label_id
+              WHERE page_labels.page_id = ?1) +
+            (SELECT COALESCE(SUM(length(CAST(name AS BLOB))), 0)
+               FROM folders WHERE project_id = page.project_id)
+         FROM pages page
+         LEFT JOIN projects project ON project.id = page.project_id
+         WHERE page.id = ?1",
         [page_id],
         |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
-    ensure_metadata_size(items, bytes)
+    ensure_metadata_size(metadata_items, 0)?;
+    if source_bytes > max_total_bytes {
+        return Err(LificError::BadRequest(format!(
+            "page source exceeds the {max_total_bytes} byte total export limit"
+        )));
+    }
+    Ok(())
 }
 
 fn bounded_folders(conn: &Connection, project_id: i64) -> Result<Vec<Folder>, LificError> {
@@ -246,10 +291,7 @@ fn validate_bundle(bundle: &ExportBundle) -> Result<(), LificError> {
     Ok(())
 }
 
-fn bounded_issue_comments(
-    conn: &Connection,
-    issue_id: i64,
-) -> Result<Vec<Comment>, LificError> {
+fn bounded_issue_comments(conn: &Connection, issue_id: i64) -> Result<Vec<Comment>, LificError> {
     let parent = queries::comments::CommentParent::Issue(issue_id);
     ensure_comment_sizes(conn, issue_id)?;
     if queries::comments::count_comments(conn, parent, None)? > MAX_EXPORT_COMMENTS {
@@ -274,10 +316,7 @@ pub fn export_issue(conn: &Connection, identifier: &str) -> Result<ExportBundle,
     Ok(bundle)
 }
 
-fn export_issue_snapshot(
-    conn: &Connection,
-    identifier: &str,
-) -> Result<ExportBundle, LificError> {
+fn export_issue_snapshot(conn: &Connection, identifier: &str) -> Result<ExportBundle, LificError> {
     let issue_id = queries::resolve_identifier(conn, identifier)?;
     let oversized: i64 = conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM issues WHERE id = ?1 AND (
@@ -289,14 +328,12 @@ fn export_issue_snapshot(
         |row| row.get(0),
     )?;
     if oversized != 0 {
-        return Err(LificError::BadRequest("issue content exceeds export limit".into()));
+        return Err(LificError::BadRequest(
+            "issue content exceeds export limit".into(),
+        ));
     }
-    ensure_issue_metadata_size(conn, issue_id)?;
-    let project_id = conn.query_row(
-        "SELECT project_id FROM issues WHERE id = ?1",
-        [issue_id],
-        |row| row.get(0),
-    )?;
+    ensure_issue_preflight(conn, issue_id, MAX_EXPORT_TOTAL_BYTES as i64)?;
+    let project_id = queries::issue_project_id(conn, issue_id)?;
     let project = bounded_project(conn, project_id)?;
     let issue = queries::get_issue(conn, issue_id)?;
     ensure_text_size("issue title", &issue.title)?;
@@ -322,10 +359,7 @@ pub fn export_page(conn: &Connection, identifier: &str) -> Result<ExportBundle, 
     Ok(bundle)
 }
 
-fn export_page_snapshot(
-    conn: &Connection,
-    identifier: &str,
-) -> Result<ExportBundle, LificError> {
+fn export_page_snapshot(conn: &Connection, identifier: &str) -> Result<ExportBundle, LificError> {
     let page_id = queries::resolve_page_identifier(conn, identifier)?;
     let oversized: i64 = conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM pages WHERE id = ?1 AND (length(CAST(title AS BLOB)) > ?2 OR length(CAST(content AS BLOB)) > ?2))",
@@ -333,23 +367,22 @@ fn export_page_snapshot(
         |row| row.get(0),
     )?;
     if oversized != 0 {
-        return Err(LificError::BadRequest("page content exceeds export limit".into()));
+        return Err(LificError::BadRequest(
+            "page content exceeds export limit".into(),
+        ));
     }
-    ensure_page_metadata_size(conn, page_id)?;
-    let project_id = conn.query_row(
-        "SELECT project_id FROM pages WHERE id = ?1",
-        [page_id],
-        |row| row.get::<_, Option<i64>>(0),
-    )?;
+    ensure_page_preflight(conn, page_id, MAX_EXPORT_TOTAL_BYTES as i64)?;
+    let project_id = queries::page_project_id(conn, page_id)?;
     let project = project_id
         .map(|project_id| bounded_project(conn, project_id))
         .transpose()?;
     let page = queries::get_page(conn, page_id)?;
     ensure_text_size("page title", &page.title)?;
     ensure_text_size("page content", &page.content)?;
-    let root = project
-        .as_ref()
-        .map_or_else(|| "workspace".to_string(), |project| project.identifier.clone());
+    let root = project.as_ref().map_or_else(
+        || "workspace".to_string(),
+        |project| project.identifier.clone(),
+    );
     let folders = project_id
         .map(|project_id| bounded_folders(conn, project_id))
         .transpose()?
@@ -381,7 +414,8 @@ fn ensure_project_preflight(
         comment_bytes,
         metadata_items,
         metadata_bytes,
-    ): (i64, i64, i64, i64, i64, i64, i64, i64) = conn.query_row(
+        project_bytes,
+    ): (i64, i64, i64, i64, i64, i64, i64, i64, i64) = conn.query_row(
         "SELECT
             (SELECT COUNT(*) FROM issues WHERE project_id = ?1),
             (SELECT COUNT(*) FROM pages WHERE project_id = ?1),
@@ -416,12 +450,18 @@ fn ensure_project_preflight(
                    JOIN projects source_project ON source_project.id = source.project_id
                    JOIN issues target ON target.id = ir.target_id
                    JOIN projects target_project ON target_project.id = target.project_id
-                  WHERE source.project_id = ?1 OR target.project_id = ?1)",
+                  WHERE source.project_id = ?1 OR target.project_id = ?1),
+            (SELECT length(CAST(name AS BLOB)) +
+                    length(CAST(identifier AS BLOB)) +
+                    length(CAST(description AS BLOB)) +
+                    length(CAST(COALESCE(emoji, '') AS BLOB))
+               FROM projects WHERE id = ?1)",
         [project_id],
         |row| {
             Ok((
                 row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?,
                 row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?,
+                row.get(8)?,
             ))
         },
     )?;
@@ -443,6 +483,7 @@ fn ensure_project_preflight(
         .checked_add(page_bytes)
         .and_then(|bytes| bytes.checked_add(comment_bytes))
         .and_then(|bytes| bytes.checked_add(metadata_bytes))
+        .and_then(|bytes| bytes.checked_add(project_bytes))
         .ok_or_else(|| LificError::BadRequest("export size overflow".into()))?;
     if source_bytes > max_total_bytes {
         return Err(LificError::BadRequest(format!(
@@ -469,7 +510,9 @@ fn ensure_project_preflight(
         |row| row.get(0),
     )?;
     if oversized != 0 {
-        return Err(LificError::BadRequest("project content exceeds export limit".into()));
+        return Err(LificError::BadRequest(
+            "project content exceeds export limit".into(),
+        ));
     }
     Ok(())
 }
@@ -479,8 +522,8 @@ fn export_project_snapshot(
     identifier: &str,
 ) -> Result<ExportBundle, LificError> {
     let project_id = queries::resolve_project_identifier(conn, identifier)?;
+    ensure_project_preflight(conn, project_id, MAX_EXPORT_TOTAL_BYTES as i64)?;
     let project = bounded_project(conn, project_id)?;
-    ensure_project_preflight(conn, project.id, MAX_EXPORT_TOTAL_BYTES as i64)?;
     let issue_ids = conn
         .prepare_cached("SELECT id FROM issues WHERE project_id = ?1 ORDER BY id")?
         .query_map([project.id], |row| row.get(0))?
@@ -728,10 +771,7 @@ pub fn bundle_to_zip_file(bundle: &ExportBundle, path: &Path) -> Result<(), Lifi
     Ok(())
 }
 
-pub(crate) fn bundle_to_json_file(
-    bundle: &ExportBundle,
-    path: &Path,
-) -> Result<(), LificError> {
+pub(crate) fn bundle_to_json_file(bundle: &ExportBundle, path: &Path) -> Result<(), LificError> {
     bundle_to_json_file_with_limit(bundle, path, MAX_EXPORT_JSON_BYTES)
 }
 
@@ -1054,7 +1094,10 @@ mod tests {
             .unwrap();
         assert!(issue_file.content.contains("identifier: EXP-1"));
         assert!(issue_file.content.contains("## Comments"));
-        assert_eq!(issue_file.content.matches("First exported comment").count(), 1);
+        assert_eq!(
+            issue_file.content.matches("First exported comment").count(),
+            1
+        );
     }
 
     // LIF-136: duplicate relations must appear in exported frontmatter, both
@@ -1520,12 +1563,8 @@ mod tests {
             }],
         };
         let output = scratch_dir("json-byte-cap");
-        let error = bundle_to_json_file_with_limit(
-            &bundle,
-            &output.path().join("export.json"),
-            64,
-        )
-        .unwrap_err();
+        let error = bundle_to_json_file_with_limit(&bundle, &output.path().join("export.json"), 64)
+            .unwrap_err();
 
         assert!(error.to_string().contains("encoded-output limit"));
     }
@@ -1584,6 +1623,85 @@ mod tests {
         .unwrap();
 
         let error = export_project(&conn, "META").unwrap_err();
+        assert!(error.to_string().contains("too many metadata entries"));
+    }
+
+    #[test]
+    fn issue_preflight_combines_all_source_bytes() {
+        let db = open_memory().unwrap();
+        let conn = db.write().unwrap();
+        let project = queries::create_project(
+            &conn,
+            &CreateProject {
+                name: "Source project".into(),
+                identifier: "ONE".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let issue = queries::create_issue(
+            &conn,
+            &CreateIssue {
+                project_id: project.id,
+                title: "Source title".into(),
+                description: "Source description".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let error = ensure_issue_preflight(&conn, issue.id, 32).unwrap_err();
+        assert!(error.to_string().contains("source exceeds"));
+    }
+
+    #[test]
+    fn page_export_combines_label_and_folder_metadata_counts() {
+        let db = open_memory().unwrap();
+        let conn = db.write().unwrap();
+        let project = queries::create_project(
+            &conn,
+            &CreateProject {
+                name: "Metadata project".into(),
+                identifier: "TWO".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let page = queries::create_page(
+            &conn,
+            &CreatePage {
+                project_id: Some(project.id),
+                title: "Metadata page".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        conn.execute(
+            "WITH RECURSIVE sequence(value) AS (
+                 SELECT 1 UNION ALL SELECT value + 1 FROM sequence WHERE value < 2501
+             )
+             INSERT INTO labels (project_id, name)
+             SELECT ?1, 'label-' || value FROM sequence",
+            [project.id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO page_labels (page_id, label_id)
+             SELECT ?1, id FROM labels WHERE project_id = ?2",
+            rusqlite::params![page.id, project.id],
+        )
+        .unwrap();
+        conn.execute(
+            "WITH RECURSIVE sequence(value) AS (
+                 SELECT 1 UNION ALL SELECT value + 1 FROM sequence WHERE value < 2500
+             )
+             INSERT INTO folders (project_id, name)
+             SELECT ?1, 'folder-' || value FROM sequence",
+            [project.id],
+        )
+        .unwrap();
+
+        let error = export_page(&conn, &page.identifier).unwrap_err();
         assert!(error.to_string().contains("too many metadata entries"));
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -10,12 +10,12 @@ use rmcp::{handler::server::wrapper::Parameters, tool, tool_router};
 
 use crate::{
     authz::filter_visible,
-    db::{DbPool, models, queries},
+    db::{models, queries, DbPool},
     links::{IssueLinkContext, MarkdownReference},
 };
 
 use super::schemas::*;
-use super::{LificMcp, current_issue_link_context, sanitize_error};
+use super::{current_issue_link_context, sanitize_error, LificMcp};
 
 /// Self-onboarding nudge (LIF-257): shown by cold read tools when the DB has
 /// **zero** projects, so the first agent connecting to a fresh install learns
@@ -1845,7 +1845,9 @@ impl LificMcp {
         description = "Export as markdown: an issue (PRO-42), a page (PRO-DOC-3), or a whole project (PRO). Issues and pages return the markdown; projects return the exported file paths."
     )]
     async fn export(&self, Parameters(input): Parameters<ExportInput>) -> String {
-        self.export_inner(input).await.unwrap_or_else(error_response)
+        self.export_inner(input)
+            .await
+            .unwrap_or_else(error_response)
     }
 
     async fn export_inner(&self, input: ExportInput) -> Result<String, String> {
@@ -1863,13 +1865,13 @@ impl LificMcp {
         let kind = if looks_like_page_identifier(ident) {
             let project_id = self.read(|conn| {
                 let id = queries::resolve_page_identifier(conn, ident)?;
-                Ok(queries::get_page(conn, id)?.project_id)
+                queries::page_project_id(conn, id)
             })?;
             require_page_role_mcp(&self.db, project_id, models::Role::Viewer)?;
             Kind::Page
         } else if let Ok(project_id) = self.read(|conn| {
             let id = queries::resolve_identifier(conn, ident)?;
-            Ok(queries::get_issue(conn, id)?.project_id)
+            queries::issue_project_id(conn, id)
         }) {
             require_role_mcp(&self.db, project_id, models::Role::Viewer)?;
             Kind::Issue
@@ -1890,9 +1892,7 @@ impl LificMcp {
             let bundle = match kind {
                 Kind::Issue => this.read(|conn| crate::export::export_issue(conn, &identifier)),
                 Kind::Page => this.read(|conn| crate::export::export_page(conn, &identifier)),
-                Kind::Project => {
-                    this.read(|conn| crate::export::export_project(conn, &identifier))
-                }
+                Kind::Project => this.read(|conn| crate::export::export_project(conn, &identifier)),
             }?;
             Ok::<_, String>((bundle, slot))
         })
@@ -2150,8 +2150,10 @@ impl LificMcp {
                             &models::UpdateIssue {
                                 status: models::Status::parse_opt(input.set_status.as_deref())
                                     .map_err(crate::error::LificError::BadRequest)?,
-                                priority: models::Priority::parse_opt(input.set_priority.as_deref())
-                                    .map_err(crate::error::LificError::BadRequest)?,
+                                priority: models::Priority::parse_opt(
+                                    input.set_priority.as_deref(),
+                                )
+                                .map_err(crate::error::LificError::BadRequest)?,
                                 module_id: set_module_id.map(Some),
                                 ..Default::default()
                             },
@@ -3141,11 +3143,7 @@ impl LificMcp {
                 let lead_user_id = super::current_auth_user().and_then(|u| {
                     self.read(|conn| {
                         Ok(conn
-                            .query_row(
-                                "SELECT 1 FROM users WHERE id = ?1",
-                                rusqlite::params![u.id],
-                                |_| Ok(()),
-                            )
+                            .query_row("SELECT 1 FROM users WHERE id = ?1", rusqlite::params![u.id], |_| Ok(()))
                             .is_ok())
                     })
                     .ok()
@@ -3176,10 +3174,7 @@ impl LificMcp {
             }
             ("project", "update") => {
                 if matches!((&input.current_name, &input.project), (Some(_), None)) {
-                    return Err(
-                        "project updates must be targeted with project=<identifier>, not current_name"
-                            .into(),
-                    );
+                    return Err("project updates must be targeted with project=<identifier>, not current_name".into());
                 }
                 let Some(ref proj) = input.project else {
                     return Err("project identifier required".into());
@@ -4628,7 +4623,11 @@ mod tests {
         seed_first_admin(&db);
         let realtime = crate::realtime::RealtimeHub::new();
         let rx = realtime.subscribe();
-        (LificMcp::with_realtime(db, realtime), rx, acquire_test_guard())
+        (
+            LificMcp::with_realtime(db, realtime),
+            rx,
+            acquire_test_guard(),
+        )
     }
 
     fn drain_realtime(rx: &mut tokio::sync::broadcast::Receiver<crate::realtime::RealtimeMessage>) {
@@ -6222,19 +6221,18 @@ mod tests {
         };
         let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
 
-        let result =
-            crate::mcp::with_request_context(Some(auth_user), Some(context), || async {
-                m.add_comment(Parameters(AddCommentInput {
-                    identifier: "SRC-1".into(),
-                    content: "Unique comment needle".into(),
-                }));
-                m.search(Parameters(SearchInput {
-                    query: "needle".into(),
-                    result_type: Some("comment".into()),
-                    ..Default::default()
-                }))
-            })
-            .await;
+        let result = crate::mcp::with_request_context(Some(auth_user), Some(context), || async {
+            m.add_comment(Parameters(AddCommentInput {
+                identifier: "SRC-1".into(),
+                content: "Unique comment needle".into(),
+            }));
+            m.search(Parameters(SearchInput {
+                query: "needle".into(),
+                result_type: Some("comment".into()),
+                ..Default::default()
+            }))
+        })
+        .await;
 
         assert!(
             result.contains(
@@ -6315,14 +6313,8 @@ mod tests {
         let attachment_id = m
             .write(|conn| {
                 use crate::db::queries::attachments as att;
-                let attachment = att::create_attachment(
-                    conn,
-                    "sha",
-                    "server.log",
-                    "text/plain",
-                    64,
-                    None,
-                )?;
+                let attachment =
+                    att::create_attachment(conn, "sha", "server.log", "text/plain", 64, None)?;
                 att::link_attachment(
                     conn,
                     attachment.id,
@@ -6339,7 +6331,10 @@ mod tests {
             ..Default::default()
         }));
         assert!(result.contains("[attachment] server.log"), "got: {result}");
-        assert!(result.contains(&format!("#{attachment_id}")), "got: {result}");
+        assert!(
+            result.contains(&format!("#{attachment_id}")),
+            "got: {result}"
+        );
         assert!(result.contains("SRC-1"), "got: {result}");
     }
 
@@ -7150,7 +7145,10 @@ mod tests {
         assert!(result.starts_with("Comment #"), "got: {result}");
 
         let comment_id = comment_id_from(&result);
-        assert_eq!(links_for(&m, att), vec![("comment".to_string(), comment_id)]);
+        assert_eq!(
+            links_for(&m, att),
+            vec![("comment".to_string(), comment_id)]
+        );
     }
 
     #[test]
@@ -7167,7 +7165,10 @@ mod tests {
             content: format!("/api/attachments/{old}"),
         }));
         let comment_id = comment_id_from(&created);
-        assert_eq!(links_for(&m, old), vec![("comment".to_string(), comment_id)]);
+        assert_eq!(
+            links_for(&m, old),
+            vec![("comment".to_string(), comment_id)]
+        );
 
         let result = m.edit_comment(Parameters(EditCommentInput {
             comment_id,
@@ -7176,7 +7177,10 @@ mod tests {
         assert!(result.starts_with("Comment #"), "got: {result}");
 
         assert!(links_for(&m, old).is_empty(), "dropped reference unlinks");
-        assert_eq!(links_for(&m, new), vec![("comment".to_string(), comment_id)]);
+        assert_eq!(
+            links_for(&m, new),
+            vec![("comment".to_string(), comment_id)]
+        );
     }
 
     #[test]
@@ -7789,27 +7793,35 @@ mod tests {
         assert!(created.starts_with("Created"), "got: {created}");
 
         // Issue shape (EXP-1) returns the issue markdown.
-        let issue = m.export(Parameters(ExportInput {
-            identifier: "EXP-1".into(),
-        })).await;
+        let issue = m
+            .export(Parameters(ExportInput {
+                identifier: "EXP-1".into(),
+            }))
+            .await;
         assert!(issue.contains("issue body here"), "got: {issue}");
 
         // Page shape (EXP-DOC-1) returns the page markdown.
-        let page = m.export(Parameters(ExportInput {
-            identifier: "EXP-DOC-1".into(),
-        })).await;
+        let page = m
+            .export(Parameters(ExportInput {
+                identifier: "EXP-DOC-1".into(),
+            }))
+            .await;
         assert!(page.contains("page body here"), "got: {page}");
 
         // Bare project shape (EXP) returns the exported file listing.
-        let project = m.export(Parameters(ExportInput {
-            identifier: "EXP".into(),
-        })).await;
+        let project = m
+            .export(Parameters(ExportInput {
+                identifier: "EXP".into(),
+            }))
+            .await;
         assert!(project.contains("exported file(s)"), "got: {project}");
 
         // Unknown identifiers name all three shapes in the error.
-        let err = m.export(Parameters(ExportInput {
-            identifier: "NOPE-999".into(),
-        })).await;
+        let err = m
+            .export(Parameters(ExportInput {
+                identifier: "NOPE-999".into(),
+            }))
+            .await;
         assert!(
             err.contains("not a known issue, page, or project"),
             "got: {err}"
@@ -7817,9 +7829,11 @@ mod tests {
 
         let first = m.db.acquire_export_slot().unwrap();
         let second = m.db.acquire_export_slot().unwrap();
-        let blocked = m.export(Parameters(ExportInput {
-            identifier: "EXP".into(),
-        })).await;
+        let blocked = m
+            .export(Parameters(ExportInput {
+                identifier: "EXP".into(),
+            }))
+            .await;
         assert!(blocked.contains("too many exports"), "got: {blocked}");
         drop((first, second));
     }
@@ -7846,9 +7860,11 @@ mod tests {
             "get_issue mangled content: {detail}"
         );
 
-        let exported = m.export(Parameters(ExportInput {
-            identifier: "ESC-1".into(),
-        })).await;
+        let exported = m
+            .export(Parameters(ExportInput {
+                identifier: "ESC-1".into(),
+            }))
+            .await;
         assert!(
             exported.contains(description.trim_end()),
             "export mangled content: {exported}"
@@ -7896,7 +7912,7 @@ mod tests {
             realtime_events(&mut rx),
             vec![crate::realtime::RealtimeEvent::IssueUpdated {
                 project_id,
-                issue_id,
+                issue_id
             }]
         );
     }
@@ -9175,9 +9191,7 @@ mod tests {
         );
         assert_eq!(
             deleted,
-            format!(
-                "Comment #{comment_id} deleted from [PRJ-1](https://tracker.example/PRJ/issues/PRJ-1)"
-            )
+            format!("Comment #{comment_id} deleted from [PRJ-1](https://tracker.example/PRJ/issues/PRJ-1)")
         );
     }
 
@@ -9206,7 +9220,7 @@ mod tests {
             realtime_events(&mut events),
             vec![crate::realtime::RealtimeEvent::IssueUpdated {
                 project_id,
-                issue_id,
+                issue_id
             }]
         );
 
@@ -9215,7 +9229,7 @@ mod tests {
             realtime_events(&mut events),
             vec![crate::realtime::RealtimeEvent::IssueUpdated {
                 project_id,
-                issue_id,
+                issue_id
             }]
         );
     }
@@ -9594,26 +9608,25 @@ mod tests {
         assert_eq!(linked, "TST-1 blocks TST-2");
         let context = crate::links::IssueLinkContext::parse("https://tracker.example").unwrap();
 
-        let (live, stale) =
-            crate::mcp::with_request_context(None, Some(context), || async {
-                let live = m.get_activity(Parameters(GetActivityInput {
-                    identifier: "TST".into(),
-                    ..Default::default()
-                }));
-                m.manage_resource(Parameters(ManageResourceInput {
-                    resource_type: "project".into(),
-                    action: "update".into(),
-                    project: Some("TST".into()),
-                    identifier: Some("NEW".into()),
-                    ..Default::default()
-                }));
-                let stale = m.get_activity(Parameters(GetActivityInput {
-                    identifier: "NEW".into(),
-                    ..Default::default()
-                }));
-                (live, stale)
-            })
-            .await;
+        let (live, stale) = crate::mcp::with_request_context(None, Some(context), || async {
+            let live = m.get_activity(Parameters(GetActivityInput {
+                identifier: "TST".into(),
+                ..Default::default()
+            }));
+            m.manage_resource(Parameters(ManageResourceInput {
+                resource_type: "project".into(),
+                action: "update".into(),
+                project: Some("TST".into()),
+                identifier: Some("NEW".into()),
+                ..Default::default()
+            }));
+            let stale = m.get_activity(Parameters(GetActivityInput {
+                identifier: "NEW".into(),
+                ..Default::default()
+            }));
+            (live, stale)
+        })
+        .await;
 
         assert!(
             live.contains(
@@ -9653,9 +9666,7 @@ mod tests {
         .await;
 
         assert!(
-            out.contains(
-                "created plan_step [TST-PLAN-1](https://tracker.example/TST/plans/1): Exercise the link"
-            ),
+            out.contains("created plan_step [TST-PLAN-1](https://tracker.example/TST/plans/1): Exercise the link"),
             "got: {out}"
         );
     }
@@ -10059,7 +10070,7 @@ mod tests {
             vec![
                 crate::realtime::RealtimeEvent::IssueUpdated {
                     project_id,
-                    issue_id,
+                    issue_id
                 },
                 crate::realtime::RealtimeEvent::ProjectUpdated { project_id },
             ]
@@ -10900,7 +10911,8 @@ mod authz_gating_tests {
 
     #[test]
     fn issue_read_denies_non_member_allows_viewer() {
-        let (m, _admin, lead, _maintainer, viewer, non_member, project_id, _guard) = setup_membership_mcp();
+        let (m, _admin, lead, _maintainer, viewer, non_member, project_id, _guard) =
+            setup_membership_mcp();
         let _ = project_id;
         let created = as_user(&lead, || {
             m.create_issue(Parameters(CreateIssueInput {
@@ -11447,7 +11459,8 @@ mod authz_gating_tests {
 
     #[test]
     fn issue_create_gated_by_maintainer_role() {
-        let (m, admin, lead, maintainer, viewer, non_member, _project_id, _guard) = setup_membership_mcp();
+        let (m, admin, lead, maintainer, viewer, non_member, _project_id, _guard) =
+            setup_membership_mcp();
 
         for (user, expect_ok) in [
             (&non_member, false),
@@ -11479,7 +11492,8 @@ mod authz_gating_tests {
 
     #[test]
     fn issue_update_and_delete_gated_by_maintainer_role() {
-        let (m, _admin, lead, maintainer, viewer, non_member, _project_id, _guard) = setup_membership_mcp();
+        let (m, _admin, lead, maintainer, viewer, non_member, _project_id, _guard) =
+            setup_membership_mcp();
         let created = as_user(&maintainer, || {
             m.create_issue(Parameters(CreateIssueInput {
                 project: "MEM".into(),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1844,52 +1844,81 @@ impl LificMcp {
     #[tool(
         description = "Export as markdown: an issue (PRO-42), a page (PRO-DOC-3), or a whole project (PRO). Issues and pages return the markdown; projects return the exported file paths."
     )]
-    fn export(&self, Parameters(input): Parameters<ExportInput>) -> String {
-        self.export_inner(input).unwrap_or_else(error_response)
+    async fn export(&self, Parameters(input): Parameters<ExportInput>) -> String {
+        self.export_inner(input).await.unwrap_or_else(error_response)
     }
 
-    fn export_inner(&self, input: ExportInput) -> Result<String, String> {
+    async fn export_inner(&self, input: ExportInput) -> Result<String, String> {
+        #[derive(Clone, Copy)]
+        enum Kind {
+            Issue,
+            Page,
+            Project,
+        }
+
         let ident = input.identifier.trim();
         // Same identifier-shape dispatch as get_activity: pages are
         // unambiguous (DOC segment); issue resolution requires a numeric
         // tail, so a bare project identifier falls through cleanly.
-        if looks_like_page_identifier(ident) {
+        let kind = if looks_like_page_identifier(ident) {
             let project_id = self.read(|conn| {
                 let id = queries::resolve_page_identifier(conn, ident)?;
                 Ok(queries::get_page(conn, id)?.project_id)
             })?;
             require_page_role_mcp(&self.db, project_id, models::Role::Viewer)?;
-            let bundle = self.read(|conn| crate::export::export_page(conn, ident))?;
-            Ok(bundle
-                .files
-                .into_iter()
-                .next()
-                .map(|file| file.content)
-                .unwrap_or_else(|| "Error: page export produced no files".into()))
+            Kind::Page
         } else if let Ok(project_id) = self.read(|conn| {
             let id = queries::resolve_identifier(conn, ident)?;
             Ok(queries::get_issue(conn, id)?.project_id)
         }) {
             require_role_mcp(&self.db, project_id, models::Role::Viewer)?;
-            let bundle = self.read(|conn| crate::export::export_issue(conn, ident))?;
-            Ok(bundle
+            Kind::Issue
+        } else {
+            let project_id = resolve_project(&*self.read_conn()?, ident)
+                .map_err(|_| unknown_identifier(ident))?;
+            require_role_mcp(&self.db, project_id, models::Role::Viewer)?;
+            Kind::Project
+        };
+
+        let slot = self
+            .db
+            .acquire_export_slot()
+            .map_err(|error| error.to_string())?;
+        let this = self.clone();
+        let identifier = ident.to_string();
+        let (bundle, _slot) = tokio::task::spawn_blocking(move || {
+            let bundle = match kind {
+                Kind::Issue => this.read(|conn| crate::export::export_issue(conn, &identifier)),
+                Kind::Page => this.read(|conn| crate::export::export_page(conn, &identifier)),
+                Kind::Project => {
+                    this.read(|conn| crate::export::export_project(conn, &identifier))
+                }
+            }?;
+            Ok::<_, String>((bundle, slot))
+        })
+        .await
+        .map_err(|error| format!("export worker failed: {error}"))??;
+
+        match kind {
+            Kind::Page => Ok(bundle
                 .files
                 .into_iter()
                 .next()
                 .map(|file| file.content)
-                .unwrap_or_else(|| "Error: issue export produced no files".into()))
-        } else {
-            let pid = resolve_project(&*self.read_conn()?, ident)
-                .map_err(|_| unknown_identifier(ident))?;
-            require_role_mcp(&self.db, pid, models::Role::Viewer)?;
-            let bundle = self.read(|conn| crate::export::export_project(conn, ident))?;
-            Ok(render_response(|output| {
+                .unwrap_or_else(|| "Error: page export produced no files".into())),
+            Kind::Issue => Ok(bundle
+                .files
+                .into_iter()
+                .next()
+                .map(|file| file.content)
+                .unwrap_or_else(|| "Error: issue export produced no files".into())),
+            Kind::Project => Ok(render_response(|output| {
                 writeln!(output, "{} exported file(s):", bundle.files.len())?;
                 bundle
                     .files
                     .iter()
                     .try_for_each(|file| writeln!(output, "- {}", file.path))
-            }))
+            })),
         }
     }
 
@@ -7746,8 +7775,8 @@ mod tests {
         assert!(!detail.contains("brown"), "got: {detail}");
     }
 
-    #[test]
-    fn export_dispatches_on_identifier_shape() {
+    #[tokio::test]
+    async fn export_dispatches_on_identifier_shape() {
         let (m, _guard) = mcp();
         seed_project(&m, "Test", "EXP");
         seed_issue_with_description(&m, "EXP", "Ship it", "issue body here");
@@ -7762,33 +7791,41 @@ mod tests {
         // Issue shape (EXP-1) returns the issue markdown.
         let issue = m.export(Parameters(ExportInput {
             identifier: "EXP-1".into(),
-        }));
+        })).await;
         assert!(issue.contains("issue body here"), "got: {issue}");
 
         // Page shape (EXP-DOC-1) returns the page markdown.
         let page = m.export(Parameters(ExportInput {
             identifier: "EXP-DOC-1".into(),
-        }));
+        })).await;
         assert!(page.contains("page body here"), "got: {page}");
 
         // Bare project shape (EXP) returns the exported file listing.
         let project = m.export(Parameters(ExportInput {
             identifier: "EXP".into(),
-        }));
+        })).await;
         assert!(project.contains("exported file(s)"), "got: {project}");
 
         // Unknown identifiers name all three shapes in the error.
         let err = m.export(Parameters(ExportInput {
             identifier: "NOPE-999".into(),
-        }));
+        })).await;
         assert!(
             err.contains("not a known issue, page, or project"),
             "got: {err}"
         );
+
+        let first = m.db.acquire_export_slot().unwrap();
+        let second = m.db.acquire_export_slot().unwrap();
+        let blocked = m.export(Parameters(ExportInput {
+            identifier: "EXP".into(),
+        })).await;
+        assert!(blocked.contains("too many exports"), "got: {blocked}");
+        drop((first, second));
     }
 
-    #[test]
-    fn create_and_edit_issue_preserves_literal_escapes_in_multiline_code() {
+    #[tokio::test]
+    async fn create_and_edit_issue_preserves_literal_escapes_in_multiline_code() {
         let (m, _guard) = mcp();
         seed_project(&m, "Test", "ESC");
         let description = "Example:\n```c\nprintf(\"\\n\");\n```\n";
@@ -7811,7 +7848,7 @@ mod tests {
 
         let exported = m.export(Parameters(ExportInput {
             identifier: "ESC-1".into(),
-        }));
+        })).await;
         assert!(
             exported.contains(description.trim_end()),
             "export mangled content: {exported}"


### PR DESCRIPTION
## Why

Export construction did not enforce a cohesive item or byte budget, and HTTP delivery retained both the rendered bundle and a complete JSON or ZIP response in memory. Concurrent Viewer requests multiplied that work and performed blocking database, rendering, and serialization operations on the async runtime.

## Implementation

- Build issue, page, and project exports from consistent read snapshots with byte-accurate preflight checks.
- Enforce file-count, comment-count, metadata-item, per-file, aggregate-source, rendered-bundle, and encoded-JSON limits.
- Validate the same bundle policy before directory, JSON, and ZIP output.
- Write HTTP output to temporary files and stream bounded chunks instead of constructing a second in-memory response.
- Share a two-operation export budget across HTTP and MCP, acquired after authorization; exhausted HTTP capacity returns `429` with retry guidance.
- Run database traversal, rendering, and serialization in blocking workers.
- Retain streaming resources only until completion, disconnect, idle timeout, or the absolute response deadline.

## Tests added

- Aggregate source content, comments, file counts, folder and label metadata, individual rendered files, and encoded JSON fail at their respective limits.
- UTF-8 byte accounting and control-heavy JSON exercise the byte-based limits and JSON/ZIP policy parity.
- Normal project exports preserve issue and nested-page paths and include each expected comment exactly once.
- Two in-flight HTTP responses consume the shared capacity, a third receives `429`, and denied requests consume no slot.
- Export preparation remains off the async runtime, while cancellation retains capacity until blocking work actually exits.
- Completed, dropped, stalled, and continuously trickling responses release their slot and temporary output under the intended lifecycle rules.
- MCP issue, page, and project exports preserve their existing result shapes and observe the same capacity limit.
