### PR TITLE
fix(mcp): add full_descriptions flag to get_plan

### DIFF
--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -404,6 +404,10 @@ pub struct CreatePlanInput {
 pub struct GetPlanInput {
     #[schemars(description = "Plan ID like LIF-PLAN-3")]
     pub plan: String,
+    #[schemars(
+        description = "Return full step descriptions (default false truncates each to 100 chars)"
+    )]
+    pub full_descriptions: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -434,7 +434,7 @@ impl Display for CommentLines<'_> {
 /// Render a plan + its step tree compactly for get_plan / create_plan output.
 /// Step lines carry `#<id>` so the agent can target edits, and issue-linked
 /// steps show provenance ("via LIF-42" / "reopened — LIF-42 reopened").
-pub(crate) fn fmt_plan(p: &models::Plan) -> String {
+pub(crate) fn fmt_plan(p: &models::Plan, full_descriptions: bool) -> String {
     let context = current_issue_link_context();
     render_response(|output| {
         write!(
@@ -443,6 +443,7 @@ pub(crate) fn fmt_plan(p: &models::Plan) -> String {
             PlanView {
                 plan: p,
                 context: context.as_deref(),
+                full_descriptions,
             }
         )
     })
@@ -451,6 +452,7 @@ pub(crate) fn fmt_plan(p: &models::Plan) -> String {
 struct PlanView<'a> {
     plan: &'a models::Plan,
     context: Option<&'a IssueLinkContext>,
+    full_descriptions: bool,
 }
 
 impl Display for PlanView<'_> {
@@ -476,6 +478,7 @@ impl Display for PlanView<'_> {
                 nodes: &plan.steps,
                 depth: 0,
                 context: self.context,
+                full_descriptions: self.full_descriptions,
             },
             formatter,
         )
@@ -688,6 +691,7 @@ struct PlanSteps<'a> {
     nodes: &'a [models::PlanStepNode],
     depth: usize,
     context: Option<&'a IssueLinkContext>,
+    full_descriptions: bool,
 }
 
 impl Display for PlanSteps<'_> {
@@ -718,8 +722,16 @@ impl Display for PlanSteps<'_> {
             formatter.write_char('\n')?;
             (!node.description.is_empty())
                 .then(|| {
-                    (0..self.depth).try_for_each(|_| formatter.write_str("  "))?;
-                    writeln!(formatter, "    {}", truncate_value(&node.description, 100))
+                    if self.full_descriptions {
+                        let prefix = format!("{}    ", "  ".repeat(self.depth));
+                        for line in node.description.lines() {
+                            writeln!(formatter, "{prefix}{line}")?;
+                        }
+                    } else {
+                        (0..self.depth).try_for_each(|_| formatter.write_str("  "))?;
+                        writeln!(formatter, "    {}", truncate_value(&node.description, 100))?;
+                    }
+                    Ok(())
                 })
                 .transpose()?;
             (!node.children.is_empty())
@@ -729,6 +741,7 @@ impl Display for PlanSteps<'_> {
                             nodes: &node.children,
                             depth: self.depth + 1,
                             context: self.context,
+                            full_descriptions: self.full_descriptions,
                         },
                         formatter,
                     )
@@ -3749,13 +3762,14 @@ impl LificMcp {
                 PlanView {
                     plan: &plan,
                     context: context.as_deref(),
+                    full_descriptions: false,
                 }
             )
         }))
     }
 
     #[tool(
-        description = "Rehydrate a plan's full step tree (e.g. LIF-PLAN-3) when resuming work. Step lines show the #id used by edit_plan_step and update_plan_step, done state, and linked issues."
+        description = "Rehydrate a plan's full step tree (e.g. LIF-PLAN-3) when resuming work. Step lines show the #id used by edit_plan_step and update_plan_step, done state, and linked issues. Step descriptions are truncated to 100 chars unless full_descriptions=true."
     )]
     fn get_plan(&self, Parameters(input): Parameters<GetPlanInput>) -> String {
         self.get_plan_inner(input).unwrap_or_else(error_response)
@@ -3767,7 +3781,7 @@ impl LificMcp {
             queries::plans::get_plan(conn, id)
         })?;
         require_role_mcp(&self.db, plan.project_id, models::Role::Viewer)?;
-        Ok(fmt_plan(&plan))
+        Ok(fmt_plan(&plan, input.full_descriptions.unwrap_or(false)))
     }
 
     #[tool(
@@ -3823,6 +3837,7 @@ impl LificMcp {
                 PlanView {
                     plan: &plan,
                     context: context.as_deref(),
+                    full_descriptions: false,
                 }
             )
         }))
@@ -4043,6 +4058,7 @@ impl LificMcp {
                     PlanView {
                         plan: &plan,
                         context: context.as_deref(),
+                        full_descriptions: false,
                     }
                 ),
                 false => write!(
@@ -9903,6 +9919,7 @@ mod tests {
         crate::mcp::reset_issue_link_context_reads();
         let got = m.get_plan(Parameters(GetPlanInput {
             plan: "PLN-PLAN-1".into(),
+            ..Default::default()
         }));
         assert!(
             got.contains("Frontend"),
@@ -9910,6 +9927,44 @@ mod tests {
         );
         assert!(got.contains("0/4 done"), "header should count steps: {got}");
         assert_eq!(crate::mcp::issue_link_context_reads(), 1);
+    }
+
+    #[test]
+    fn get_plan_full_descriptions_returns_untruncated_step_bodies() {
+        let (m, _guard) = mcp();
+        seed_project(&m, "Plans", "PLN");
+
+        let long = "start ".to_string() + &"x".repeat(120) + " end";
+        m.create_plan(Parameters(CreatePlanInput {
+            project: "PLN".into(),
+            title: "Plan".into(),
+            anchor_issue: None,
+            steps: Some(vec![PlanStepInput {
+                title: "step".into(),
+                description: Some(long.clone()),
+                ..Default::default()
+            }]),
+        }));
+
+        let got = m.get_plan(Parameters(GetPlanInput {
+            plan: "PLN-PLAN-1".into(),
+            full_descriptions: Some(false),
+        }));
+        assert!(
+            !got.contains(&long),
+            "default get_plan must truncate descriptions: {got}"
+        );
+        assert!(got.contains("…"), "truncation should be marked: {got}");
+
+        crate::mcp::reset_issue_link_context_reads();
+        let full = m.get_plan(Parameters(GetPlanInput {
+            plan: "PLN-PLAN-1".into(),
+            full_descriptions: Some(true),
+        }));
+        assert!(
+            full.contains(&long),
+            "full_descriptions=true must return the whole body: {full}"
+        );
     }
 
     #[tokio::test]
@@ -10158,6 +10213,7 @@ mod tests {
         assert!(out.contains("Edited step"), "got: {out}");
         let got = m.get_plan(Parameters(GetPlanInput {
             plan: "PLN-PLAN-1".into(),
+            ..Default::default()
         }));
         assert!(got.contains("new text"), "edit should persist: {got}");
     }
@@ -10243,6 +10299,7 @@ mod tests {
 
         let got = m.get_plan(Parameters(GetPlanInput {
             plan: "PLN-PLAN-1".into(),
+            ..Default::default()
         }));
         assert!(got.contains("[x]"), "step should be auto-completed: {got}");
         assert!(got.contains("via PLN-1"), "provenance should show: {got}");
@@ -10320,6 +10377,7 @@ mod tests {
         );
         let plan = m.get_plan(Parameters(GetPlanInput {
             plan: "ARC-PLAN-1".into(),
+            ..Default::default()
         }));
         assert!(
             plan.contains("- [ ]"),
@@ -10346,6 +10404,7 @@ mod tests {
         assert_eq!(out, "Deleted plan PLN-PLAN-1");
         let got = m.get_plan(Parameters(GetPlanInput {
             plan: "PLN-PLAN-1".into(),
+            ..Default::default()
         }));
         assert!(
             got.contains("Error"),
@@ -10479,6 +10538,7 @@ mod tests {
         // via get_plan
         let plan = m.get_plan(Parameters(GetPlanInput {
             plan: "ESC-PLAN-1".into(),
+            ..Default::default()
         }));
         assert_no_html_escape(&plan, &[raw_step]);
     }
@@ -11341,6 +11401,7 @@ mod authz_gating_tests {
         let denied_plan = as_user(&non_member, || {
             m.get_plan(Parameters(GetPlanInput {
                 plan: "MEM-PLAN-1".into(),
+                ..Default::default()
             }))
         });
         assert!(is_forbidden(&denied_plan), "got: {denied_plan}");
@@ -11354,6 +11415,7 @@ mod authz_gating_tests {
         let allowed_plan = as_user(&viewer, || {
             m.get_plan(Parameters(GetPlanInput {
                 plan: "MEM-PLAN-1".into(),
+                ..Default::default()
             }))
         });
         assert!(!is_forbidden(&allowed_plan), "got: {allowed_plan}");


### PR DESCRIPTION
## Human summary
I ran into an issue earlier where I prompted effectively: "That plan looks good can you put it into lific?". When I had another agent audit the plan I realized some function signatures I had in the descriptions were getting truncated and the agent reported it wasn't able to get the full signature or update the description. I needed to do some manual triage / fixing of the too long descriptions into issues but would have preferred to just have given the agent the ability to read the full description with a flag like what's in this PR, instead of having it be silently mangled. As far as I can tell there isn't really a workaround if you set the description on a plan item to over 100 characters.

Been enjoying using the tool and wanted to fix a wart I ran into. If the normal flow is supposed to be issues for details and plans for high level mission objectives that's cool, in that case would really appreciate an error when the description is submitted and over 100 characters along with that being documented in the MCP.

--- 
## AI PR summary
Plan step descriptions were truncated to 100 chars in every MCP plan render path (get_plan, create_plan, edit_plan_step, update_plan_step echo_tree). This made the edit_plan_step impossible on steps with long descriptions — the agent could not see the exact old_string it needed to match, since get_plan returned a truncated substring.

Fixed by adding an opt-in full_descriptions flag to get_plan. When true, step descriptions are rendered in full with multi-line indentation. Default (false) preserves the existing compact 100-char behavior for all plan tools, including create_plan, edit_plan_step, and update_plan_step.

--- 
## AI Bug / Issue write up
**Bug:** `get_plan` (and every other plan MCP tool) truncates each step's description to 100 characters, collapsing newlines to spaces, with no way to retrieve the full text via MCP. This makes `edit_plan_step` (which does exact-string matching on the stored description) impossible to use reliably on any step whose description exceeds 100 characters or contains newlines — the agent can't see the full string it needs to match.

### Reproduction

1. Create a plan with a step that has a >100-char description:
```
create_plan(project="AWT", title="Example", steps=[{
  title="Add Spec to pkg/engine/spec.go",
  description="InputKind: InputZero/InputJSON/InputFlags. Spec carries Info (types.WorkflowInfo), Tags []string, Inputs []InputDef and an optional FlagBuilder callback."
}])
```

2. Read it back — description is silently sliced, newlines collapsed, `…` appended:
```
get_plan(plan="AWT-PLAN-3")
```
Output:
```
- [ ] #NNN Add Spec to pkg/engine/spec.go [AWT-21: backlog]
    InputKind: InputZero/InputJSON/InputFlags. Spec carries Info (types.WorkflowInfo), Tags []string, In…
```

3. Attempt `edit_plan_step` — **fails**. The agent copies the visible text as `old_string`, but the literal match in `apply_edit` searches the full stored description. The truncated substring either ends mid-word (no match past position 100) or includes the `…` ellipsis character (not present in stored content):
```
edit_plan_step(plan="AWT-PLAN-3", step_id=NNN, old_string="…Tags []string, In…", new_string="…")
→ Error: old_string not found in content; check exact whitespace and newlines
```

Multi-line descriptions are even worse — `truncate_value` collapses `\n` to spaces, so `"line one\nline two"` displays as `"line one line two"`, which also fails the literal match.

### Root cause

`src/mcp/tools.rs:722` in `PlanSteps::fmt()` — the Display impl used by every plan read path truncates each step description to 100 chars:

```rust
(!node.description.is_empty())
    .then(|| {
        (0..self.depth).try_for_each(|_| formatter.write_str("  "))?;
        writeln!(formatter, "    {}", truncate_value(&node.description, 100))
    })
    .transpose()?;
```

Where `truncate_value` (`src/mcp/tools.rs:916-925`) collapses `\n` → ` ` and appends `…`:

```rust
impl Display for TruncatedValue<'_> {
    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
        let mut characters = self.value.chars();
        characters.by_ref().take(self.max).try_for_each(|character| {
            formatter.write_char(if character == '\n' { ' ' } else { character })
        })?;
        characters.next().map_or(Ok(()), |_| formatter.write_char('…'))
    }
}
```

And `apply_edit` (`src/mcp/tools.rs:790`) does a strict literal substring match against the full stored description:

```rust
let count = content.matches(old).count();
match count {
    0 => Err(…"old_string not found in content; check exact whitespace and newlines"…),
```

The full description is stored correctly in the DB and returned by the REST API, but there was no MCP path to read it. The only workaround was to manually fetch the full text via REST and construct the edit offline.

### Fix

Added `full_descriptions: Option<bool>` to `get_plan`. When `true`, step descriptions are rendered in full with proper multi-line indentation. Default (`false`) preserves the existing compact behavior.

```
get_plan(plan="AWT-PLAN-3", full_descriptions=true)
```
Output:
```
- [ ] #NNN Add Spec to pkg/engine/spec.go [AWT-21: backlog]
    InputKind: InputZero/InputJSON/InputFlags. Spec carries Info
    (types.WorkflowInfo), Tags []string, Inputs []InputDef and an optional
    FlagBuilder callback.
```