### PR TITLE
Bound GitHub import concurrency and retained memory

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -268,7 +268,7 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
         // preview step.
         .route(
             "/api/projects/{id}/import/github",
-            post(projects::import_github),
+            post(projects::import_github).layer(DefaultBodyLimit::max(16 * 1024)),
         )
         // Saved views (LIF-242) — Viewer-gated + strict per-user ownership
         // enforced in the query layer (see src/api/views.rs doc comment).

--- a/src/api/projects.rs
+++ b/src/api/projects.rs
@@ -2,6 +2,9 @@ use axum::{
     Extension,
     extract::{Json, Path, Query, State},
 };
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::authz;
 use crate::db::{DbPool, models::*};
@@ -211,6 +214,52 @@ pub(super) struct GithubImportRequest {
     dry_run: bool,
 }
 
+// Keep a small global ceiling while allowing unrelated projects to import in
+// parallel. The per-project gate below is the important isolation boundary:
+// one expensive import cannot make another import for the same project race
+// its writes or consume unbounded resources.
+const GITHUB_IMPORT_GLOBAL_LIMIT: usize = 4;
+static GITHUB_IMPORT_SLOTS: OnceLock<Arc<Semaphore>> = OnceLock::new();
+static GITHUB_IMPORT_PROJECT_SLOTS: OnceLock<Mutex<HashMap<i64, Weak<Semaphore>>>> =
+    OnceLock::new();
+
+fn github_import_permits(
+    project_id: i64,
+) -> Result<(OwnedSemaphorePermit, OwnedSemaphorePermit), LificError> {
+    let project_slot = {
+        let slots = GITHUB_IMPORT_PROJECT_SLOTS.get_or_init(|| Mutex::new(HashMap::new()));
+        let mut slots = slots
+            .lock()
+            .map_err(|_| LificError::Internal("GitHub import gate poisoned".into()))?;
+        slots.retain(|_, slot| slot.strong_count() > 0);
+        match slots.entry(project_id) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if let Some(slot) = entry.get().upgrade() {
+                    slot
+                } else {
+                    let slot = Arc::new(Semaphore::new(1));
+                    entry.insert(Arc::downgrade(&slot));
+                    slot
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let slot = Arc::new(Semaphore::new(1));
+                entry.insert(Arc::downgrade(&slot));
+                slot
+            }
+        }
+    };
+    let project_permit = project_slot.try_acquire_owned().map_err(|_| {
+        LificError::Conflict("a GitHub import is already running for this project".into())
+    })?;
+    let global_permit = GITHUB_IMPORT_SLOTS
+        .get_or_init(|| Arc::new(Semaphore::new(GITHUB_IMPORT_GLOBAL_LIMIT)))
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| LificError::Conflict("too many GitHub imports are already running".into()))?;
+    Ok((global_permit, project_permit))
+}
+
 fn default_import_state() -> String {
     "all".to_string()
 }
@@ -241,6 +290,11 @@ pub(super) async fn import_github(
     Json(req): Json<GithubImportRequest>,
 ) -> Result<Json<crate::import::ImportSummary>, LificError> {
     require_project_lead(&db, &identity, project_id)?;
+    // Move both permits into the blocking closure. `spawn_blocking` cannot
+    // stop a running blocking task when this request is cancelled; keeping
+    // the permits in that closure prevents a cancelled request from releasing
+    // admission while its network/DB work is still running.
+    let (global_permit, project_permit) = github_import_permits(project_id)?;
 
     // Resolve the import-bot owner from the authenticated user (the bot is
     // owned by whoever ran the import), so audit provenance is correct. On a
@@ -250,6 +304,8 @@ pub(super) async fn import_github(
 
     let db2 = db.clone();
     let summary = tokio::task::spawn_blocking(move || {
+        let _global_permit = global_permit;
+        let _project_permit = project_permit;
         run_github_import_blocking(&db2, project_id, owner_id, &req)
     })
     .await
@@ -324,13 +380,41 @@ pub(super) fn import_github_with(
 
 #[cfg(test)]
 mod tests {
-    use super::{GithubImportRequest, import_github_with};
+    use super::{GithubImportRequest, github_import_permits, import_github_with};
     use crate::api::test_helpers::*;
     use crate::db::models::*;
     use axum::Extension;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn github_import_gate_is_per_project_and_survives_task_abort() {
+        let project_id = i64::MIN + 1;
+        let (global, project) = github_import_permits(project_id).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let task = tokio::task::spawn_blocking(move || {
+            // A blocking task keeps running after JoinHandle::abort(). The
+            // permits must therefore live in this closure, not in the request
+            // future that spawned it.
+            let _global = global;
+            let _project = project;
+            started_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        started_rx.recv().unwrap();
+        task.abort();
+        assert!(
+            github_import_permits(project_id).is_err(),
+            "same project must remain closed while aborted blocking work runs"
+        );
+
+        // A different project is admitted while the first one is occupied.
+        let (_other_global, _other_project) = github_import_permits(project_id + 1).unwrap();
+        release_tx.send(()).unwrap();
+        let _ = task.await;
+    }
 
     #[tokio::test]
     async fn project_crud_lifecycle() {

--- a/src/import/github.rs
+++ b/src/import/github.rs
@@ -426,9 +426,13 @@ impl GithubFetcher for LiveGithub {
                 .get("link")
                 .and_then(|v| v.to_str().ok())
                 .map(|s| s.to_string());
-            let batch: Vec<GithubComment> = resp
-                .json()
-                .map_err(|e| format!("failed to parse comments JSON: {e}"))?;
+            let batch: Vec<GithubComment> = Self::json_bounded(resp, "comments")?;
+            if batch.len() > 100 || all.len() + batch.len() > MAX_GITHUB_COMMENTS_PER_ISSUE {
+                return Err(format!(
+                    "GitHub comments exceed the {} per-issue limit",
+                    MAX_GITHUB_COMMENTS_PER_ISSUE
+                ));
+            }
             all.extend(batch);
             if !has_next_page(link.as_deref()) {
                 break;
@@ -539,6 +543,7 @@ mod tests {
     struct FakeGithub {
         pages: Vec<Vec<GithubIssue>>,
         comments: Vec<GithubComment>,
+        comment_fetches: std::cell::Cell<usize>,
     }
     impl GithubFetcher for FakeGithub {
         fn fetch_issues_page(
@@ -552,6 +557,7 @@ mod tests {
             Ok((issues, has_next))
         }
         fn fetch_comments(&self, _n: i64) -> Result<Vec<GithubComment>, String> {
+            self.comment_fetches.set(self.comment_fetches.get() + 1);
             Ok(self.comments.clone())
         }
     }
@@ -570,14 +576,84 @@ mod tests {
                 body: Some("a comment".into()),
                 created_at: Some("2024-01-01T00:00:00Z".into()),
             }],
+            comment_fetches: std::cell::Cell::new(0),
         };
-        let fetched =
-            collect(&fetcher, "octocat/hello", StateFilter::All, &StatusMap::default()).unwrap();
+        let fetched = collect(
+            &fetcher,
+            "octocat/hello",
+            StateFilter::All,
+            &StatusMap::default(),
+        )
+        .unwrap();
         // Fixture: 3 real issues + 1 PR.
         assert_eq!(fetched.issues.len(), 3);
         assert_eq!(fetched.skipped_non_issues, 1);
         // Each real issue got one comment from the fake.
         assert!(fetched.issues.iter().all(|i| i.comments.len() == 1));
         assert_eq!(fetched.issues[0].comments[0].author, "octocat");
+    }
+
+    #[test]
+    fn collect_rejects_comment_blowup() {
+        let issue = fixture_issues().into_iter().next().unwrap();
+        let fetcher = FakeGithub {
+            pages: vec![vec![issue]],
+            comments: vec![
+                GithubComment {
+                    user: None,
+                    body: Some("x".into()),
+                    created_at: None,
+                };
+                MAX_GITHUB_COMMENTS_PER_ISSUE + 1
+            ],
+            comment_fetches: std::cell::Cell::new(0),
+        };
+        let error = collect(
+            &fetcher,
+            "octocat/hello",
+            StateFilter::All,
+            &StatusMap::default(),
+        )
+        .unwrap_err();
+        assert!(error.contains("too many comments"));
+    }
+
+    #[test]
+    fn collect_rejects_issue_limit_before_fetching_comments() {
+        let issue = fixture_issues().into_iter().next().unwrap();
+        let fetcher = FakeGithub {
+            pages: vec![vec![issue; MAX_GITHUB_ISSUES + 1]],
+            comments: Vec::new(),
+            comment_fetches: std::cell::Cell::new(0),
+        };
+        let error = collect(
+            &fetcher,
+            "octocat/hello",
+            StateFilter::All,
+            &StatusMap::default(),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("too many issues"));
+        assert_eq!(fetcher.comment_fetches.get(), MAX_GITHUB_ISSUES);
+    }
+
+    #[test]
+    fn normalized_size_counts_empty_comment_allocations() {
+        let issue = fixture_issues().into_iter().next().unwrap();
+        let comments = vec![
+            GithubComment {
+                user: None,
+                body: None,
+                created_at: None,
+            };
+            MAX_GITHUB_COMMENTS_PER_ISSUE
+        ];
+        let normalized = map_issue("octocat/hello", &issue, &comments, &StatusMap::default());
+
+        assert!(
+            normalized_retained_bytes(&normalized)
+                >= comments.len() * std::mem::size_of::<super::super::NormalizedComment>()
+        );
     }
 }

--- a/src/import/github.rs
+++ b/src/import/github.rs
@@ -14,9 +14,16 @@
 //! tested against fixture JSON; the network lives behind [`GithubFetcher`].
 
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use std::io::Read;
 
 use super::{NormalizedComment, NormalizedIssue, NormalizedLabel, StatusMap};
 use crate::db::models::{Priority, Status};
+
+pub const MAX_GITHUB_ISSUES: usize = 10_000;
+pub const MAX_GITHUB_COMMENTS_PER_ISSUE: usize = 1_000;
+pub const MAX_GITHUB_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_GITHUB_NORMALIZED_BYTES: usize = 128 * 1024 * 1024;
 
 /// One issue as returned by the GitHub REST API (fields we use).
 #[derive(Debug, Clone, Deserialize)]
@@ -185,6 +192,7 @@ pub fn collect(
     map: &StatusMap,
 ) -> Result<super::FetchedIssues, String> {
     let mut out = super::FetchedIssues::default();
+    let mut total_normalized_bytes = 0usize;
     let mut page = 1u32;
     loop {
         let (issues, has_next) = fetcher.fetch_issues_page(page, state)?;
@@ -193,12 +201,46 @@ pub fn collect(
                 out.skipped_non_issues += 1;
                 continue;
             }
+            if out.issues.len() >= MAX_GITHUB_ISSUES {
+                return Err(format!(
+                    "GitHub repository has too many issues (more than {})",
+                    MAX_GITHUB_ISSUES
+                ));
+            }
             out.skipped_assignees += issue.assignees.len();
             if issue.milestone.is_some() {
                 out.skipped_other += 1;
             }
             let comments = fetcher.fetch_comments(issue.number)?;
-            out.issues.push(map_issue(slug, issue, &comments, map));
+            if comments.len() > MAX_GITHUB_COMMENTS_PER_ISSUE {
+                return Err(format!(
+                    "GitHub issue #{} has too many comments ({} > {})",
+                    issue.number,
+                    comments.len(),
+                    MAX_GITHUB_COMMENTS_PER_ISSUE
+                ));
+            }
+            let normalized = map_issue(slug, issue, &comments, map);
+            let previous_capacity = out.issues.capacity();
+            out.issues
+                .try_reserve(1)
+                .map_err(|_| "GitHub import normalized allocation failed".to_string())?;
+            let issue_slots = out
+                .issues
+                .capacity()
+                .saturating_sub(previous_capacity)
+                .saturating_mul(std::mem::size_of::<NormalizedIssue>());
+            total_normalized_bytes = total_normalized_bytes
+                .checked_add(issue_slots)
+                .and_then(|bytes| bytes.checked_add(normalized_retained_bytes(&normalized)))
+                .ok_or_else(|| "GitHub import content size overflow".to_string())?;
+            if total_normalized_bytes > MAX_GITHUB_NORMALIZED_BYTES {
+                return Err(format!(
+                    "GitHub import normalized data exceeds {} byte limit",
+                    MAX_GITHUB_NORMALIZED_BYTES
+                ));
+            }
+            out.issues.push(normalized);
         }
         if !has_next {
             break;
@@ -210,6 +252,40 @@ pub fn collect(
         }
     }
     Ok(out)
+}
+
+fn normalized_retained_bytes(issue: &NormalizedIssue) -> usize {
+    let label_bytes = issue.labels.iter().fold(
+        issue
+            .labels
+            .capacity()
+            .saturating_mul(std::mem::size_of::<NormalizedLabel>()),
+        |bytes, label| {
+            bytes
+                .saturating_add(label.name.capacity())
+                .saturating_add(label.color.as_ref().map_or(0, String::capacity))
+        },
+    );
+    let comment_bytes = issue.comments.iter().fold(
+        issue
+            .comments
+            .capacity()
+            .saturating_mul(std::mem::size_of::<NormalizedComment>()),
+        |bytes, comment| {
+            bytes
+                .saturating_add(comment.author.capacity())
+                .saturating_add(comment.body.capacity())
+                .saturating_add(comment.created_at.as_ref().map_or(0, String::capacity))
+        },
+    );
+
+    issue
+        .source
+        .capacity()
+        .saturating_add(issue.title.capacity())
+        .saturating_add(issue.description.capacity())
+        .saturating_add(label_bytes)
+        .saturating_add(comment_bytes)
 }
 
 /// Parse the RFC 5988 `Link` header to decide whether a next page exists.
@@ -290,6 +366,25 @@ impl LiveGithub {
         }
         Ok(resp)
     }
+
+    fn json_bounded<T: DeserializeOwned>(
+        resp: reqwest::blocking::Response,
+        label: &str,
+    ) -> Result<T, String> {
+        let mut bytes = Vec::new();
+        let mut reader = resp.take((MAX_GITHUB_RESPONSE_BYTES + 1) as u64);
+        reader
+            .read_to_end(&mut bytes)
+            .map_err(|e| format!("failed to read GitHub {label} response: {e}"))?;
+        if bytes.len() > MAX_GITHUB_RESPONSE_BYTES {
+            return Err(format!(
+                "GitHub {label} response exceeds {} byte limit",
+                MAX_GITHUB_RESPONSE_BYTES
+            ));
+        }
+        serde_json::from_slice(&bytes)
+            .map_err(|e| format!("failed to parse GitHub {label} JSON: {e}"))
+    }
 }
 
 impl GithubFetcher for LiveGithub {
@@ -310,9 +405,10 @@ impl GithubFetcher for LiveGithub {
             .get("link")
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
-        let issues: Vec<GithubIssue> = resp
-            .json()
-            .map_err(|e| format!("failed to parse issues JSON: {e}"))?;
+        let issues: Vec<GithubIssue> = Self::json_bounded(resp, "issues")?;
+        if issues.len() > 100 {
+            return Err("GitHub issues response exceeds the per-page item limit".into());
+        }
         Ok((issues, has_next_page(link.as_deref())))
     }
 


### PR DESCRIPTION
## Summary

Bound the blocking work and retained memory created by the web GitHub import endpoint. The endpoint now rejects excess concurrent work, prevents overlapping imports for one project, limits remote responses and imported item counts, and caps the normalized repository retained before dry-run or apply.

later, this should be refactored to be streaming I think.

## What changed

- Limit import request bodies to 16 KiB.
- Admit at most four GitHub imports per process and one per project.
- Hold admission permits inside the blocking task so aborting the request cannot admit replacement work while the original task still runs.
- Read at most 8 MiB from each GitHub response before JSON decoding.
- Limit issue pages to 100 entries, total imported issues to 10,000, comment pages to 100 entries, and comments to 1,000 per issue.
- Apply the same collection limits to dry-run and real imports.
- Cap retained normalized data at 128 MiB using allocation-aware accounting for issue slots, label and comment vector storage, and string capacities.

The operation retains its existing per-request HTTP timeout. Import-wide request-count, cumulative-response, and wall-clock budgets are outside this change.

## Tests added

- The admission test verifies that one project cannot start a second import while its first blocking task is still running, even after the request task is aborted, while an unrelated project remains admissible.
- The comment-bound test verifies that a source returning more than the per-issue comment ceiling is rejected.
- The memory-accounting test verifies that empty comments consume their retained object and vector footprint rather than being charged only for their text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards for GitHub imports, including limits on issues, comments, response sizes, and processed data.
  * Limited imports to four concurrent operations overall and one active import per project.
  * Added clear conflict responses when import capacity is unavailable.

* **Bug Fixes**
  * Improved handling of oversized or excessive GitHub data to prevent imports from exceeding resource limits.
  * Increased reliability when imports are cancelled or interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
