### PR TITLE
Harden Mermaid rendering, SVG delivery, and label colors

### DIFF
--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -372,10 +372,8 @@ pub(super) async fn list_project_orphans(
 ///
 /// Three layers keep a hostile upload from executing on our origin:
 /// - `X-Content-Type-Options: nosniff`, so a browser never re-guesses the type.
-/// - `Content-Disposition: inline` only for the raster formats in
-///   [`storage::is_inline_safe_mime`]; everything else, SVG included, is
-///   forced to `attachment`. An SVG is an image that can carry `<script>`,
-///   and browsers run it when the file is navigated to directly.
+/// - `Content-Disposition: inline` only for safe raster and media formats;
+///   active SVG documents are forced to `attachment`.
 /// - `Content-Security-Policy: default-src 'none'; sandbox`, which neuters
 ///   script, fetch and form submission even if a future MIME slips through
 ///   the disposition rule.
@@ -404,6 +402,11 @@ pub(super) async fn download_attachment(
     let bytes = store.read(&attachment.sha256)?;
     let total = bytes.len() as u64;
     let inline_safe = storage::is_inline_safe_mime(&attachment.mime);
+    let content_type = if attachment.mime == "image/svg+xml" {
+        "application/octet-stream"
+    } else {
+        &attachment.mime
+    };
 
     // Force download for anything that isn't a plain raster image or a media
     // container. Either way the filename is offered for the "Save as" dialog.
@@ -447,7 +450,7 @@ pub(super) async fn download_attachment(
 
     let mut builder = Response::builder()
         .status(status)
-        .header(header::CONTENT_TYPE, &attachment.mime)
+        .header(header::CONTENT_TYPE, content_type)
         .header(header::CONTENT_LENGTH, body.len())
         .header(header::ACCEPT_RANGES, "bytes")
         // Content-addressed: the same id always returns the same bytes.
@@ -1561,6 +1564,30 @@ mod api_tests {
             assert!(csp.contains("default-src 'none'"), "{name}: {csp}");
             assert!(csp.contains("sandbox"), "{name}: {csp}");
         }
+    }
+
+    #[tokio::test]
+    async fn svg_download_uses_an_inert_content_type() {
+        let app = test_app();
+        let svg = br#"<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>"#;
+        let resp = upload(&app, "diagram.svg", "image/svg+xml", svg, None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let id = parse_json(resp).await["id"].as_i64().unwrap();
+
+        let resp = json_get(&app, &format!("/api/attachments/{id}")).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "application/octet-stream"
+        );
+        assert_eq!(
+            resp.headers().get("content-disposition").unwrap(),
+            "attachment; filename=\"diagram.svg\""
+        );
+        assert_eq!(
+            resp.headers().get("content-security-policy").unwrap(),
+            "default-src 'none'; sandbox"
+        );
     }
 
     #[tokio::test]

--- a/web/src/lib/ColorPicker.svelte
+++ b/web/src/lib/ColorPicker.svelte
@@ -10,6 +10,7 @@
     colorName,
     isValidHex,
     normalizeHex,
+    safeLabelColor,
   } from "./labelColors";
 
   let {
@@ -29,12 +30,13 @@
   let open = $state(false);
   let hexDraft = $state("");
   let hexBad = $state(false);
+  let displayValue = $derived(safeLabelColor(value));
 
   function toggle(e: MouseEvent) {
     e.stopPropagation();
     open = !open;
     if (open) {
-      hexDraft = value.replace(/^#/, "");
+      hexDraft = displayValue.replace(/^#/, "");
       hexBad = false;
     }
   }
@@ -62,9 +64,9 @@
     class="rounded-full shrink-0 border border-black/10 dark:border-white/15
            shadow-sm transition-transform hover:scale-105
            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-    style="width: {size}px; height: {size}px; background: {value}"
-    aria-label="Color: {colorName(value)}. Click to change."
-    title="{colorName(value)} · {value}"
+    style="width: {size}px; height: {size}px; background: {displayValue}"
+    aria-label="Color: {colorName(displayValue)}. Click to change."
+    title="{colorName(displayValue)} · {displayValue}"
     onclick={toggle}
   ></button>
 
@@ -79,7 +81,7 @@
     >
       <div class="grid grid-cols-6 gap-1.5 mb-2.5">
         {#each LABEL_PALETTE as c (c.value)}
-          {@const selected = c.value.toLowerCase() === value.toLowerCase()}
+          {@const selected = c.value.toLowerCase() === displayValue.toLowerCase()}
           <button
             type="button"
             class="size-6 rounded-full grid place-items-center transition-transform

--- a/web/src/lib/CommandPalette.svelte
+++ b/web/src/lib/CommandPalette.svelte
@@ -25,6 +25,7 @@
     type Folder,
   } from "./api";
   import { fuzzyMatch } from "./fuzzy";
+  import { safeLabelColor } from "./labelColors";
   import { commandPaletteState } from "./commandPaletteState.svelte";
   import { shortcutHelpState } from "./shortcutHelpState.svelte";
   import ProjectIcon from "./ProjectIcon.svelte";
@@ -713,7 +714,7 @@
                 {:else if c.color}
                   <span
                     class="size-2.5 rounded-full"
-                    style="background: {c.color}"
+                    style="background: {safeLabelColor(c.color)}"
                   ></span>
                 {/if}
               </span>

--- a/web/src/lib/Comments.svelte
+++ b/web/src/lib/Comments.svelte
@@ -12,6 +12,7 @@
   // CommentThread with no other changes.
 
   import Markdown from "./Markdown.svelte";
+  import { createMermaidBudget } from "./mermaidLimits";
   import TimeAgo from "./TimeAgo.svelte";
   import {
     listMentionCandidates,
@@ -78,6 +79,10 @@
   let updatingId = $state<number | null>(null);
   let deletingId = $state<number | null>(null);
   let menuId = $state<number | null>(null);
+  let mermaidBudget = $derived.by(() => {
+    comments;
+    return createMermaidBudget();
+  });
   let confirmDeleteId = $state<number | null>(null);
 
   let pendingCommentTarget = $state(commentTargetFromHash(window.location.hash));
@@ -521,7 +526,7 @@
               </div>
             {:else}
               <div class="cmt__md">
-                <Markdown content={comment.content} mentions={candidates} class="text-sm" />
+                <Markdown content={comment.content} mentions={candidates} class="text-sm" {mermaidBudget} />
               </div>
             {/if}
           </div>

--- a/web/src/lib/LabelEditor.svelte
+++ b/web/src/lib/LabelEditor.svelte
@@ -18,7 +18,7 @@
 
   import { Plus, X, Check } from "lucide-svelte";
   import type { Label } from "./api";
-  import { colorForName } from "./labelColors";
+  import { colorForName, safeLabelColor } from "./labelColors";
   import ColorPicker from "./ColorPicker.svelte";
 
   let {
@@ -129,7 +129,7 @@
           class="inline-flex items-center gap-1 text-caption
                  font-medium px-2 py-0.5 rounded-full border"
           style={obj
-            ? `color: ${obj.color}; border-color: ${obj.color}40; background: ${obj.color}10;`
+            ? `color: ${safeLabelColor(obj.color)}; border-color: ${safeLabelColor(obj.color)}40; background: ${safeLabelColor(obj.color)}10;`
             : ""}
         >
           {name}
@@ -208,7 +208,7 @@
             >
               <span
                 class="size-2.5 rounded-full shrink-0"
-                style="background: {label.color};"
+                style="background: {safeLabelColor(label.color)};"
               ></span>
               <span class="flex-1 min-w-0 truncate {isAttached ? 'font-medium' : ''}">
                 {label.name}

--- a/web/src/lib/LabelManager.svelte
+++ b/web/src/lib/LabelManager.svelte
@@ -24,7 +24,7 @@
   import { Tag, Trash2, Plus, ArrowRight, Search } from "lucide-svelte";
   import ColorPicker from "./ColorPicker.svelte";
   import Skeleton from "./Skeleton.svelte";
-  import { colorForName, DEFAULT_LABEL_COLOR } from "./labelColors";
+  import { colorForName, DEFAULT_LABEL_COLOR, safeLabelColor } from "./labelColors";
 
   let {
     projectId,
@@ -364,7 +364,7 @@
             <button
               class="inline-flex items-center gap-1.5 text-caption font-medium px-2 py-1 rounded-full border
                      hover:brightness-110 transition"
-              style="color: {p.color}; border-color: {p.color}55; background: {p.color}12;"
+              style="color: {safeLabelColor(p.color)}; border-color: {safeLabelColor(p.color)}55; background: {safeLabelColor(p.color)}12;"
               onclick={() => create(p.name, p.color)}
             >
               <Plus size={11} />
@@ -390,7 +390,7 @@
         <div class="flex flex-wrap items-center gap-3 px-4 py-2.5 {idx > 0 ? 'border-t border-[var(--border)]' : ''}">
           {#if confirmingId === l.id}
             <!-- Delete / merge confirm (#4) -->
-            <span class="size-3 rounded-full shrink-0" style="background: {l.color}"></span>
+            <span class="size-3 rounded-full shrink-0" style="background: {safeLabelColor(l.color)}"></span>
             <div class="flex-1 min-w-0">
               <p class="text-body-sm text-[var(--text)]">
                 Delete <strong>{l.name}</strong>?
@@ -440,7 +440,7 @@
           {:else if !canEdit}
             <!-- Read-only display row (viewer): static dot + name, usage
                  count still links out to the filtered issue list. -->
-            <span class="size-3.5 rounded-full shrink-0" style="background: {l.color}"></span>
+            <span class="size-3.5 rounded-full shrink-0" style="background: {safeLabelColor(l.color)}"></span>
             <span class="flex-1 min-w-0 text-body-sm font-medium text-[var(--text)] truncate">{l.name}</span>
             {#if usageTotal(l.name) > 0}
               <button
@@ -519,7 +519,7 @@
             <button
               class="inline-flex items-center gap-1.5 text-caption font-medium px-2 py-1 rounded-full border
                      hover:brightness-110 transition"
-              style="color: {p.color}; border-color: {p.color}55; background: {p.color}12;"
+              style="color: {safeLabelColor(p.color)}; border-color: {safeLabelColor(p.color)}55; background: {safeLabelColor(p.color)}12;"
               onclick={() => create(p.name, p.color)}
             >
               <Plus size={11} />

--- a/web/src/lib/Markdown.svelte
+++ b/web/src/lib/Markdown.svelte
@@ -2,6 +2,12 @@
   import { marked } from "marked";
   import { mount, unmount } from "svelte";
   import DOMPurify from "dompurify";
+  import {
+    createMermaidBudget,
+    mermaidIsTooComplex,
+    type MermaidBudget,
+  } from "./mermaidLimits";
+  import { renderMermaidBlock } from "./mermaidRender";
   import IssueHoverCard from "./IssueHoverCard.svelte";
   import { IDENTIFIER_RE, PROJECT_CODE_RE, refKind, routeFor, projectCodeOf } from "./references";
   import { openPeek } from "./issues/peek.svelte"; // LIF-248
@@ -18,7 +24,13 @@
     // that resolve against this set render as chips showing the display
     // name; unknown tokens stay literal text.
     mentions = [],
-  }: { content: string; class?: string; mentions?: MentionUser[] } = $props();
+    mermaidBudget = createMermaidBudget(),
+  }: {
+    content: string;
+    class?: string;
+    mentions?: MentionUser[];
+    mermaidBudget?: MermaidBudget;
+  } = $props();
 
   // Lowercased username → display name, for chip rendering.
   let mentionMap = $derived(
@@ -137,6 +149,9 @@
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   renderer.code = function (token: any): string {
     if (token?.lang === "mermaid") {
+      if (typeof token.text !== "string" || mermaidIsTooComplex(token.text)) {
+        return `<div class="mermaid-block mermaid-skipped" data-rendered="skipped">Mermaid diagram skipped: source is too complex.</div>`;
+      }
       return `<div class="mermaid-block" data-mermaid="${encodeURIComponent(token.text)}"></div>`;
     }
     // LIF-110: wrap real code blocks so a copy button can latch on.
@@ -369,26 +384,12 @@
       });
       for (const block of Array.from(blocks)) {
         if (cancelled) return;
-        const src = decodeURIComponent(block.dataset.mermaid ?? "");
-        try {
-          const id = `mmd-${Math.random().toString(36).slice(2)}`;
-          const { svg } = await mermaid.render(id, src);
-          block.innerHTML = svg;
-          block.dataset.rendered = "true";
-        } catch (err) {
-          // LIF-402: the error message echoes the offending diagram source,
-          // which is attacker-controlled content that already passed through
-          // DOMPurify as inert text. Interpolating it into an HTML string
-          // here would hand it back a parser and re-open stored XSS, so the
-          // node is built directly and the message set as text.
-          const pre = document.createElement("pre");
-          pre.style.color = "var(--error)";
-          pre.style.whiteSpace = "pre-wrap";
-          pre.style.margin = "0";
-          pre.textContent = `Mermaid error: ${String(err)}`;
-          block.replaceChildren(pre);
-          block.dataset.rendered = "error";
-        }
+        await renderMermaidBlock(
+          block,
+          (id, source) => mermaid.render(id, source),
+          mermaidBudget,
+          () => cancelled,
+        );
       }
     })();
 

--- a/web/src/lib/issues/BulkActionBar.svelte
+++ b/web/src/lib/issues/BulkActionBar.svelte
@@ -18,6 +18,7 @@
   // outside-click on window), so the open menu must stay in sync both ways.
   // All the actual mutations live in the parent and arrive as callbacks.
   import type { Module, Label } from "../api";
+  import { safeLabelColor } from "../labelColors";
   import { fly } from "svelte/transition";
   import { Trash2, X } from "lucide-svelte";
   import StatusIcon from "../StatusIcon.svelte";
@@ -196,7 +197,7 @@
               >
                 <span
                   class="size-2.5 rounded-full shrink-0"
-                  style="background: {lbl.color}"
+                  style="background: {safeLabelColor(lbl.color)}"
                 ></span>
                 <span class="truncate">{lbl.name}</span>
               </button>

--- a/web/src/lib/issues/FilterModal.svelte
+++ b/web/src/lib/issues/FilterModal.svelte
@@ -22,6 +22,7 @@
   } from "./grouping";
   import type { IssueListState } from "./state.svelte";
   import type { Label, Module } from "../api";
+  import { safeLabelColor } from "../labelColors";
 
   let {
     view,
@@ -247,7 +248,7 @@
                          {active ? 'bg-[var(--accent-subtle)]' : 'hover:bg-[var(--bg-subtle)]'}"
                   onclick={() => view.toggleLabelFilter(l.name)}
                 >
-                  <span class="size-2.5 rounded-full shrink-0" style="background: {l.color}"></span>
+                  <span class="size-2.5 rounded-full shrink-0" style="background: {safeLabelColor(l.color)}"></span>
                   <span class="flex-1 min-w-0 truncate text-body-sm font-medium text-[var(--text)]">{l.name}</span>
                   {#if active}<Check size={14} class="shrink-0 text-[var(--accent)]" />{/if}
                 </button>

--- a/web/src/lib/issues/IssueCard.svelte
+++ b/web/src/lib/issues/IssueCard.svelte
@@ -3,6 +3,7 @@
   // A pure leaf: it renders one issue and emits a click; all drag behavior
   // is owned by the dndzone in the parent, which wraps this component.
   import type { Issue, Label } from "../api";
+  import { safeLabelColor } from "../labelColors";
   import PriorityIcon from "../PriorityIcon.svelte";
   import Tooltip from "../Tooltip.svelte";
   import TimeAgo from "../TimeAgo.svelte";
@@ -158,7 +159,7 @@
         class="text-micro font-medium px-1.5 py-0.5
                rounded-full border border-[var(--border)]"
         style={labelObj
-          ? `color: ${labelObj.color}; border-color: ${labelObj.color}40;`
+          ? `color: ${safeLabelColor(labelObj.color)}; border-color: ${safeLabelColor(labelObj.color)}40;`
           : ""}
       >
         {lbl}

--- a/web/src/lib/issues/IssueRow.svelte
+++ b/web/src/lib/issues/IssueRow.svelte
@@ -10,6 +10,7 @@
   // state instance; keeping them explicit here first makes the seam
   // reviewable and build-verifiable.
   import type { Issue, Label, Module } from "../api";
+  import { safeLabelColor } from "../labelColors";
   import { Check, Signal, Layers, PanelRight, ExternalLink, Copy } from "lucide-svelte";
   import { longpress } from "../actions/longpress"; // press-and-hold peek on touch
   import StatusIcon from "../StatusIcon.svelte";
@@ -330,7 +331,7 @@
         <span
           class="text-micro font-medium px-1.5 py-0.5 rounded-full
                  border border-[var(--border)]"
-          style={labelObj ? `color: ${labelObj.color}; border-color: ${labelObj.color}40;` : ""}
+          style={labelObj ? `color: ${safeLabelColor(labelObj.color)}; border-color: ${safeLabelColor(labelObj.color)}40;` : ""}
         >
           {lbl}
         </span>

--- a/web/src/lib/issues/PeekPanel.svelte
+++ b/web/src/lib/issues/PeekPanel.svelte
@@ -34,6 +34,7 @@
     type Module,
     type Label,
   } from "../api";
+  import { safeLabelColor } from "../labelColors";
   import { peekState, closePeek, notifyPeekSync } from "./peek.svelte";
   import { sheetDrag } from "../actions/sheetdrag"; // swipe-down dismiss (mobile sheet)
   import { updateIssueWithUndo } from "./state.svelte";
@@ -443,7 +444,7 @@
               <span
                 class="text-caption font-medium px-2 py-0.5 rounded-full border"
                 style={labelObj
-                  ? `color: ${labelObj.color}; border-color: ${labelObj.color}40; background: ${labelObj.color}10;`
+                  ? `color: ${safeLabelColor(labelObj.color)}; border-color: ${safeLabelColor(labelObj.color)}40; background: ${safeLabelColor(labelObj.color)}10;`
                   : "border-color: var(--border);"}
               >
                 {lbl}

--- a/web/src/lib/labelColors.ts
+++ b/web/src/lib/labelColors.ts
@@ -32,6 +32,11 @@ export const LABEL_COLORS: string[] = LABEL_PALETTE.map((c) => c.value);
 /** Server's default label color (mirrors `default_label_color()` in Rust). */
 export const DEFAULT_LABEL_COLOR = "#6B7280";
 
+/** Defense in depth for legacy/imported rows that predate server validation. */
+export function safeLabelColor(color: string): string {
+  return /^#[0-9a-fA-F]{6}$/.test(color) ? color : DEFAULT_LABEL_COLOR;
+}
+
 /** Human name for a hex (nearest by exact match, else "Custom"). */
 export function colorName(hex: string): string {
   const found = LABEL_PALETTE.find(

--- a/web/src/lib/mermaidLimits.ts
+++ b/web/src/lib/mermaidLimits.ts
@@ -1,0 +1,30 @@
+const MAX_SOURCE_BYTES = 4 * 1024;
+const MAX_COMPLEXITY = 128;
+const MAX_TOTAL_SOURCE_BYTES = 8 * 1024;
+const MAX_BLOCKS = 2;
+
+export type MermaidBudget = {
+  blocks: number;
+  sourceBytes: number;
+};
+
+export function createMermaidBudget(): MermaidBudget {
+  return { blocks: 0, sourceBytes: 0 };
+}
+
+export function mermaidIsTooComplex(source: string): boolean {
+  const sourceBytes = new TextEncoder().encode(source).byteLength;
+  const statements = source.split(/[;\n]/).length;
+  const links = source.match(/-->|==>|-\.->|---|->/g)?.length ?? 0;
+  return sourceBytes > MAX_SOURCE_BYTES || statements + links > MAX_COMPLEXITY;
+}
+
+export function claimMermaidBudget(
+  sourceBytes: number,
+  budget: MermaidBudget,
+): "blocks" | "bytes" | undefined {
+  if (budget.blocks >= MAX_BLOCKS) return "blocks";
+  if (budget.sourceBytes + sourceBytes > MAX_TOTAL_SOURCE_BYTES) return "bytes";
+  budget.blocks += 1;
+  budget.sourceBytes += sourceBytes;
+}

--- a/web/src/lib/mermaidRender.ts
+++ b/web/src/lib/mermaidRender.ts
@@ -1,0 +1,58 @@
+import {
+  claimMermaidBudget,
+  mermaidIsTooComplex,
+  type MermaidBudget,
+} from "./mermaidLimits";
+
+function showMermaidMessage(block: HTMLDivElement, message: string): void {
+  block.style.color = "var(--error)";
+  block.style.whiteSpace = "pre-wrap";
+  block.style.margin = "0";
+  block.textContent = message;
+  block.dataset.rendered = "error";
+}
+
+export async function renderMermaidBlock(
+  block: HTMLDivElement,
+  render: (id: string, source: string) => Promise<{ svg: string }>,
+  budget: MermaidBudget,
+  cancelled: () => boolean,
+): Promise<void> {
+  let source: string;
+  try {
+    source = decodeURIComponent(block.dataset.mermaid ?? "");
+  } catch {
+    showMermaidMessage(block, "Mermaid diagram skipped: source is malformed.");
+    return;
+  }
+
+  if (mermaidIsTooComplex(source)) {
+    showMermaidMessage(block, "Mermaid diagram skipped: source is too complex.");
+    return;
+  }
+
+  const budgetError = claimMermaidBudget(
+    new TextEncoder().encode(source).byteLength,
+    budget,
+  );
+  if (budgetError) {
+    showMermaidMessage(
+      block,
+      budgetError === "blocks"
+        ? "Mermaid diagram skipped: this document contains too many diagrams."
+        : "Mermaid diagram skipped: this document contains too much diagram source.",
+    );
+    return;
+  }
+
+  try {
+    const id = `mmd-${Math.random().toString(36).slice(2)}`;
+    const { svg } = await render(id, source);
+    if (!cancelled()) {
+      block.innerHTML = svg;
+      block.dataset.rendered = "true";
+    }
+  } catch (error) {
+    if (!cancelled()) showMermaidMessage(block, `Mermaid error: ${String(error)}`);
+  }
+}

--- a/web/src/routes/PageList.svelte
+++ b/web/src/routes/PageList.svelte
@@ -49,6 +49,7 @@
   import { projectRole, loadProjectRole } from "../lib/projectRole.svelte"; // LIF-234
   import { loadSubTab, saveSubTab } from "../lib/subtab";
   import { toast } from "../lib/toast/toast.svelte";
+  import { safeLabelColor } from "../lib/labelColors";
 
   // LIF-234: pages are content — create/edit/delete + folder management are
   // maintainer-gated. A viewer browses the tree read-only.
@@ -770,7 +771,7 @@
           {#snippet renderSelected(opt)}
             <span class="flex items-center gap-1.5 text-body-sm">
               {#if opt.value && opt.color}
-                <span class="size-2.5 rounded-full shrink-0" style="background: {opt.color}"></span>
+                <span class="size-2.5 rounded-full shrink-0" style="background: {safeLabelColor(String(opt.color))}"></span>
                 <span class="text-[var(--text)]">{opt.label}</span>
               {:else}
                 <span class="text-[var(--text-muted)]">{opt.label}</span>
@@ -780,7 +781,7 @@
           {#snippet renderOption(opt, isSelected)}
             <span class="flex items-center gap-2 text-body-sm {isSelected ? 'font-medium' : ''}">
               {#if opt.value && opt.color}
-                <span class="size-2.5 rounded-full shrink-0" style="background: {opt.color}"></span>
+                <span class="size-2.5 rounded-full shrink-0" style="background: {safeLabelColor(String(opt.color))}"></span>
                 <span class="{isSelected ? 'text-[var(--accent)]' : 'text-[var(--text)]'}">{opt.label}</span>
               {:else}
                 <span class="text-[var(--text-muted)]">{opt.label}</span>
@@ -1178,7 +1179,7 @@
                       <span
                         class="text-micro font-medium px-1.5 py-0.5 rounded-full
                                border border-[var(--border)]"
-                        style={labelObj ? `color: ${labelObj.color}; border-color: ${labelObj.color}40;` : ""}
+                        style={labelObj ? `color: ${safeLabelColor(labelObj.color)}; border-color: ${safeLabelColor(labelObj.color)}40;` : ""}
                       >
                         {lbl}
                       </span>
@@ -1679,7 +1680,7 @@
                 <span
                   class="text-micro font-medium px-1.5 py-0.5 rounded-full
                          border border-[var(--border)]"
-                  style={labelObj ? `color: ${labelObj.color}; border-color: ${labelObj.color}40;` : ""}
+                  style={labelObj ? `color: ${safeLabelColor(labelObj.color)}; border-color: ${safeLabelColor(labelObj.color)}40;` : ""}
                 >
                   {lbl}
                 </span>

--- a/web/tests/comments.test.ts
+++ b/web/tests/comments.test.ts
@@ -28,6 +28,7 @@ const { deleteComment, updateComment } = await import("../src/lib/api");
 const originalFetch = globalThis.fetch;
 let vite: ViteDevServer;
 let Comments: Component<any>;
+let ColorPicker: Component<any>;
 let renderComponent: typeof import("svelte/server").render;
 
 beforeAll(async () => {
@@ -41,8 +42,9 @@ beforeAll(async () => {
     },
   });
   ({ default: Comments } = await vite.ssrLoadModule("/src/lib/Comments.svelte"));
+  ({ default: ColorPicker } = await vite.ssrLoadModule("/src/lib/ColorPicker.svelte"));
   ({ render: renderComponent } = await vite.ssrLoadModule("svelte/server"));
-}, 20_000);
+}, 60_000);
 
 afterAll(async () => {
   await vite.close();
@@ -96,6 +98,17 @@ test("renders mutation actions only for the comment author", () => {
 
   expect(owner).toContain("Comment 42 actions");
   expect(otherUser).not.toContain("Comment 42 actions");
+});
+
+test("renders unsafe stored label colors through the component fallback", () => {
+  const value = "red; background-image: url(https://example.test)";
+  const html = renderComponent(ColorPicker, {
+    props: { value, onChange: () => {} },
+  }).body;
+
+  expect(html).toContain("background: #6B7280");
+  expect(html).not.toContain(value);
+  expect(html).not.toContain("background-image");
 });
 
 test("marks comments edited only when the update timestamp changes", () => {

--- a/web/tests/labelColors.test.ts
+++ b/web/tests/labelColors.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_LABEL_COLOR,
+  safeLabelColor,
+} from "../src/lib/labelColors";
+
+describe("safeLabelColor", () => {
+  test("preserves hex colors and rejects CSS source", () => {
+    expect(safeLabelColor("#12aBcF")).toBe("#12aBcF");
+    expect(safeLabelColor("red; background-image: url(https://example.test)"))
+      .toBe(DEFAULT_LABEL_COLOR);
+  });
+});

--- a/web/tests/mermaidLimits.test.ts
+++ b/web/tests/mermaidLimits.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+  claimMermaidBudget,
+  createMermaidBudget,
+  mermaidIsTooComplex,
+} from "../src/lib/mermaidLimits";
+
+describe("mermaidIsTooComplex", () => {
+  test("accepts ordinary diagrams and rejects large or dense input", () => {
+    expect(mermaidIsTooComplex("graph TD\nA-->B\nB-->C")).toBe(false);
+    expect(mermaidIsTooComplex("x".repeat(4097))).toBe(true);
+    expect(mermaidIsTooComplex(Array(129).fill("node").join("\n"))).toBe(true);
+    expect(mermaidIsTooComplex(`graph TD\nA${"-->A".repeat(128)}`)).toBe(true);
+  });
+});
+
+describe("claimMermaidBudget", () => {
+  test("shares aggregate block and source limits", () => {
+    const budget = createMermaidBudget();
+
+    expect(claimMermaidBudget(4096, budget)).toBeUndefined();
+    expect(claimMermaidBudget(4096, budget)).toBeUndefined();
+    expect(claimMermaidBudget(1, budget)).toBe("blocks");
+    expect(budget).toEqual({ blocks: 2, sourceBytes: 8192 });
+  });
+
+  test("does not consume rejected source", () => {
+    const budget = createMermaidBudget();
+
+    expect(claimMermaidBudget(8193, budget)).toBe("bytes");
+    expect(budget).toEqual({ blocks: 0, sourceBytes: 0 });
+  });
+});

--- a/web/tests/mermaidRender.test.ts
+++ b/web/tests/mermaidRender.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { createMermaidBudget } from "../src/lib/mermaidLimits";
+import { renderMermaidBlock } from "../src/lib/mermaidRender";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function block(source: string): HTMLDivElement {
+  return {
+    dataset: { mermaid: source },
+    style: {},
+    textContent: "",
+    innerHTML: "",
+  } as unknown as HTMLDivElement;
+}
+
+describe("renderMermaidBlock", () => {
+  test("rejects a forged complex placeholder before rendering", async () => {
+    const target = block(encodeURIComponent(`graph TD\nA${"-->A".repeat(128)}`));
+    let renders = 0;
+
+    await renderMermaidBlock(target, async () => {
+      renders += 1;
+      return { svg: "<svg></svg>" };
+    }, createMermaidBudget(), () => false);
+
+    expect(renders).toBe(0);
+    expect(target.textContent).toContain("too complex");
+    expect(target.dataset.rendered).toBe("error");
+  });
+
+  test("rejects malformed encoded source without throwing", async () => {
+    const target = block("%invalid");
+    let renders = 0;
+
+    await renderMermaidBlock(target, async () => {
+      renders += 1;
+      return { svg: "<svg></svg>" };
+    }, createMermaidBudget(), () => false);
+
+    expect(renders).toBe(0);
+    expect(target.textContent).toContain("malformed");
+  });
+
+  test("enforces one shared budget across blocks", async () => {
+    const budget = createMermaidBudget();
+    const blocks = ["A", "B", "C"].map((source) => block(encodeURIComponent(source)));
+    let renders = 0;
+
+    for (const target of blocks) {
+      await renderMermaidBlock(target, async () => {
+        renders += 1;
+        return { svg: "<svg></svg>" };
+      }, budget, () => false);
+    }
+
+    expect(renders).toBe(2);
+    expect(blocks[2].textContent).toContain("too many diagrams");
+  });
+
+  test("does not update after cancellation", async () => {
+    const pending = deferred<{ svg: string }>();
+    const target = block(encodeURIComponent("graph TD\nA-->B"));
+    let cancelled = false;
+
+    const rendering = renderMermaidBlock(
+      target,
+      async () => pending.promise,
+      createMermaidBudget(),
+      () => cancelled,
+    );
+    cancelled = true;
+    pending.resolve({ svg: "<svg></svg>" });
+    await rendering;
+
+    expect(target.innerHTML).toBe("");
+    expect(target.dataset.rendered).toBeUndefined();
+  });
+
+  test("reports success and failure while active", async () => {
+    const success = block(encodeURIComponent("graph TD\nA-->B"));
+    const failure = block(encodeURIComponent("graph TD\nA-->B"));
+
+    await renderMermaidBlock(
+      success,
+      async () => ({ svg: "<svg>safe</svg>" }),
+      createMermaidBudget(),
+      () => false,
+    );
+    await renderMermaidBlock(
+      failure,
+      async () => { throw new Error("invalid diagram"); },
+      createMermaidBudget(),
+      () => false,
+    );
+
+    expect(success.innerHTML).toBe("<svg>safe</svg>");
+    expect(success.dataset.rendered).toBe("true");
+    expect(failure.textContent).toBe("Mermaid error: Error: invalid diagram");
+    expect(failure.dataset.rendered).toBe("error");
+  });
+});


### PR DESCRIPTION
## Summary

- Make Mermaid's post-sanitization render boundary safe: errors are written as text, malformed or forged placeholders are rejected, source and complexity are capped, and comment threads share an aggregate render budget.
- Serve SVG attachments as inert downloads with a non-active content type while retaining normal inline behavior for safe image and media formats.
- Apply a safe fallback to invalid legacy, imported, or restored label colors before they reach frontend CSS sinks.

## Regression coverage

- Mermaid limit tests keep ordinary diagrams renderable while rejecting oversized and dense sources, enforce aggregate byte and block limits, and confirm rejected input does not consume the shared budget.
- Mermaid render-boundary tests prove forged complex placeholders and malformed encoded sources never reach the renderer, multiple blocks share one budget, cancelled renders cannot mutate detached content, valid diagrams still render, and failures remain inert text.
- The label-color helper test preserves valid hexadecimal colors and replaces CSS source with the default color.
- The component rendering test feeds an unsafe stored color through the actual color picker and confirms neither the original value nor an injected CSS property reaches its rendered style.
- The attachment response test uploads an SVG containing script, then verifies it is returned as an attachment with an inert content type and restrictive content policy.
