### PR TITLE
Bound restore archives and validate attachment integrity

### DIFF
--- a/migrations/043_attachment_integrity.sql
+++ b/migrations/043_attachment_integrity.sql
@@ -1,0 +1,63 @@
+-- Enforce the invariants required by content-addressed attachment storage.
+-- Existing rows are copied through the constrained table, so invalid legacy
+-- metadata makes the migration fail instead of silently becoming trusted.
+
+DROP TRIGGER IF EXISTS attachments_fts_ai;
+DROP TRIGGER IF EXISTS attachments_fts_au;
+DROP TRIGGER IF EXISTS attachments_fts_ad;
+
+CREATE TABLE attachments_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    sha256      TEXT NOT NULL
+                CHECK (length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*'),
+    filename    TEXT NOT NULL,
+    mime        TEXT NOT NULL CHECK (mime IN (
+        'image/png',
+        'image/jpeg',
+        'image/gif',
+        'image/webp',
+        'image/svg+xml',
+        'application/pdf',
+        'text/plain',
+        'application/zip',
+        'video/mp4',
+        'video/webm',
+        'audio/webm',
+        'audio/ogg',
+        'audio/mpeg',
+        'application/vnd.sqlite3'
+    )),
+    size_bytes  INTEGER NOT NULL CHECK (size_bytes >= 0),
+    uploader_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    width       INTEGER,
+    height      INTEGER,
+    alt_text    TEXT
+);
+
+INSERT INTO attachments_new
+    (id, sha256, filename, mime, size_bytes, uploader_id, created_at,
+     width, height, alt_text)
+SELECT id, sha256, filename, mime, size_bytes, uploader_id, created_at,
+       width, height, alt_text
+FROM attachments;
+
+DROP TABLE attachments;
+ALTER TABLE attachments_new RENAME TO attachments;
+
+CREATE INDEX idx_attachments_sha256 ON attachments(sha256);
+
+CREATE TRIGGER attachments_fts_ai AFTER INSERT ON attachments BEGIN
+    INSERT INTO attachments_fts(filename, extracted_text, attachment_id)
+    VALUES (NEW.filename, '', NEW.id);
+END;
+
+CREATE TRIGGER attachments_fts_au AFTER UPDATE ON attachments BEGIN
+    UPDATE attachments_fts
+    SET filename = NEW.filename
+    WHERE attachment_id = OLD.id;
+END;
+
+CREATE TRIGGER attachments_fts_ad AFTER DELETE ON attachments BEGIN
+    DELETE FROM attachments_fts WHERE attachment_id = OLD.id;
+END;

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -206,6 +206,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "attachment search",
         include_str!("../../migrations/042_attachment_search.sql"),
     ),
+    (
+        43,
+        "attachment integrity",
+        include_str!("../../migrations/043_attachment_integrity.sql"),
+    ),
 ];
 
 /// Migrations that rebuild a table other tables reference by foreign key.
@@ -234,7 +239,7 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
 /// before its savepoint releases, and `run_inner` repeats the check
 /// batch-wide before commit to cover every other migration that ran while
 /// enforcement was off.
-const FK_REBUILD_MIGRATIONS: &[i64] = &[39];
+const FK_REBUILD_MIGRATIONS: &[i64] = &[39, 43];
 
 /// Highest migration version this binary knows how to apply. Used by
 /// `lific dump`/`restore` (LIF-266) to stamp and gate archives on schema
@@ -640,7 +645,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(has_column, 0, "fixture must start on the pre-checksum shape");
+        assert_eq!(
+            has_column, 0,
+            "fixture must start on the pre-checksum shape"
+        );
 
         run(&conn).expect("a legacy database must upgrade cleanly");
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -645,10 +645,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(
-            has_column, 0,
-            "fixture must start on the pre-checksum shape"
-        );
+        assert_eq!(has_column, 0, "fixture must start on the pre-checksum shape");
 
         run(&conn).expect("a legacy database must upgrade cleanly");
 

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -118,7 +118,11 @@ pub fn update_alt_text(
 /// screenshot into two projects produces two rows over one blob, and this is
 /// how `GET /api/attachments/{id}/links` finds the twin so a caller can see
 /// the file is already in the tracker before uploading a third copy.
-pub fn duplicates_of(conn: &Connection, id: i64, sha256: &str) -> Result<Vec<Attachment>, LificError> {
+pub fn duplicates_of(
+    conn: &Connection,
+    id: i64,
+    sha256: &str,
+) -> Result<Vec<Attachment>, LificError> {
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT {ATTACHMENT_COLUMNS} FROM attachments
          WHERE sha256 = ?1 AND id != ?2 ORDER BY id"
@@ -640,11 +644,10 @@ pub fn list_project_attachments(
          WHERE {where_clause}"
     );
     let totals_params = base_params();
-    let (total_count, total_bytes): (i64, i64) = conn.query_row(
-        &totals_sql,
-        bind(&totals_params).as_slice(),
-        |row| Ok((row.get(0)?, row.get(1)?)),
-    )?;
+    let (total_count, total_bytes): (i64, i64) =
+        conn.query_row(&totals_sql, bind(&totals_params).as_slice(), |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?;
 
     let ids: Vec<i64> = items.iter().map(|item| item.id).collect();
     let mut entities = linked_entities_in_project(conn, project_id, &ids)?;
@@ -1160,6 +1163,10 @@ mod tests {
     use crate::db::models::CreateProject;
     use crate::db::{self, queries};
 
+    fn test_sha(label: &str) -> String {
+        crate::storage::AttachmentStore::hash_bytes(label.as_bytes())
+    }
+
     fn test_db() -> db::DbPool {
         db::open_memory().expect("test db")
     }
@@ -1208,13 +1215,20 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let uploader = seed_user(&conn, "up");
-        let att = create_attachment(&conn, "abc123", "shot.png", "image/png", 42, Some(uploader))
-            .unwrap();
+        let att = create_attachment(
+            &conn,
+            &test_sha("abc123"),
+            "shot.png",
+            "image/png",
+            42,
+            Some(uploader),
+        )
+        .unwrap();
         assert_eq!(att.filename, "shot.png");
         assert_eq!(att.size_bytes, 42);
 
         let fetched = get_attachment(&conn, att.id).unwrap();
-        assert_eq!(fetched.sha256, "abc123");
+        assert_eq!(fetched.sha256, test_sha("abc123"));
 
         assert!(delete_attachment(&conn, att.id).unwrap());
         assert!(get_attachment(&conn, att.id).is_err());
@@ -1227,7 +1241,7 @@ mod tests {
         let uploader_id = seed_user(&conn, "uploader");
         let attachment = create_attachment(
             &conn,
-            "owned",
+            &test_sha("owned"),
             "owned.txt",
             "text/plain",
             1,
@@ -1259,7 +1273,8 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let issue = seed_issue(&conn);
-        let att = create_attachment(&conn, "h1", "a.pdf", "application/pdf", 10, None).unwrap();
+        let att = create_attachment(&conn, &test_sha("h1"), "a.pdf", "application/pdf", 10, None)
+            .unwrap();
 
         assert!(
             list_for_entity(&conn, AttachmentEntity::Issue, issue)
@@ -1291,9 +1306,9 @@ mod tests {
     fn dedup_count_rows_for_sha() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        create_attachment(&conn, "same", "a.png", "image/png", 1, None).unwrap();
-        create_attachment(&conn, "same", "b.png", "image/png", 1, None).unwrap();
-        assert_eq!(count_rows_for_sha(&conn, "same").unwrap(), 2);
+        create_attachment(&conn, &test_sha("same"), "a.png", "image/png", 1, None).unwrap();
+        create_attachment(&conn, &test_sha("same"), "b.png", "image/png", 1, None).unwrap();
+        assert_eq!(count_rows_for_sha(&conn, &test_sha("same")).unwrap(), 2);
     }
 
     #[test]
@@ -1301,13 +1316,21 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let issue = seed_issue(&conn);
-        let a = create_attachment(&conn, "a", "a.png", "image/png", 1, None).unwrap();
-        let b = create_attachment(&conn, "b", "b.png", "image/png", 1, None).unwrap();
-        let c = create_attachment(&conn, "c", "c.png", "image/png", 1, None).unwrap();
+        let a = create_attachment(&conn, &test_sha("a"), "a.png", "image/png", 1, None).unwrap();
+        let b = create_attachment(&conn, &test_sha("b"), "b.png", "image/png", 1, None).unwrap();
+        let c = create_attachment(&conn, &test_sha("c"), "c.png", "image/png", 1, None).unwrap();
 
         // Start linking a + b.
-        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[a.id, b.id], 0, true, Some(1))
-            .unwrap();
+        sync_entity_links(
+            &conn,
+            AttachmentEntity::Issue,
+            issue,
+            &[a.id, b.id],
+            0,
+            true,
+            Some(1),
+        )
+        .unwrap();
         let ids: Vec<i64> = list_for_entity(&conn, AttachmentEntity::Issue, issue)
             .unwrap()
             .into_iter()
@@ -1316,8 +1339,16 @@ mod tests {
         assert_eq!(ids, vec![a.id, b.id]);
 
         // Re-sync to b + c: a is unlinked, c is added.
-        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[b.id, c.id], 0, true, Some(1))
-            .unwrap();
+        sync_entity_links(
+            &conn,
+            AttachmentEntity::Issue,
+            issue,
+            &[b.id, c.id],
+            0,
+            true,
+            Some(1),
+        )
+        .unwrap();
         let mut ids: Vec<i64> = list_for_entity(&conn, AttachmentEntity::Issue, issue)
             .unwrap()
             .into_iter()
@@ -1335,12 +1366,39 @@ mod tests {
         let conn = pool.write().unwrap();
         let issue = seed_issue(&conn);
         // 99999 doesn't exist — must not create a dangling link.
-        sync_entity_links(&conn, AttachmentEntity::Issue, issue, &[99999], 0, true, Some(1))
-            .unwrap();
+        sync_entity_links(
+            &conn,
+            AttachmentEntity::Issue,
+            issue,
+            &[99999],
+            0,
+            true,
+            Some(1),
+        )
+        .unwrap();
         assert!(
             list_for_entity(&conn, AttachmentEntity::Issue, issue)
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn attachment_metadata_rejects_invalid_hash_and_mime() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+
+        assert!(create_attachment(&conn, "../outside", "file.png", "image/png", 1, None,).is_err());
+        assert!(
+            create_attachment(
+                &conn,
+                &test_sha("valid"),
+                "file.bin",
+                "application/octet-stream",
+                1,
+                None,
+            )
+            .is_err()
         );
     }
 
@@ -1351,8 +1409,15 @@ mod tests {
         let owner = seed_user(&conn, "owner");
         let editor = seed_user(&conn, "editor");
         let issue = seed_issue(&conn);
-        let att = create_attachment(&conn, "foreign", "f.png", "image/png", 1, Some(owner))
-            .unwrap();
+        let att = create_attachment(
+            &conn,
+            &test_sha("foreign"),
+            "f.png",
+            "image/png",
+            1,
+            Some(owner),
+        )
+        .unwrap();
 
         sync_entity_links(
             &conn,
@@ -1364,9 +1429,11 @@ mod tests {
             Some(1),
         )
         .unwrap();
-        assert!(list_for_entity(&conn, AttachmentEntity::Issue, issue)
-            .unwrap()
-            .is_empty());
+        assert!(
+            list_for_entity(&conn, AttachmentEntity::Issue, issue)
+                .unwrap()
+                .is_empty()
+        );
 
         // Once the owner has placed the attachment in the same project, a
         // maintainer editing another entity in that project may reference it.
@@ -1422,10 +1489,24 @@ mod tests {
             let editor = seed_user(&conn, "editor");
             let issue = seed_issue(&conn);
             let project_id = queries::get_issue(&conn, issue).unwrap().project_id;
-            let mine =
-                create_attachment(&conn, "mine", "m.png", "image/png", 1, Some(editor)).unwrap();
-            let theirs =
-                create_attachment(&conn, "theirs", "t.png", "image/png", 1, Some(owner)).unwrap();
+            let mine = create_attachment(
+                &conn,
+                &test_sha("mine"),
+                "m.png",
+                "image/png",
+                1,
+                Some(editor),
+            )
+            .unwrap();
+            let theirs = create_attachment(
+                &conn,
+                &test_sha("theirs"),
+                "t.png",
+                "image/png",
+                1,
+                Some(owner),
+            )
+            .unwrap();
             (issue, project_id, editor, mine.id, theirs.id)
         };
 
@@ -1486,9 +1567,11 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let issue = seed_issue(&conn);
-        let linked = create_attachment(&conn, "l", "l.png", "image/png", 1, None).unwrap();
+        let linked =
+            create_attachment(&conn, &test_sha("l"), "l.png", "image/png", 1, None).unwrap();
         link_attachment(&conn, linked.id, AttachmentEntity::Issue, issue).unwrap();
-        let orphan = create_attachment(&conn, "o", "o.png", "image/png", 1, None).unwrap();
+        let orphan =
+            create_attachment(&conn, &test_sha("o"), "o.png", "image/png", 1, None).unwrap();
 
         // Grace of 1 hour: the just-created orphan is too new to collect.
         assert!(find_orphans(&conn, 3600).unwrap().is_empty());
@@ -1505,7 +1588,7 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let issue = seed_issue(&conn);
-        let att = create_attachment(&conn, "h", "a.png", "image/png", 1, None).unwrap();
+        let att = create_attachment(&conn, &test_sha("h"), "a.png", "image/png", 1, None).unwrap();
         link_attachment(&conn, att.id, AttachmentEntity::Issue, issue).unwrap();
         assert_eq!(
             list_for_entity(&conn, AttachmentEntity::Issue, issue)
@@ -1568,7 +1651,8 @@ mod tests {
         size: i64,
         uploader: Option<i64>,
     ) -> i64 {
-        let att = create_attachment(conn, sha, filename, mime, size, uploader).unwrap();
+        let sha = test_sha(sha);
+        let att = create_attachment(conn, &sha, filename, mime, size, uploader).unwrap();
         link_attachment(conn, att.id, AttachmentEntity::Issue, issue_id).unwrap();
         att.id
     }
@@ -1580,10 +1664,34 @@ mod tests {
         let project = seed_named_project(&conn, "FIL");
         let issue = seed_issue_in(&conn, project, "Bug with a screenshot");
         let uploader = seed_user(&conn, "uploader");
-        attach_to_issue(&conn, issue, "s1", "shot.png", "image/png", 100, Some(uploader));
-        attach_to_issue(&conn, issue, "s2", "trace.log", "text/plain", 250, Some(uploader));
+        attach_to_issue(
+            &conn,
+            issue,
+            "s1",
+            "shot.png",
+            "image/png",
+            100,
+            Some(uploader),
+        );
+        attach_to_issue(
+            &conn,
+            issue,
+            "s2",
+            "trace.log",
+            "text/plain",
+            250,
+            Some(uploader),
+        );
         // An unlinked upload is NOT part of the project listing.
-        create_attachment(&conn, "s3", "stray.png", "image/png", 999, Some(uploader)).unwrap();
+        create_attachment(
+            &conn,
+            &test_sha("s3"),
+            "stray.png",
+            "image/png",
+            999,
+            Some(uploader),
+        )
+        .unwrap();
 
         let page =
             list_project_attachments(&conn, project, &ProjectAttachmentQuery::default()).unwrap();
@@ -1646,8 +1754,15 @@ mod tests {
             },
         )
         .unwrap();
-        let on_page = create_attachment(&conn, "c", "c.zip", "application/zip", 30, Some(alice))
-            .unwrap();
+        let on_page = create_attachment(
+            &conn,
+            &test_sha("c"),
+            "c.zip",
+            "application/zip",
+            30,
+            Some(alice),
+        )
+        .unwrap();
         link_attachment(&conn, on_page.id, AttachmentEntity::Page, page_row.id).unwrap();
 
         let by_class = list_project_attachments(
@@ -1704,7 +1819,15 @@ mod tests {
         let conn = pool.write().unwrap();
         let project = seed_named_project(&conn, "SRT");
         let issue = seed_issue_in(&conn, project, "target");
-        attach_to_issue(&conn, issue, "a", "big.bin", "application/octet-stream", 900, None);
+        attach_to_issue(
+            &conn,
+            issue,
+            "a",
+            "big.bin",
+            "application/vnd.sqlite3",
+            900,
+            None,
+        );
         attach_to_issue(&conn, issue, "b", "mid.png", "image/png", 500, None);
         attach_to_issue(&conn, issue, "c", "small.txt", "text/plain", 10, None);
 
@@ -1810,7 +1933,15 @@ mod tests {
             "see the log",
         )
         .unwrap();
-        let att = create_attachment(&conn, "z", "log.txt", "text/plain", 5, Some(author)).unwrap();
+        let att = create_attachment(
+            &conn,
+            &test_sha("z"),
+            "log.txt",
+            "text/plain",
+            5,
+            Some(author),
+        )
+        .unwrap();
         link_attachment(&conn, att.id, AttachmentEntity::Comment, comment.id).unwrap();
 
         let page =
@@ -1841,7 +1972,8 @@ mod tests {
         let second = seed_named_project(&conn, "TWO");
         let first_issue = seed_issue_in(&conn, first, "one");
         let second_issue = seed_issue_in(&conn, second, "two");
-        let att = create_attachment(&conn, "s", "shared.png", "image/png", 1, None).unwrap();
+        let att =
+            create_attachment(&conn, &test_sha("s"), "shared.png", "image/png", 1, None).unwrap();
         link_attachment(&conn, att.id, AttachmentEntity::Issue, first_issue).unwrap();
         link_attachment(&conn, att.id, AttachmentEntity::Issue, second_issue).unwrap();
 
@@ -1854,7 +1986,8 @@ mod tests {
             Some("TWO-1")
         );
         // No link at all: nothing to point at.
-        let unlinked = create_attachment(&conn, "u", "u.png", "image/png", 1, None).unwrap();
+        let unlinked =
+            create_attachment(&conn, &test_sha("u"), "u.png", "image/png", 1, None).unwrap();
         assert!(primary_link(&conn, unlinked.id, None).unwrap().is_none());
     }
 
@@ -1877,10 +2010,25 @@ mod tests {
         // Linked: never an orphan.
         attach_to_issue(&conn, issue, "a", "used.png", "image/png", 10, Some(member));
         // Unlinked, by a member: the row this endpoint exists for.
-        let pending =
-            create_attachment(&conn, "b", "draft.png", "image/png", 20, Some(member)).unwrap();
+        let pending = create_attachment(
+            &conn,
+            &test_sha("b"),
+            "draft.png",
+            "image/png",
+            20,
+            Some(member),
+        )
+        .unwrap();
         // Unlinked, by a non-member: not this project's business.
-        create_attachment(&conn, "c", "other.png", "image/png", 30, Some(stranger)).unwrap();
+        create_attachment(
+            &conn,
+            &test_sha("c"),
+            "other.png",
+            "image/png",
+            30,
+            Some(stranger),
+        )
+        .unwrap();
 
         let orphans = list_project_orphans(&conn, project, 24 * 60 * 60).unwrap();
         assert_eq!(orphans.len(), 1);
@@ -1914,13 +2062,14 @@ mod tests {
     fn extracted_text_is_indexed_once_and_not_reoffered() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        let text = create_attachment(&conn, "t1", "notes.txt", "text/plain", 12, None).unwrap();
-        create_attachment(&conn, "i1", "shot.png", "image/png", 12, None).unwrap();
+        let text =
+            create_attachment(&conn, &test_sha("t1"), "notes.txt", "text/plain", 12, None).unwrap();
+        create_attachment(&conn, &test_sha("i1"), "shot.png", "image/png", 12, None).unwrap();
 
         // The insert trigger indexed the filename but no contents yet, so the
         // text row is the only backfill candidate.
         let pending = unindexed_text_attachments(&conn).unwrap();
-        assert_eq!(pending, vec![(text.id, "t1".to_string())]);
+        assert_eq!(pending, vec![(text.id, test_sha("t1"))]);
 
         set_extracted_text(&conn, text.id, "the quokka migration notes").unwrap();
         assert!(
@@ -1945,7 +2094,8 @@ mod tests {
     fn dimensions_drive_the_derived_thumbnail_flag() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        let att = create_attachment(&conn, "dim", "big.png", "image/png", 1, None).unwrap();
+        let att =
+            create_attachment(&conn, &test_sha("dim"), "big.png", "image/png", 1, None).unwrap();
         assert_eq!(att.width, None);
         assert!(
             !att.has_thumbnail,
@@ -1958,12 +2108,14 @@ mod tests {
         assert!(att.has_thumbnail);
 
         // A raster that already fits the thumbnail box needs none.
-        let small = create_attachment(&conn, "small", "s.png", "image/png", 1, None).unwrap();
+        let small =
+            create_attachment(&conn, &test_sha("small"), "s.png", "image/png", 1, None).unwrap();
         set_dimensions(&conn, small.id, 100, 100).unwrap();
         assert!(!get_attachment(&conn, small.id).unwrap().has_thumbnail);
 
         // Nor does a non-raster, whatever dimensions someone recorded.
-        let pdf = create_attachment(&conn, "pdf", "a.pdf", "application/pdf", 1, None).unwrap();
+        let pdf = create_attachment(&conn, &test_sha("pdf"), "a.pdf", "application/pdf", 1, None)
+            .unwrap();
         set_dimensions(&conn, pdf.id, 2000, 2000).unwrap();
         assert!(!get_attachment(&conn, pdf.id).unwrap().has_thumbnail);
     }
@@ -1972,7 +2124,8 @@ mod tests {
     fn alt_text_round_trips_and_clears() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        let att = create_attachment(&conn, "alt", "a.png", "image/png", 1, None).unwrap();
+        let att =
+            create_attachment(&conn, &test_sha("alt"), "a.png", "image/png", 1, None).unwrap();
         assert_eq!(att.alt_text, None);
 
         let updated = update_alt_text(&conn, att.id, Some("a red square")).unwrap();
@@ -1988,15 +2141,22 @@ mod tests {
     fn duplicates_are_the_other_rows_over_the_same_bytes() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        let a = create_attachment(&conn, "shared", "a.png", "image/png", 1, None).unwrap();
-        let b = create_attachment(&conn, "shared", "b.png", "image/png", 1, None).unwrap();
-        let other = create_attachment(&conn, "alone", "c.png", "image/png", 1, None).unwrap();
+        let a =
+            create_attachment(&conn, &test_sha("shared"), "a.png", "image/png", 1, None).unwrap();
+        let b =
+            create_attachment(&conn, &test_sha("shared"), "b.png", "image/png", 1, None).unwrap();
+        let other =
+            create_attachment(&conn, &test_sha("alone"), "c.png", "image/png", 1, None).unwrap();
 
-        let dupes = duplicates_of(&conn, a.id, "shared").unwrap();
+        let dupes = duplicates_of(&conn, a.id, &test_sha("shared")).unwrap();
         assert_eq!(dupes.len(), 1);
         assert_eq!(dupes[0].id, b.id);
         assert_eq!(dupes[0].filename, "b.png");
-        assert!(duplicates_of(&conn, other.id, "alone").unwrap().is_empty());
+        assert!(
+            duplicates_of(&conn, other.id, &test_sha("alone"))
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -2004,7 +2164,7 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let issue = seed_issue(&conn);
-        let att = create_attachment(&conn, "l", "a.png", "image/png", 1, None).unwrap();
+        let att = create_attachment(&conn, &test_sha("l"), "a.png", "image/png", 1, None).unwrap();
         assert!(links_for_attachment(&conn, att.id).unwrap().is_empty());
 
         link_attachment(&conn, att.id, AttachmentEntity::Issue, issue).unwrap();

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -118,11 +118,7 @@ pub fn update_alt_text(
 /// screenshot into two projects produces two rows over one blob, and this is
 /// how `GET /api/attachments/{id}/links` finds the twin so a caller can see
 /// the file is already in the tracker before uploading a third copy.
-pub fn duplicates_of(
-    conn: &Connection,
-    id: i64,
-    sha256: &str,
-) -> Result<Vec<Attachment>, LificError> {
+pub fn duplicates_of(conn: &Connection, id: i64, sha256: &str) -> Result<Vec<Attachment>, LificError> {
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT {ATTACHMENT_COLUMNS} FROM attachments
          WHERE sha256 = ?1 AND id != ?2 ORDER BY id"
@@ -644,10 +640,11 @@ pub fn list_project_attachments(
          WHERE {where_clause}"
     );
     let totals_params = base_params();
-    let (total_count, total_bytes): (i64, i64) =
-        conn.query_row(&totals_sql, bind(&totals_params).as_slice(), |row| {
-            Ok((row.get(0)?, row.get(1)?))
-        })?;
+    let (total_count, total_bytes): (i64, i64) = conn.query_row(
+        &totals_sql,
+        bind(&totals_params).as_slice(),
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
 
     let ids: Vec<i64> = items.iter().map(|item| item.id).collect();
     let mut entities = linked_entities_in_project(conn, project_id, &ids)?;

--- a/src/db/queries/comments.rs
+++ b/src/db/queries/comments.rs
@@ -795,7 +795,7 @@ mod tests {
         .unwrap();
         let attachment = queries::attachments::create_attachment(
             &conn,
-            "foreign",
+            &crate::storage::AttachmentStore::hash_bytes(b"foreign"),
             "foreign.txt",
             "text/plain",
             7,

--- a/src/db/queries/search.rs
+++ b/src/db/queries/search.rs
@@ -1591,8 +1591,8 @@ mod tests {
         text: Option<&str>,
     ) -> i64 {
         use crate::db::queries::attachments as att;
-        let attachment =
-            att::create_attachment(conn, filename, filename, mime, 42, None).unwrap();
+        let sha = crate::storage::AttachmentStore::hash_bytes(filename.as_bytes());
+        let attachment = att::create_attachment(conn, &sha, filename, mime, 42, None).unwrap();
         if let Some(issue_id) = issue_id {
             att::link_attachment(conn, attachment.id, AttachmentEntity::Issue, issue_id).unwrap();
         }
@@ -1827,8 +1827,9 @@ mod tests {
         assert!(hidden_issue < visible_issue);
 
         use crate::db::queries::attachments as att;
+        let sha = crate::storage::AttachmentStore::hash_bytes(b"sha");
         let attachment =
-            att::create_attachment(&conn, "sha", "gribblenaut.log", "text/plain", 9, None).unwrap();
+            att::create_attachment(&conn, &sha, "gribblenaut.log", "text/plain", 9, None).unwrap();
         att::link_attachment(&conn, attachment.id, AttachmentEntity::Issue, hidden_issue).unwrap();
         att::link_attachment(&conn, attachment.id, AttachmentEntity::Issue, visible_issue).unwrap();
 

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -1867,8 +1867,8 @@ mod tests {
         .unwrap();
         conn.execute(
             "INSERT INTO attachments (sha256, filename, mime, size_bytes, uploader_id)
-             VALUES ('abc', 'f.png', 'image/png', 1, ?1)",
-            params![loser],
+             VALUES (?1, 'f.png', 'image/png', 1, ?2)",
+            params![crate::storage::AttachmentStore::hash_bytes(b"abc"), loser],
         )
         .unwrap();
         conn.execute("UPDATE projects SET lead_user_id = ?1", params![loser])

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -187,9 +187,8 @@ pub fn write_dump(pool: &DbPool, db_path: &Path, out_path: &Path) -> Result<Mani
             // attachments/<sha256>
             for (name, path, _size) in &blobs {
                 let entry_name = format!("{ARCHIVE_ATTACHMENTS_PREFIX}{name}");
-                tar.append_path_with_name(path, &entry_name).map_err(|e| {
-                    LificError::Internal(format!("append attachment {name}: {e}"))
-                })?;
+                tar.append_path_with_name(path, &entry_name)
+                    .map_err(|e| LificError::Internal(format!("append attachment {name}: {e}")))?;
             }
 
             let enc = tar
@@ -331,6 +330,11 @@ fn validate_attachment_entry(name: &str) -> Result<String, LificError> {
             "rejected attachment entry (path traversal or invalid name): {name}"
         )));
     }
+    if !valid_sha256(rest) {
+        return Err(LificError::BadRequest(format!(
+            "rejected attachment entry (expected lowercase SHA-256): {name}"
+        )));
+    }
     Ok(rest.to_string())
 }
 
@@ -376,7 +380,10 @@ fn read_entry_bounded<R: Read>(
 }
 
 fn valid_sha256(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
 }
 
 /// Validate the extracted SQLite file before it can replace the live DB. This
@@ -384,11 +391,9 @@ fn valid_sha256(value: &str) -> bool {
 /// a safe content-addressed filename with matching staged bytes.
 fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
     let db = staging.join(ARCHIVE_DB_NAME);
-    let conn = rusqlite::Connection::open_with_flags(
-        &db,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-    )
-    .map_err(|e| LificError::BadRequest(format!("open staged database: {e}")))?;
+    let conn =
+        rusqlite::Connection::open_with_flags(&db, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| LificError::BadRequest(format!("open staged database: {e}")))?;
     let check: String = conn
         .query_row("PRAGMA quick_check", [], |row| row.get(0))
         .map_err(|e| LificError::BadRequest(format!("validate staged database: {e}")))?;
@@ -413,11 +418,13 @@ fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
         .prepare("SELECT sha256, size_bytes FROM attachments")
         .map_err(|e| LificError::BadRequest(format!("read staged attachments: {e}")))?;
     let rows = stmt
-        .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })
         .map_err(|e| LificError::BadRequest(format!("read staged attachment rows: {e}")))?;
     for row in rows {
-        let (sha, size) = row
-            .map_err(|e| LificError::BadRequest(format!("read staged attachment row: {e}")))?;
+        let (sha, size) =
+            row.map_err(|e| LificError::BadRequest(format!("read staged attachment row: {e}")))?;
         if !valid_sha256(&sha) || size < 0 || size as u64 > MAX_ATTACHMENT_BYTES {
             return Err(LificError::BadRequest(
                 "staged attachment metadata has an invalid content address or size".into(),
@@ -425,7 +432,9 @@ fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
         }
         let path = staging.join("attachments").join(&sha);
         let metadata = std::fs::metadata(&path).map_err(|_| {
-            LificError::BadRequest(format!("staged database references missing attachment {sha}"))
+            LificError::BadRequest(format!(
+                "staged database references missing attachment {sha}"
+            ))
         })?;
         if !metadata.is_file() || metadata.len() != size as u64 {
             return Err(LificError::BadRequest(format!(
@@ -460,7 +469,9 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
         let entry = entry.map_err(|e| LificError::BadRequest(format!("read entry: {e}")))?;
         entry_count += 1;
         if entry_count > MAX_RESTORE_ENTRIES + 2 {
-            return Err(LificError::BadRequest("archive has too many entries".into()));
+            return Err(LificError::BadRequest(
+                "archive has too many entries".into(),
+            ));
         }
         let size = entry.size();
         let path = entry
@@ -471,13 +482,17 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
             continue;
         } else if name == ARCHIVE_DB_NAME {
             if size > MAX_DB_BYTES {
-                return Err(LificError::BadRequest("archive database exceeds restore limit".into()));
+                return Err(LificError::BadRequest(
+                    "archive database exceeds restore limit".into(),
+                ));
             }
             has_db = true;
         } else if name.starts_with(ARCHIVE_ATTACHMENTS_PREFIX) {
             validate_attachment_entry(&name)?;
             if size > MAX_ATTACHMENT_BYTES {
-                return Err(LificError::BadRequest("archive attachment exceeds restore limit".into()));
+                return Err(LificError::BadRequest(
+                    "archive attachment exceeds restore limit".into(),
+                ));
             }
             attachment_count += 1;
             attachment_bytes = attachment_bytes
@@ -497,11 +512,11 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
         }
     }
     if !has_db {
-        return Err(LificError::BadRequest(
-            "archive is missing lific.db".into(),
-        ));
+        return Err(LificError::BadRequest("archive is missing lific.db".into()));
     }
-    if attachment_count != manifest.attachment_count || attachment_bytes != manifest.attachment_bytes {
+    if attachment_count != manifest.attachment_count
+        || attachment_bytes != manifest.attachment_bytes
+    {
         return Err(LificError::BadRequest(
             "archive attachment entries do not match manifest".into(),
         ));
@@ -540,7 +555,9 @@ fn read_manifest(archive: &Path) -> Result<Manifest, LificError> {
 /// may still be running (best-effort — see command help).
 fn wal_is_hot(db_path: &Path) -> bool {
     let wal = PathBuf::from(format!("{}-wal", db_path.display()));
-    std::fs::metadata(&wal).map(|m| m.len() > 0).unwrap_or(false)
+    std::fs::metadata(&wal)
+        .map(|m| m.len() > 0)
+        .unwrap_or(false)
 }
 
 /// Run `lific restore`: validate the archive, then stage-extract it into the
@@ -664,9 +681,7 @@ pub fn run_restore(
             }
         }
         if !staging.join(ARCHIVE_DB_NAME).exists() {
-            return Err(LificError::BadRequest(
-                "archive is missing lific.db".into(),
-            ));
+            return Err(LificError::BadRequest("archive is missing lific.db".into()));
         }
         validate_staged_database(&staging)?;
         Ok(attachment_count)
@@ -686,18 +701,54 @@ pub fn run_restore(
         }
     };
 
-    // Move restored files into place. DB first, then swap the attachments dir.
-    std::fs::rename(staging.join(ARCHIVE_DB_NAME), db_path)
-        .map_err(|e| LificError::Internal(format!("install restored db: {e}")))?;
-    set_owner_only(db_path)
-        .map_err(|e| LificError::Internal(format!("chmod restored db: {e}")))?;
-
+    // Move restored files into place as one recoverable transaction. Keep the
+    // old attachment directory until both the DB and new directory are live so
+    // a filesystem failure cannot leave mismatched metadata and blobs.
     let attachments_dest = attachments_dir_for(db_path);
-    if attachments_dest.exists() {
-        let _ = std::fs::remove_dir_all(&attachments_dest);
+    let attachments_backup = PathBuf::from(format!(
+        "{}.pre-restore-{}",
+        attachments_dest.display(),
+        archive_timestamp()
+    ));
+    let had_attachments = attachments_dest.exists();
+    if had_attachments {
+        if let Err(e) = std::fs::rename(&attachments_dest, &attachments_backup) {
+            if let Some(moved) = &moved_existing_to {
+                let _ = std::fs::rename(moved, db_path);
+            }
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(LificError::Internal(format!(
+                "move existing attachments aside: {e}"
+            )));
+        }
     }
-    std::fs::rename(staging.join("attachments"), &attachments_dest)
-        .map_err(|e| LificError::Internal(format!("install restored attachments: {e}")))?;
+
+    let install_result = (|| -> Result<(), LificError> {
+        std::fs::rename(staging.join(ARCHIVE_DB_NAME), db_path)
+            .map_err(|e| LificError::Internal(format!("install restored db: {e}")))?;
+        set_owner_only(db_path)
+            .map_err(|e| LificError::Internal(format!("chmod restored db: {e}")))?;
+        std::fs::rename(staging.join("attachments"), &attachments_dest)
+            .map_err(|e| LificError::Internal(format!("install restored attachments: {e}")))?;
+        Ok(())
+    })();
+
+    if let Err(error) = install_result {
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_dir_all(&attachments_dest);
+        if had_attachments {
+            let _ = std::fs::rename(&attachments_backup, &attachments_dest);
+        }
+        if let Some(moved) = &moved_existing_to {
+            let _ = std::fs::rename(moved, db_path);
+        }
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(error);
+    }
+
+    if had_attachments {
+        let _ = std::fs::remove_dir_all(&attachments_backup);
+    }
 
     let _ = std::fs::remove_dir_all(&staging);
 
@@ -788,9 +839,21 @@ mod tests {
         }
         let att = dir.join("attachments");
         fs::create_dir_all(&att).unwrap();
-        fs::write(att.join("deadbeef01"), b"blob one").unwrap();
-        fs::write(att.join("deadbeef02"), b"second blob bytes").unwrap();
-        fs::write(att.join("deadbeef02.tmp"), b"partial write").unwrap();
+        fs::write(
+            att.join("0000000000000000000000000000000000000000000000000000000000000001"),
+            b"blob one",
+        )
+        .unwrap();
+        fs::write(
+            att.join("0000000000000000000000000000000000000000000000000000000000000002"),
+            b"second blob bytes",
+        )
+        .unwrap();
+        fs::write(
+            att.join("0000000000000000000000000000000000000000000000000000000000000002.tmp"),
+            b"partial write",
+        )
+        .unwrap();
         (tmp, db_path)
     }
 
@@ -801,7 +864,13 @@ mod tests {
         let mut tar = tar::Archive::new(dec);
         tar.entries()
             .unwrap()
-            .map(|e| e.unwrap().path().unwrap().to_string_lossy().replace('\\', "/"))
+            .map(|e| {
+                e.unwrap()
+                    .path()
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
             .collect()
     }
 
@@ -815,17 +884,33 @@ mod tests {
         let entries = archive_entries(&out);
         assert!(entries.contains(&ARCHIVE_DB_NAME.to_string()));
         assert!(entries.contains(&ARCHIVE_MANIFEST_NAME.to_string()));
-        assert!(entries.contains(&"attachments/deadbeef01".to_string()));
-        assert!(entries.contains(&"attachments/deadbeef02".to_string()));
+        assert!(
+            entries.contains(
+                &"attachments/0000000000000000000000000000000000000000000000000000000000000001"
+                    .to_string()
+            )
+        );
+        assert!(
+            entries.contains(
+                &"attachments/0000000000000000000000000000000000000000000000000000000000000002"
+                    .to_string()
+            )
+        );
         assert!(
             !entries.iter().any(|e| e.ends_with(".tmp")),
             "in-progress .tmp writes must be excluded: {entries:?}"
         );
 
         assert_eq!(manifest.attachment_count, 2);
-        assert_eq!(manifest.attachment_bytes, (b"blob one".len() + b"second blob bytes".len()) as u64);
+        assert_eq!(
+            manifest.attachment_bytes,
+            (b"blob one".len() + b"second blob bytes".len()) as u64
+        );
         assert_eq!(manifest.lific_version, env!("CARGO_PKG_VERSION"));
-        assert_eq!(manifest.schema_version, crate::db::migrate::latest_version());
+        assert_eq!(
+            manifest.schema_version,
+            crate::db::migrate::latest_version()
+        );
         assert!(manifest.db_size_bytes > 0);
     }
 
@@ -928,19 +1013,31 @@ mod tests {
         let pool = crate::db::open(&dst_db).unwrap();
         let conn = pool.read().unwrap();
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM projects WHERE identifier = 'DMP'", [], |r| {
-                r.get(0)
-            })
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE identifier = 'DMP'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(count, 1);
 
         // Blob bytes identical.
         assert_eq!(
-            fs::read(dst_dir.join("attachments").join("deadbeef01")).unwrap(),
+            fs::read(
+                dst_dir
+                    .join("attachments")
+                    .join("0000000000000000000000000000000000000000000000000000000000000001")
+            )
+            .unwrap(),
             b"blob one"
         );
         assert_eq!(
-            fs::read(dst_dir.join("attachments").join("deadbeef02")).unwrap(),
+            fs::read(
+                dst_dir
+                    .join("attachments")
+                    .join("0000000000000000000000000000000000000000000000000000000000000002")
+            )
+            .unwrap(),
             b"second blob bytes"
         );
     }
@@ -991,24 +1088,38 @@ mod tests {
         }
 
         let res = run_restore(&out, &dst_db, true).unwrap();
-        let moved = res.moved_existing_to.expect("existing db should be moved aside");
+        let moved = res
+            .moved_existing_to
+            .expect("existing db should be moved aside");
         assert!(moved.exists(), "moved-aside db must still exist");
         assert!(
-            moved.file_name().unwrap().to_string_lossy().contains("pre-restore-"),
+            moved
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains("pre-restore-"),
             "moved db name must include pre-restore-: {}",
             moved.display()
         );
         // The moved-aside db still has the OLD project.
         let conn = rusqlite::Connection::open(&moved).unwrap();
         let old: i64 = conn
-            .query_row("SELECT COUNT(*) FROM projects WHERE identifier='OLD'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE identifier='OLD'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(old, 1);
         // The live db now has the restored project.
         let pool = crate::db::open(&dst_db).unwrap();
         let conn = pool.read().unwrap();
         let dmp: i64 = conn
-            .query_row("SELECT COUNT(*) FROM projects WHERE identifier='DMP'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE identifier='DMP'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(dmp, 1);
     }
@@ -1121,7 +1232,11 @@ mod tests {
         let pool = crate::db::open(&dst_db).unwrap();
         let conn = pool.read().unwrap();
         let org: i64 = conn
-            .query_row("SELECT COUNT(*) FROM projects WHERE identifier='ORG'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE identifier='ORG'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(org, 1, "original data must survive a failed restore");
     }
@@ -1179,7 +1294,12 @@ mod tests {
 
     #[test]
     fn validate_attachment_entry_accepts_bare_hash_rejects_traversal() {
-        assert!(validate_attachment_entry("attachments/abc123def").is_ok());
+        assert!(
+            validate_attachment_entry(
+                "attachments/0000000000000000000000000000000000000000000000000000000000000001"
+            )
+            .is_ok()
+        );
         assert!(validate_attachment_entry("attachments/../etc/passwd").is_err());
         assert!(validate_attachment_entry("attachments/sub/dir").is_err());
         assert!(validate_attachment_entry("attachments/").is_err());

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -491,12 +491,9 @@ fn validate_staged_database(staging: &Path, manifest: &Manifest) -> Result<(), L
         )
         .map_err(|e| LificError::BadRequest(format!("inspect staged schema: {e}")))?;
     if !has_attachments {
-        if manifest.attachment_count != 0 || manifest.attachment_bytes != 0 {
-            return Err(LificError::BadRequest(
-                "manifest contains attachments but staged schema does not support them".into(),
-            ));
-        }
-        return Ok(());
+        return Err(LificError::BadRequest(
+            "staged database is missing the attachments table".into(),
+        ));
     }
 
     if schema_version < ATTACHMENTS_SCHEMA_VERSION {
@@ -555,6 +552,45 @@ fn validate_staged_database(staging: &Path, manifest: &Manifest) -> Result<(), L
             )));
         }
         validated_sizes.insert(sha, size);
+    }
+
+    let attachments_dir = staging.join("attachments");
+    for entry in std::fs::read_dir(&attachments_dir)
+        .map_err(|e| LificError::BadRequest(format!("read staged attachments: {e}")))?
+    {
+        let entry = entry
+            .map_err(|e| LificError::BadRequest(format!("read staged attachment: {e}")))?;
+        let path = entry.path();
+        let metadata = std::fs::symlink_metadata(&path).map_err(|e| {
+            LificError::BadRequest(format!("inspect staged attachment {}: {e}", path.display()))
+        })?;
+        if !metadata.is_file() {
+            return Err(LificError::BadRequest(format!(
+                "staged attachment is not a regular file: {}",
+                path.display()
+            )));
+        }
+        let name = entry.file_name().into_string().map_err(|_| {
+            LificError::BadRequest(format!(
+                "staged attachment has a non-UTF-8 name: {}",
+                path.display()
+            ))
+        })?;
+        if !crate::storage::valid_sha256(&name) {
+            return Err(LificError::BadRequest(format!(
+                "staged attachment has an invalid content address: {name}"
+            )));
+        }
+        if metadata.len() > MAX_ATTACHMENT_BYTES {
+            return Err(LificError::BadRequest(format!(
+                "staged attachment exceeds restore limit: {name}"
+            )));
+        }
+        if hash_file(&path)? != name {
+            return Err(LificError::BadRequest(format!(
+                "staged attachment {name} does not match its content address"
+            )));
+        }
     }
     Ok(())
 }
@@ -1051,18 +1087,20 @@ mod tests {
         }
         let att = dir.join("attachments");
         fs::create_dir_all(&att).unwrap();
+        let first_sha = crate::storage::AttachmentStore::hash_bytes(b"blob one");
+        let second_sha = crate::storage::AttachmentStore::hash_bytes(b"second blob bytes");
         fs::write(
-            att.join("0000000000000000000000000000000000000000000000000000000000000001"),
+            att.join(&first_sha),
             b"blob one",
         )
         .unwrap();
         fs::write(
-            att.join("0000000000000000000000000000000000000000000000000000000000000002"),
+            att.join(&second_sha),
             b"second blob bytes",
         )
         .unwrap();
         fs::write(
-            att.join("0000000000000000000000000000000000000000000000000000000000000002.tmp"),
+            att.join(format!("{second_sha}.tmp")),
             b"partial write",
         )
         .unwrap();
@@ -1096,18 +1134,14 @@ mod tests {
         let entries = archive_entries(&out);
         assert!(entries.contains(&ARCHIVE_DB_NAME.to_string()));
         assert!(entries.contains(&ARCHIVE_MANIFEST_NAME.to_string()));
-        assert!(
-            entries.contains(
-                &"attachments/0000000000000000000000000000000000000000000000000000000000000001"
-                    .to_string()
-            )
-        );
-        assert!(
-            entries.contains(
-                &"attachments/0000000000000000000000000000000000000000000000000000000000000002"
-                    .to_string()
-            )
-        );
+        assert!(entries.contains(&format!(
+            "{ARCHIVE_ATTACHMENTS_PREFIX}{}",
+            crate::storage::AttachmentStore::hash_bytes(b"blob one")
+        )));
+        assert!(entries.contains(&format!(
+            "{ARCHIVE_ATTACHMENTS_PREFIX}{}",
+            crate::storage::AttachmentStore::hash_bytes(b"second blob bytes")
+        )));
         assert!(
             !entries.iter().any(|e| e.ends_with(".tmp")),
             "in-progress .tmp writes must be excluded: {entries:?}"
@@ -1235,20 +1269,16 @@ mod tests {
 
         // Blob bytes identical.
         assert_eq!(
-            fs::read(
-                dst_dir
-                    .join("attachments")
-                    .join("0000000000000000000000000000000000000000000000000000000000000001")
-            )
+            fs::read(dst_dir.join("attachments").join(
+                crate::storage::AttachmentStore::hash_bytes(b"blob one"),
+            ))
             .unwrap(),
             b"blob one"
         );
         assert_eq!(
-            fs::read(
-                dst_dir
-                    .join("attachments")
-                    .join("0000000000000000000000000000000000000000000000000000000000000002")
-            )
+            fs::read(dst_dir.join("attachments").join(
+                crate::storage::AttachmentStore::hash_bytes(b"second blob bytes"),
+            ))
             .unwrap(),
             b"second blob bytes"
         );
@@ -1628,6 +1658,63 @@ mod tests {
 
         let error = validate_staged_database(&staging, &manifest).unwrap_err();
         assert!(error.to_string().contains("content address"));
+    }
+
+    #[test]
+    fn staged_database_rejects_unreferenced_blob_content_hash_mismatch() {
+        let (dir_tmp, db_path) = seed_data_dir("unreferenced_content_hash");
+        let dir = dir_tmp.path();
+        let pool = crate::db::open(&db_path).unwrap();
+        checkpoint_db_file(&db_path);
+        drop(pool);
+
+        let staging = dir.join("staging");
+        fs::create_dir_all(staging.join("attachments")).unwrap();
+        fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
+        let sha = crate::storage::AttachmentStore::hash_bytes(b"good");
+        fs::write(staging.join("attachments").join(&sha), b"evil").unwrap();
+        let manifest = Manifest {
+            lific_version: env!("CARGO_PKG_VERSION").into(),
+            schema_version: crate::db::migrate::latest_version(),
+            created_at: String::new(),
+            db_size_bytes: fs::metadata(&db_path).unwrap().len(),
+            attachment_count: 1,
+            attachment_bytes: 4,
+        };
+
+        let error = validate_staged_database(&staging, &manifest).unwrap_err();
+        assert!(error.to_string().contains("content address"));
+    }
+
+    #[test]
+    fn staged_database_requires_attachment_table() {
+        let (dir_tmp, db_path) = seed_data_dir("missing_attachments_table");
+        let dir = dir_tmp.path();
+        checkpoint_db_file(&db_path);
+        let staging = dir.join("staging");
+        fs::create_dir_all(staging.join("attachments")).unwrap();
+        fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
+        {
+            let conn = rusqlite::Connection::open(staging.join(ARCHIVE_DB_NAME)).unwrap();
+            conn.execute_batch(
+                "DROP TRIGGER IF EXISTS attachments_fts_ai;
+                 DROP TRIGGER IF EXISTS attachments_fts_au;
+                 DROP TRIGGER IF EXISTS attachments_fts_ad;
+                 DROP TABLE attachments;",
+            )
+            .unwrap();
+        }
+        let manifest = Manifest {
+            lific_version: env!("CARGO_PKG_VERSION").into(),
+            schema_version: crate::db::migrate::latest_version(),
+            created_at: String::new(),
+            db_size_bytes: 0,
+            attachment_count: 0,
+            attachment_bytes: 0,
+        };
+
+        let error = validate_staged_database(&staging, &manifest).unwrap_err();
+        assert!(error.to_string().contains("attachments table"));
     }
 
     #[test]

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -470,20 +470,39 @@ fn validate_attachment_schema(conn: &rusqlite::Connection) -> Result<(), LificEr
             |row| row.get(0),
         )
         .map_err(|e| LificError::BadRequest(format!("read staged attachment schema: {e}")))?;
-    let sql = sql
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_lowercase();
-    let required = [
-        "check (length(sha256) = 64 and sha256 not glob '*[^0-9a-f]*')",
-        "mime text not null check (mime in (",
-        "size_bytes integer not null check (size_bytes >= 0)",
-    ];
-    if required.iter().any(|fragment| !sql.contains(fragment)) {
-        return Err(LificError::BadRequest(
-            "staged attachment table is missing required integrity constraints".into(),
-        ));
+    let probe = rusqlite::Connection::open_in_memory()
+        .map_err(|e| LificError::BadRequest(format!("create staged schema probe: {e}")))?;
+    probe
+        .execute_batch("CREATE TABLE users (id INTEGER PRIMARY KEY);")
+        .map_err(|e| LificError::BadRequest(format!("create staged schema probe: {e}")))?;
+    probe
+        .execute_batch(&sql)
+        .map_err(|e| LificError::BadRequest(format!("create staged schema probe: {e}")))?;
+
+    let insert = |sha256: &str, mime: &str, size_bytes: i64| {
+        probe.execute(
+            "INSERT INTO attachments (sha256, filename, mime, size_bytes)
+             VALUES (?1, 'schema-probe', ?2, ?3)",
+            rusqlite::params![sha256, mime, size_bytes],
+        )
+    };
+    let valid_sha = crate::storage::AttachmentStore::hash_bytes(b"schema-probe");
+    let invalid_mime_sha = "b".repeat(64);
+    let invalid_size_sha = "c".repeat(64);
+    insert(&valid_sha, "text/plain", 0).map_err(|e| {
+        LificError::BadRequest(format!("staged attachment schema rejects valid metadata: {e}"))
+    })?;
+
+    for (sha256, mime, size_bytes) in [
+        ("../outside", "text/plain", 0),
+        (invalid_mime_sha.as_str(), "application/octet-stream", 0),
+        (invalid_size_sha.as_str(), "text/plain", -1),
+    ] {
+        if insert(sha256, mime, size_bytes).is_ok() {
+            return Err(LificError::BadRequest(
+                "staged attachment table is missing required integrity constraints".into(),
+            ));
+        }
     }
     Ok(())
 }
@@ -606,7 +625,7 @@ fn validate_staged_database(staging: &Path, manifest: &Manifest) -> Result<(), L
         }
 
         let mut mime_stmt = conn
-            .prepare("SELECT sha256, mime FROM attachments")
+            .prepare("SELECT DISTINCT sha256, mime FROM attachments")
             .map_err(|e| LificError::BadRequest(format!("read staged attachment MIME: {e}")))?;
         let mime_rows = mime_stmt
             .query_map([], |row| {
@@ -1848,8 +1867,10 @@ mod tests {
         conn.execute_batch(
             "CREATE TABLE attachments (
                 sha256 TEXT NOT NULL,
-                mime TEXT NOT NULL,
-                size_bytes INTEGER NOT NULL
+                filename TEXT NOT NULL,
+                mime TEXT NOT NULL /* mime TEXT NOT NULL CHECK (mime IN ( */,
+                size_bytes INTEGER NOT NULL /* size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0) */
+                /* CHECK (length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*') */
             )",
         )
         .unwrap();

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -415,17 +415,25 @@ fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
     }
 
     let mut stmt = conn
-        .prepare("SELECT sha256, size_bytes FROM attachments")
+        .prepare("SELECT sha256, MIN(size_bytes), MAX(size_bytes) FROM attachments GROUP BY sha256")
         .map_err(|e| LificError::BadRequest(format!("read staged attachments: {e}")))?;
     let rows = stmt
         .query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
         })
         .map_err(|e| LificError::BadRequest(format!("read staged attachment rows: {e}")))?;
     for row in rows {
-        let (sha, size) =
+        let (sha, size, max_size) =
             row.map_err(|e| LificError::BadRequest(format!("read staged attachment row: {e}")))?;
-        if !valid_sha256(&sha) || size < 0 || size as u64 > MAX_ATTACHMENT_BYTES {
+        if !valid_sha256(&sha)
+            || size < 0
+            || max_size != size
+            || size as u64 > MAX_ATTACHMENT_BYTES
+        {
             return Err(LificError::BadRequest(
                 "staged attachment metadata has an invalid content address or size".into(),
             ));
@@ -459,6 +467,7 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
     let dec = flate2::read::GzDecoder::new(file);
     let mut tar = tar::Archive::new(dec);
     let mut has_db = false;
+    let mut db_bytes = None;
     let mut entry_count = 0u64;
     let mut attachment_count = 0u64;
     let mut attachment_bytes = 0u64;
@@ -487,6 +496,7 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
                 ));
             }
             has_db = true;
+            db_bytes = Some(size);
         } else if name.starts_with(ARCHIVE_ATTACHMENTS_PREFIX) {
             validate_attachment_entry(&name)?;
             if size > MAX_ATTACHMENT_BYTES {
@@ -513,6 +523,11 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
     }
     if !has_db {
         return Err(LificError::BadRequest("archive is missing lific.db".into()));
+    }
+    if db_bytes != Some(manifest.db_size_bytes) {
+        return Err(LificError::BadRequest(
+            "archive database size does not match manifest".into(),
+        ));
     }
     if attachment_count != manifest.attachment_count
         || attachment_bytes != manifest.attachment_bytes
@@ -711,16 +726,16 @@ pub fn run_restore(
         archive_timestamp()
     ));
     let had_attachments = attachments_dest.exists();
-    if had_attachments {
-        if let Err(e) = std::fs::rename(&attachments_dest, &attachments_backup) {
-            if let Some(moved) = &moved_existing_to {
-                let _ = std::fs::rename(moved, db_path);
-            }
-            let _ = std::fs::remove_dir_all(&staging);
-            return Err(LificError::Internal(format!(
-                "move existing attachments aside: {e}"
-            )));
+    if had_attachments
+        && let Err(e) = std::fs::rename(&attachments_dest, &attachments_backup)
+    {
+        if let Some(moved) = &moved_existing_to {
+            let _ = std::fs::rename(moved, db_path);
         }
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(LificError::Internal(format!(
+            "move existing attachments aside: {e}"
+        )));
     }
 
     let install_result = (|| -> Result<(), LificError> {
@@ -1309,7 +1324,8 @@ mod tests {
 
     #[test]
     fn inspect_rejects_manifest_size_bomb() {
-        let (dir, db_path) = seed_data_dir("manifest_limit");
+        let (dir_tmp, db_path) = seed_data_dir("manifest_limit");
+        let dir = dir_tmp.path();
         let out = dir.join("source.tar.gz");
         write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap();
         let mut manifest = read_manifest(&out).unwrap();
@@ -1318,12 +1334,12 @@ mod tests {
         rewrite_archive_manifest(&out, &rewritten, &manifest);
         let error = inspect_archive(&rewritten).unwrap_err();
         assert!(error.to_string().contains("total restore size"));
-        fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn staged_database_rejects_missing_or_mismatched_attachment_metadata() {
-        let (dir, db_path) = seed_data_dir("staged_metadata");
+        let (dir_tmp, db_path) = seed_data_dir("staged_metadata");
+        let dir = dir_tmp.path();
         let pool = crate::db::open(&db_path).unwrap();
         let sha = "a".repeat(64);
         {
@@ -1344,7 +1360,6 @@ mod tests {
         fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
         let error = validate_staged_database(&staging).unwrap_err();
         assert!(error.to_string().contains("missing attachment"));
-        fs::remove_dir_all(&dir).ok();
     }
 
     // Test helper: re-pack an archive but overwrite the manifest's

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -13,10 +13,12 @@
 //! it back into a data dir. The interval backup task (`src/backup.rs`) emits
 //! the *same* artifact via [`write_dump`], so there is exactly one backup shape.
 
-use std::io::Read;
+use std::collections::HashMap;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::db::DbPool;
 use crate::error::LificError;
@@ -36,6 +38,14 @@ pub const MAX_DB_BYTES: u64 = 512 * 1024 * 1024;
 pub const MAX_ATTACHMENT_BYTES: u64 = 64 * 1024 * 1024;
 pub const MAX_TOTAL_RESTORE_BYTES: u64 = 1024 * 1024 * 1024;
 pub const MAX_RESTORE_ENTRIES: u64 = 10_000;
+const ATTACHMENTS_SCHEMA_VERSION: i64 = 31;
+const TAR_ENTRY_OVERHEAD: u64 = 1024;
+const TAR_END_MARKER_BYTES: u64 = 1024;
+const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 =
+    MAX_TOTAL_RESTORE_BYTES
+        + MAX_MANIFEST_BYTES
+        + (MAX_RESTORE_ENTRIES + 2) * TAR_ENTRY_OVERHEAD
+        + TAR_END_MARKER_BYTES;
 
 /// Metadata describing an archive's contents. Serialized as `manifest.json`
 /// at the root of every dump so a restore can validate compatibility and print
@@ -330,7 +340,7 @@ fn validate_attachment_entry(name: &str) -> Result<String, LificError> {
             "rejected attachment entry (path traversal or invalid name): {name}"
         )));
     }
-    if !valid_sha256(rest) {
+    if !crate::storage::valid_sha256(rest) {
         return Err(LificError::BadRequest(format!(
             "rejected attachment entry (expected lowercase SHA-256): {name}"
         )));
@@ -379,17 +389,68 @@ fn read_entry_bounded<R: Read>(
     Ok(buf)
 }
 
-fn valid_sha256(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+fn bounded_archive(
+    file: std::fs::File,
+) -> tar::Archive<std::io::Take<flate2::read::GzDecoder<std::fs::File>>> {
+    let decoder = flate2::read::GzDecoder::new(file);
+    tar::Archive::new(decoder.take(MAX_ARCHIVE_DECOMPRESSED_BYTES))
+}
+
+fn copy_entry_bounded<R: Read, W: Write>(
+    entry: &mut tar::Entry<'_, R>,
+    output: &mut W,
+    max_bytes: u64,
+    total_bytes: &mut u64,
+    label: &str,
+) -> Result<u64, LificError> {
+    let size = entry.size();
+    if size > max_bytes {
+        return Err(LificError::BadRequest(format!(
+            "{label} exceeds restore limit ({size} > {max_bytes} bytes)"
+        )));
+    }
+    let new_total = total_bytes
+        .checked_add(size)
+        .ok_or_else(|| LificError::BadRequest("archive size overflow".into()))?;
+    if new_total > MAX_TOTAL_RESTORE_BYTES {
+        return Err(LificError::BadRequest(
+            "archive contents exceed total restore size limit".into(),
+        ));
+    }
+
+    let copied = std::io::copy(entry, output)
+        .map_err(|e| LificError::BadRequest(format!("read {label}: {e}")))?;
+    if copied != size {
+        return Err(LificError::BadRequest(format!(
+            "read {label}: expected {size} bytes, got {copied}"
+        )));
+    }
+    *total_bytes = new_total;
+    Ok(copied)
+}
+
+fn hash_file(path: &Path) -> Result<String, LificError> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| LificError::BadRequest(format!("open attachment: {e}")))?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0; 8192];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|e| LificError::BadRequest(format!("read attachment: {e}")))?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    let digest = digest.finalize();
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
 /// Validate the extracted SQLite file before it can replace the live DB. This
 /// catches corrupt archives and ensures every metadata attachment reference is
 /// a safe content-addressed filename with matching staged bytes.
-fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
+fn validate_staged_database(staging: &Path, manifest: &Manifest) -> Result<(), LificError> {
     let db = staging.join(ARCHIVE_DB_NAME);
     let conn =
         rusqlite::Connection::open_with_flags(&db, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
@@ -403,6 +464,25 @@ fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
         )));
     }
 
+    let schema_version: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM _migrations",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| LificError::BadRequest(format!("read staged schema version: {e}")))?;
+    if schema_version != manifest.schema_version {
+        return Err(LificError::BadRequest(format!(
+            "staged database schema version {schema_version} does not match manifest {}",
+            manifest.schema_version
+        )));
+    }
+    if schema_version > crate::db::migrate::latest_version() {
+        return Err(LificError::BadRequest(format!(
+            "staged database schema version {schema_version} is newer than this binary"
+        )));
+    }
+
     let has_attachments: bool = conn
         .query_row(
             "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'attachments')",
@@ -411,32 +491,52 @@ fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
         )
         .map_err(|e| LificError::BadRequest(format!("inspect staged schema: {e}")))?;
     if !has_attachments {
+        if manifest.attachment_count != 0 || manifest.attachment_bytes != 0 {
+            return Err(LificError::BadRequest(
+                "manifest contains attachments but staged schema does not support them".into(),
+            ));
+        }
         return Ok(());
     }
 
+    if schema_version < ATTACHMENTS_SCHEMA_VERSION {
+        return Err(LificError::BadRequest(
+            "staged database has attachment tables at an unsupported schema version".into(),
+        ));
+    }
+
     let mut stmt = conn
-        .prepare("SELECT sha256, MIN(size_bytes), MAX(size_bytes) FROM attachments GROUP BY sha256")
+        .prepare("SELECT sha256, mime, size_bytes FROM attachments")
         .map_err(|e| LificError::BadRequest(format!("read staged attachments: {e}")))?;
     let rows = stmt
         .query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
-                row.get::<_, i64>(1)?,
+                row.get::<_, String>(1)?,
                 row.get::<_, i64>(2)?,
             ))
         })
         .map_err(|e| LificError::BadRequest(format!("read staged attachment rows: {e}")))?;
+    let mut validated_sizes = HashMap::new();
     for row in rows {
-        let (sha, size, max_size) =
+        let (sha, mime, size) =
             row.map_err(|e| LificError::BadRequest(format!("read staged attachment row: {e}")))?;
-        if !valid_sha256(&sha)
+        if !crate::storage::valid_sha256(&sha)
             || size < 0
-            || max_size != size
             || size as u64 > MAX_ATTACHMENT_BYTES
+            || !crate::storage::ALLOWED_MIMES.contains(&mime.as_str())
         {
             return Err(LificError::BadRequest(
-                "staged attachment metadata has an invalid content address or size".into(),
+                "staged attachment metadata has an invalid content address, MIME, or size".into(),
             ));
+        }
+        let size = size as u64;
+        if let Some(previous_size) = validated_sizes.get(&sha)
+            && *previous_size != size
+        {
+            return Err(LificError::BadRequest(format!(
+                "staged attachment {sha} has inconsistent sizes"
+            )));
         }
         let path = staging.join("attachments").join(&sha);
         let metadata = std::fs::metadata(&path).map_err(|_| {
@@ -444,11 +544,17 @@ fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
                 "staged database references missing attachment {sha}"
             ))
         })?;
-        if !metadata.is_file() || metadata.len() != size as u64 {
+        if !metadata.is_file() || metadata.len() != size {
             return Err(LificError::BadRequest(format!(
                 "staged attachment {sha} does not match database metadata"
             )));
         }
+        if !validated_sizes.contains_key(&sha) && hash_file(&path)? != sha {
+            return Err(LificError::BadRequest(format!(
+                "staged attachment {sha} does not match its content address"
+            )));
+        }
+        validated_sizes.insert(sha, size);
     }
     Ok(())
 }
@@ -464,13 +570,15 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
     // DB member is present.
     let file = std::fs::File::open(archive)
         .map_err(|e| LificError::BadRequest(format!("open archive: {e}")))?;
-    let dec = flate2::read::GzDecoder::new(file);
-    let mut tar = tar::Archive::new(dec);
+    let mut tar = bounded_archive(file);
     let mut has_db = false;
     let mut db_bytes = None;
+    let mut manifest_entries = 0u64;
+    let mut attachment_names = std::collections::HashSet::new();
     let mut entry_count = 0u64;
     let mut attachment_count = 0u64;
     let mut attachment_bytes = 0u64;
+    let mut payload_bytes = 0u64;
     for entry in tar
         .entries()
         .map_err(|e| LificError::BadRequest(format!("read archive entries: {e}")))?
@@ -488,8 +596,19 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
             .map_err(|e| LificError::BadRequest(format!("entry path: {e}")))?;
         let name = path.to_string_lossy().replace('\\', "/");
         if name == ARCHIVE_MANIFEST_NAME {
+            manifest_entries += 1;
+            if manifest_entries > 1 {
+                return Err(LificError::BadRequest(
+                    "archive contains duplicate manifests".into(),
+                ));
+            }
             continue;
         } else if name == ARCHIVE_DB_NAME {
+            if has_db {
+                return Err(LificError::BadRequest(
+                    "archive contains duplicate databases".into(),
+                ));
+            }
             if size > MAX_DB_BYTES {
                 return Err(LificError::BadRequest(
                     "archive database exceeds restore limit".into(),
@@ -497,8 +616,16 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
             }
             has_db = true;
             db_bytes = Some(size);
+            payload_bytes = payload_bytes
+                .checked_add(size)
+                .ok_or_else(|| LificError::BadRequest("archive size overflow".into()))?;
         } else if name.starts_with(ARCHIVE_ATTACHMENTS_PREFIX) {
             validate_attachment_entry(&name)?;
+            if !attachment_names.insert(name.clone()) {
+                return Err(LificError::BadRequest(format!(
+                    "archive contains duplicate attachment: {name}"
+                )));
+            }
             if size > MAX_ATTACHMENT_BYTES {
                 return Err(LificError::BadRequest(
                     "archive attachment exceeds restore limit".into(),
@@ -508,8 +635,12 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
             attachment_bytes = attachment_bytes
                 .checked_add(size)
                 .ok_or_else(|| LificError::BadRequest("archive attachment size overflow".into()))?;
+            payload_bytes = payload_bytes
+                .checked_add(size)
+                .ok_or_else(|| LificError::BadRequest("archive size overflow".into()))?;
             if attachment_count > MAX_RESTORE_ENTRIES
                 || attachment_bytes > manifest.attachment_bytes
+                || payload_bytes > MAX_TOTAL_RESTORE_BYTES
             {
                 return Err(LificError::BadRequest(
                     "archive attachment contents exceed manifest limits".into(),
@@ -543,13 +674,19 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
 fn read_manifest(archive: &Path) -> Result<Manifest, LificError> {
     let file = std::fs::File::open(archive)
         .map_err(|e| LificError::BadRequest(format!("open archive: {e}")))?;
-    let dec = flate2::read::GzDecoder::new(file);
-    let mut tar = tar::Archive::new(dec);
+    let mut tar = bounded_archive(file);
+    let mut entry_count = 0u64;
     for entry in tar
         .entries()
         .map_err(|e| LificError::BadRequest(format!("read archive entries: {e}")))?
     {
         let mut entry = entry.map_err(|e| LificError::BadRequest(format!("read entry: {e}")))?;
+        entry_count += 1;
+        if entry_count > MAX_RESTORE_ENTRIES + 2 {
+            return Err(LificError::BadRequest(
+                "archive has too many entries before its manifest".into(),
+            ));
+        }
         let path = entry
             .path()
             .map_err(|e| LificError::BadRequest(format!("entry path: {e}")))?;
@@ -604,39 +741,18 @@ pub fn run_restore(
     std::fs::create_dir_all(&data_dir)
         .map_err(|e| LificError::Internal(format!("create data dir: {e}")))?;
 
-    // Existing-DB guard.
-    let mut moved_existing_to = None;
-    if db_path.exists() {
-        if !force {
-            return Err(LificError::Conflict(format!(
-                "{} already exists; pass --force to restore over it (stop the server first)",
-                db_path.display()
-            )));
-        }
-        // --force: move the existing DB aside rather than deleting, so a
-        // mistaken restore is recoverable. First checkpoint its WAL into the
-        // main file so the moved-aside `.db` is self-contained (the WAL/SHM are
-        // named after the live path and won't follow a rename). Best-effort —
-        // if the server holds the db open we still move what's on disk.
-        checkpoint_db_file(db_path);
-        let ts = archive_timestamp();
-        let suffix = format!("pre-restore-{ts}");
-        let dest = PathBuf::from(format!("{}.{suffix}", db_path.display()));
-        std::fs::rename(db_path, &dest)
-            .map_err(|e| LificError::Internal(format!("move existing db aside: {e}")))?;
-        // Discard the now-redundant WAL/SHM (already folded into the moved db).
-        for ext in ["-wal", "-shm"] {
-            let side = PathBuf::from(format!("{}{ext}", db_path.display()));
-            let _ = std::fs::remove_file(&side);
-        }
-        moved_existing_to = Some(dest);
+    if db_path.exists() && !force {
+        return Err(LificError::Conflict(format!(
+            "{} already exists; pass --force to restore over it (stop the server first)",
+            db_path.display()
+        )));
     }
 
-    // Staged extraction: unpack into a temp dir next to the data dir, then move
-    // into place. A failure mid-extract leaves the original data dir untouched.
+    // Stage and validate the complete restore before moving any live state.
     let staging = data_dir.join(format!(".lific-restore-{}", archive_timestamp()));
     if staging.exists() {
-        let _ = std::fs::remove_dir_all(&staging);
+        std::fs::remove_dir_all(&staging)
+            .map_err(|e| LificError::Internal(format!("clear staging dir: {e}")))?;
     }
     std::fs::create_dir_all(staging.join("attachments"))
         .map_err(|e| LificError::Internal(format!("create staging dir: {e}")))?;
@@ -644,8 +760,7 @@ pub fn run_restore(
     let extract = (|| -> Result<u64, LificError> {
         let file = std::fs::File::open(archive)
             .map_err(|e| LificError::BadRequest(format!("open archive: {e}")))?;
-        let dec = flate2::read::GzDecoder::new(file);
-        let mut tar = tar::Archive::new(dec);
+        let mut tar = bounded_archive(file);
         let mut attachment_count = 0u64;
         let mut total_bytes = 0u64;
         for entry in tar
@@ -659,35 +774,38 @@ pub fn run_restore(
                 .map_err(|e| LificError::BadRequest(format!("entry path: {e}")))?;
             let name = epath.to_string_lossy().replace('\\', "/");
             if name == ARCHIVE_MANIFEST_NAME {
-                // Persist the manifest alongside the restored DB for provenance.
+                // Keep the manifest in staging for validation; return it to the
+                // caller in RestoreResult after the install succeeds.
                 let buf = read_entry_bounded(&mut entry, MAX_MANIFEST_BYTES, "manifest")?;
                 std::fs::write(staging.join(ARCHIVE_MANIFEST_NAME), &buf)
                     .map_err(|e| LificError::Internal(format!("write manifest: {e}")))?;
             } else if name == ARCHIVE_DB_NAME {
-                let buf = read_entry_bounded(&mut entry, MAX_DB_BYTES, "database")?;
-                total_bytes = total_bytes
-                    .checked_add(buf.len() as u64)
-                    .ok_or_else(|| LificError::BadRequest("archive size overflow".into()))?;
-                if total_bytes > MAX_TOTAL_RESTORE_BYTES {
-                    return Err(LificError::BadRequest(
-                        "archive contents exceed total restore size limit".into(),
-                    ));
-                }
-                std::fs::write(staging.join(ARCHIVE_DB_NAME), &buf)
-                    .map_err(|e| LificError::Internal(format!("write db: {e}")))?;
+                let db = staging.join(ARCHIVE_DB_NAME);
+                let mut output = std::fs::File::create(&db)
+                    .map_err(|e| LificError::Internal(format!("create staged db: {e}")))?;
+                copy_entry_bounded(
+                    &mut entry,
+                    &mut output,
+                    MAX_DB_BYTES,
+                    &mut total_bytes,
+                    "database",
+                )?;
+                set_owner_only(&db)
+                    .map_err(|e| LificError::Internal(format!("chmod staged db: {e}")))?;
             } else if name.starts_with(ARCHIVE_ATTACHMENTS_PREFIX) {
                 let bare = validate_attachment_entry(&name)?;
-                let buf = read_entry_bounded(&mut entry, MAX_ATTACHMENT_BYTES, "attachment")?;
-                total_bytes = total_bytes
-                    .checked_add(buf.len() as u64)
-                    .ok_or_else(|| LificError::BadRequest("archive size overflow".into()))?;
-                if total_bytes > MAX_TOTAL_RESTORE_BYTES {
-                    return Err(LificError::BadRequest(
-                        "archive contents exceed total restore size limit".into(),
-                    ));
-                }
-                std::fs::write(staging.join("attachments").join(&bare), &buf)
-                    .map_err(|e| LificError::Internal(format!("write attachment: {e}")))?;
+                let path = staging.join("attachments").join(&bare);
+                let mut output = std::fs::File::create(&path)
+                    .map_err(|e| LificError::Internal(format!("create staged attachment: {e}")))?;
+                copy_entry_bounded(
+                    &mut entry,
+                    &mut output,
+                    MAX_ATTACHMENT_BYTES,
+                    &mut total_bytes,
+                    "attachment",
+                )?;
+                set_owner_only(&path)
+                    .map_err(|e| LificError::Internal(format!("chmod staged attachment: {e}")))?;
                 attachment_count += 1;
             } else {
                 return Err(LificError::BadRequest(format!(
@@ -698,23 +816,49 @@ pub fn run_restore(
         if !staging.join(ARCHIVE_DB_NAME).exists() {
             return Err(LificError::BadRequest("archive is missing lific.db".into()));
         }
-        validate_staged_database(&staging)?;
+        validate_staged_database(&staging, &manifest)?;
         Ok(attachment_count)
     })();
 
     let attachment_count = match extract {
         Ok(n) => n,
         Err(e) => {
-            // Roll back: discard staging; restore the moved-aside DB if any.
-            // The moved db is self-contained (WAL was checkpointed before the
-            // move), so a bare rename back is enough.
             let _ = std::fs::remove_dir_all(&staging);
-            return Err(match &moved_existing_to {
-                Some(moved) => rollback_moved_db(moved, db_path, e),
-                None => e,
-            });
+            return Err(e);
         }
     };
+
+    // Recheck after staging in case another process created the destination
+    // while the archive was being validated.
+    if db_path.exists() && !force {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(LificError::Conflict(format!(
+            "{} already exists; pass --force to restore over it (stop the server first)",
+            db_path.display()
+        )));
+    }
+
+    let mut moved_existing_to = None;
+    if db_path.exists() {
+        checkpoint_db_file(db_path);
+        let suffix = format!("pre-restore-{}", archive_timestamp());
+        let dest = PathBuf::from(format!("{}.{suffix}", db_path.display()));
+        if let Err(error) = std::fs::rename(db_path, &dest) {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(LificError::Internal(format!(
+                "move existing db aside: {error}"
+            )));
+        }
+        for ext in ["-wal", "-shm"] {
+            let side = PathBuf::from(format!("{}{ext}", db_path.display()));
+            if let Err(error) = remove_file_if_present(&side) {
+                let _ = std::fs::remove_dir_all(&staging);
+                let cause = LificError::Internal(format!("remove old {ext}: {error}"));
+                return Err(rollback_moved_db(&dest, db_path, cause));
+            }
+        }
+        moved_existing_to = Some(dest);
+    }
 
     // Move restored files into place as one recoverable transaction. Keep the
     // old attachment directory until both the DB and new directory are live so
@@ -726,16 +870,13 @@ pub fn run_restore(
         archive_timestamp()
     ));
     let had_attachments = attachments_dest.exists();
-    if had_attachments
-        && let Err(e) = std::fs::rename(&attachments_dest, &attachments_backup)
-    {
-        if let Some(moved) = &moved_existing_to {
-            let _ = std::fs::rename(moved, db_path);
-        }
+    if had_attachments && let Err(e) = std::fs::rename(&attachments_dest, &attachments_backup) {
         let _ = std::fs::remove_dir_all(&staging);
-        return Err(LificError::Internal(format!(
-            "move existing attachments aside: {e}"
-        )));
+        let cause = LificError::Internal(format!("move existing attachments aside: {e}"));
+        return Err(match &moved_existing_to {
+            Some(moved) => rollback_moved_db(moved, db_path, cause),
+            None => cause,
+        });
     }
 
     let install_result = (|| -> Result<(), LificError> {
@@ -749,16 +890,15 @@ pub fn run_restore(
     })();
 
     if let Err(error) = install_result {
-        let _ = std::fs::remove_file(db_path);
-        let _ = std::fs::remove_dir_all(&attachments_dest);
-        if had_attachments {
-            let _ = std::fs::rename(&attachments_backup, &attachments_dest);
-        }
-        if let Some(moved) = &moved_existing_to {
-            let _ = std::fs::rename(moved, db_path);
-        }
-        let _ = std::fs::remove_dir_all(&staging);
-        return Err(error);
+        return Err(rollback_install(
+            error,
+            &staging,
+            db_path,
+            &attachments_dest,
+            &attachments_backup,
+            had_attachments,
+            moved_existing_to.as_deref(),
+        ));
     }
 
     if had_attachments {
@@ -775,14 +915,71 @@ pub fn run_restore(
     })
 }
 
+fn remove_file_if_present(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_dir_if_present(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn rollback_install(
+    cause: LificError,
+    staging: &Path,
+    db_path: &Path,
+    attachments_dest: &Path,
+    attachments_backup: &Path,
+    had_attachments: bool,
+    moved_existing_to: Option<&Path>,
+) -> LificError {
+    let mut failures = Vec::new();
+    if let Err(error) = remove_file_if_present(db_path) {
+        failures.push(format!("remove installed database: {error}"));
+    }
+    if let Err(error) = remove_dir_if_present(attachments_dest) {
+        failures.push(format!("remove installed attachments: {error}"));
+    }
+    if had_attachments && let Err(error) = std::fs::rename(attachments_backup, attachments_dest) {
+        failures.push(format!("restore previous attachments: {error}"));
+    }
+    if let Some(moved) = moved_existing_to
+        && let Err(error) = std::fs::rename(moved, db_path)
+    {
+        failures.push(format!(
+            "restore previous database from {}: {error}",
+            moved.display()
+        ));
+    }
+    if let Err(error) = remove_dir_if_present(staging) {
+        failures.push(format!("remove staging directory: {error}"));
+    }
+
+    if failures.is_empty() {
+        cause
+    } else {
+        LificError::Internal(format!(
+            "restore failed ({cause}); rollback also failed: {}",
+            failures.join("; ")
+        ))
+    }
+}
+
 /// Put the database that `--force` moved aside back at `db_path` after a failed
 /// restore, and decide which error the caller should surface.
 ///
 /// On success the original failure (`cause`) is returned unchanged. If the
 /// rollback rename itself fails, swallowing it would tell the user only that
 /// the restore failed while their database sits at a path they were never
-/// shown, reading exactly like data loss (LIF-371). So that case returns a
-/// combined error carrying both failures and the exact path the original
+/// shown, reading exactly like data loss. So that case returns a combined
+/// error carrying both failures and the exact path the original
 /// database still occupies, plus where to move it back to.
 fn rollback_moved_db(moved: &Path, db_path: &Path, cause: LificError) -> LificError {
     match std::fs::rename(moved, db_path) {
@@ -1156,7 +1353,10 @@ mod tests {
         let dst_db = dst_dir.join("lific.db");
         let err = run_restore(&bumped, &dst_db, false).unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got {err:?}");
-        assert!(!dst_db.exists(), "nothing should be restored on schema refusal");
+        assert!(
+            !dst_db.exists(),
+            "nothing should be restored on schema refusal"
+        );
     }
 
     #[test]
@@ -1337,6 +1537,100 @@ mod tests {
     }
 
     #[test]
+    fn manifest_scan_rejects_excessive_entries_before_manifest() {
+        let dir_tmp = temp_dir("manifest_entries");
+        let archive = dir_tmp.path().join("too-many.tar.gz");
+        let file = fs::File::create(&archive).unwrap();
+        let enc = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut builder = tar::Builder::new(enc);
+        for index in 0..(MAX_RESTORE_ENTRIES + 3) {
+            append_bytes(&mut builder, &format!("ignored-{index}"), &[0]).unwrap();
+        }
+        let encoder = builder.into_inner().unwrap();
+        encoder.finish().unwrap();
+        let error = inspect_archive(&archive).unwrap_err();
+        assert!(error.to_string().contains("before its manifest"));
+    }
+
+    #[test]
+    fn inspect_rejects_duplicate_control_entries() {
+        let dir_tmp = temp_dir("duplicate_entries");
+        let archive = dir_tmp.path().join("duplicate.tar.gz");
+        let file = fs::File::create(&archive).unwrap();
+        let enc = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut builder = tar::Builder::new(enc);
+        let manifest = Manifest {
+            lific_version: env!("CARGO_PKG_VERSION").into(),
+            schema_version: 1,
+            created_at: String::new(),
+            db_size_bytes: 1,
+            attachment_count: 0,
+            attachment_bytes: 0,
+        };
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        append_bytes(&mut builder, ARCHIVE_MANIFEST_NAME, &bytes).unwrap();
+        append_bytes(&mut builder, ARCHIVE_MANIFEST_NAME, &bytes).unwrap();
+        let encoder = builder.into_inner().unwrap();
+        encoder.finish().unwrap();
+        let error = inspect_archive(&archive).unwrap_err();
+        assert!(error.to_string().contains("duplicate manifest"));
+    }
+
+    #[test]
+    fn restore_rejects_manifest_schema_that_does_not_match_database() {
+        let (dir_tmp, db_path) = seed_data_dir("schema_mismatch");
+        let archive = dir_tmp.path().join("source.tar.gz");
+        write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &archive).unwrap();
+        let rewritten = dir_tmp.path().join("mismatch.tar.gz");
+        rewrite_archive_with_schema(
+            &archive,
+            &rewritten,
+            crate::db::migrate::latest_version() - 1,
+        );
+
+        let destination = temp_dir("schema_mismatch_dst");
+        let error =
+            run_restore(&rewritten, &destination.path().join(ARCHIVE_DB_NAME), false).unwrap_err();
+        assert!(error.to_string().contains("does not match manifest"));
+    }
+
+    #[test]
+    fn staged_database_rejects_blob_content_hash_mismatch() {
+        let (dir_tmp, db_path) = seed_data_dir("content_hash");
+        let dir = dir_tmp.path();
+        let pool = crate::db::open(&db_path).unwrap();
+        let sha = crate::storage::AttachmentStore::hash_bytes(b"good");
+        {
+            let conn = pool.write().unwrap();
+            crate::db::queries::attachments::create_attachment(
+                &conn,
+                &sha,
+                "note.txt",
+                "text/plain",
+                4,
+                None,
+            )
+            .unwrap();
+        }
+        checkpoint_db_file(&db_path);
+        let staging = dir.join("staging");
+        fs::create_dir_all(staging.join("attachments")).unwrap();
+        fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
+        fs::write(staging.join("attachments").join(&sha), b"evil").unwrap();
+        let manifest = Manifest {
+            lific_version: env!("CARGO_PKG_VERSION").into(),
+            schema_version: crate::db::migrate::latest_version(),
+            created_at: String::new(),
+            db_size_bytes: fs::metadata(&db_path).unwrap().len(),
+            attachment_count: 1,
+            attachment_bytes: 4,
+        };
+
+        let error = validate_staged_database(&staging, &manifest).unwrap_err();
+        assert!(error.to_string().contains("content address"));
+    }
+
+    #[test]
     fn staged_database_rejects_missing_or_mismatched_attachment_metadata() {
         let (dir_tmp, db_path) = seed_data_dir("staged_metadata");
         let dir = dir_tmp.path();
@@ -1358,7 +1652,15 @@ mod tests {
         let staging = dir.join("staging");
         fs::create_dir_all(staging.join("attachments")).unwrap();
         fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
-        let error = validate_staged_database(&staging).unwrap_err();
+        let manifest = Manifest {
+            lific_version: env!("CARGO_PKG_VERSION").into(),
+            schema_version: crate::db::migrate::latest_version(),
+            created_at: String::new(),
+            db_size_bytes: fs::metadata(&db_path).unwrap().len(),
+            attachment_count: 1,
+            attachment_bytes: 4,
+        };
+        let error = validate_staged_database(&staging, &manifest).unwrap_err();
         assert!(error.to_string().contains("missing attachment"));
     }
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -462,6 +462,32 @@ fn hash_file(path: &Path) -> Result<String, LificError> {
     Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
+fn validate_attachment_schema(conn: &rusqlite::Connection) -> Result<(), LificError> {
+    let sql: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'attachments'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| LificError::BadRequest(format!("read staged attachment schema: {e}")))?;
+    let sql = sql
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    let required = [
+        "check (length(sha256) = 64 and sha256 not glob '*[^0-9a-f]*')",
+        "mime text not null check (mime in (",
+        "size_bytes integer not null check (size_bytes >= 0)",
+    ];
+    if required.iter().any(|fragment| !sql.contains(fragment)) {
+        return Err(LificError::BadRequest(
+            "staged attachment table is missing required integrity constraints".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Validate the extracted SQLite file before it can replace the live DB. This
 /// catches corrupt archives and ensures every metadata attachment reference is
 /// a safe content-addressed filename with matching staged bytes.
@@ -522,6 +548,7 @@ fn validate_staged_database(staging: &Path, manifest: &Manifest) -> Result<(), L
     }
 
     if has_attachments {
+        validate_attachment_schema(&conn)?;
         let mime_placeholders = vec!["?"; crate::storage::ALLOWED_MIMES.len()].join(", ");
         let mut stmt = conn
             .prepare(&format!(
@@ -574,6 +601,29 @@ fn validate_staged_database(staging: &Path, manifest: &Manifest) -> Result<(), L
             if hash_file(&path)? != sha {
                 return Err(LificError::BadRequest(format!(
                     "staged attachment {sha} does not match its content address"
+                )));
+            }
+        }
+
+        let mut mime_stmt = conn
+            .prepare("SELECT sha256, mime FROM attachments")
+            .map_err(|e| LificError::BadRequest(format!("read staged attachment MIME: {e}")))?;
+        let mime_rows = mime_stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| LificError::BadRequest(format!("read staged attachment MIME: {e}")))?;
+        for row in mime_rows {
+            let (sha, declared_mime) = row
+                .map_err(|e| LificError::BadRequest(format!("read staged attachment MIME: {e}")))?;
+            let path = staging.join("attachments").join(&sha);
+            let bytes = std::fs::read(&path).map_err(|e| {
+                LificError::BadRequest(format!("read staged attachment {sha}: {e}"))
+            })?;
+            let detected_mime = crate::storage::sniff_and_validate(&bytes, Some(&declared_mime))?;
+            if detected_mime != declared_mime {
+                return Err(LificError::BadRequest(format!(
+                    "staged attachment {sha} MIME {declared_mime} does not match its content ({detected_mime})"
                 )));
             }
         }
@@ -1793,6 +1843,22 @@ mod tests {
     }
 
     #[test]
+    fn staged_database_rejects_unconstrained_attachment_schema() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE attachments (
+                sha256 TEXT NOT NULL,
+                mime TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL
+            )",
+        )
+        .unwrap();
+
+        let error = validate_attachment_schema(&conn).unwrap_err();
+        assert!(error.to_string().contains("integrity constraints"));
+    }
+
+    #[test]
     fn staged_database_rejects_blob_content_hash_mismatch() {
         let (dir_tmp, db_path) = seed_data_dir("content_hash");
         let dir = dir_tmp.path();
@@ -1826,6 +1892,42 @@ mod tests {
 
         let error = validate_staged_database(&staging, &manifest).unwrap_err();
         assert!(error.to_string().contains("content address"));
+    }
+
+    #[test]
+    fn staged_database_rejects_blob_content_mime_mismatch() {
+        let (dir_tmp, db_path) = seed_data_dir("content_mime");
+        let dir = dir_tmp.path();
+        let pool = crate::db::open(&db_path).unwrap();
+        let sha = crate::storage::AttachmentStore::hash_bytes(b"good");
+        {
+            let conn = pool.write().unwrap();
+            crate::db::queries::attachments::create_attachment(
+                &conn,
+                &sha,
+                "image.png",
+                "image/png",
+                4,
+                None,
+            )
+            .unwrap();
+        }
+        checkpoint_db_file(&db_path).unwrap();
+        let staging = dir.join("staging");
+        fs::create_dir_all(staging.join("attachments")).unwrap();
+        fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
+        fs::write(staging.join("attachments").join(&sha), b"good").unwrap();
+        let manifest = Manifest {
+            lific_version: env!("CARGO_PKG_VERSION").into(),
+            schema_version: crate::db::migrate::latest_version(),
+            created_at: String::new(),
+            db_size_bytes: fs::metadata(&db_path).unwrap().len(),
+            attachment_count: 1,
+            attachment_bytes: 4,
+        };
+
+        let error = validate_staged_database(&staging, &manifest).unwrap_err();
+        assert!(error.to_string().contains("MIME image/png"));
     }
 
     #[test]

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -38,6 +38,7 @@ pub const MAX_ATTACHMENT_BYTES: u64 = 64 * 1024 * 1024;
 pub const MAX_TOTAL_RESTORE_BYTES: u64 = 1024 * 1024 * 1024;
 pub const MAX_RESTORE_ENTRIES: u64 = 10_000;
 const ATTACHMENTS_SCHEMA_VERSION: i64 = 31;
+const ATTACHMENT_INTEGRITY_SCHEMA_VERSION: i64 = 43;
 const TAR_ENTRY_OVERHEAD: u64 = 1024;
 const TAR_END_MARKER_BYTES: u64 = 1024;
 const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 =
@@ -507,6 +508,41 @@ fn validate_attachment_schema(conn: &rusqlite::Connection) -> Result<(), LificEr
     Ok(())
 }
 
+struct RestoreLock {
+    path: PathBuf,
+}
+
+impl RestoreLock {
+    fn acquire(data_dir: &Path) -> Result<Self, LificError> {
+        let path = data_dir.join(".lific-restore.lock");
+        match std::fs::create_dir(&path) {
+            Ok(()) => Ok(Self { path }),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                Err(LificError::Conflict(
+                    "another restore is already running for this data directory".into(),
+                ))
+            }
+            Err(error) => Err(LificError::Internal(format!(
+                "create restore lock: {error}"
+            ))),
+        }
+    }
+}
+
+impl Drop for RestoreLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir(&self.path);
+    }
+}
+
+fn create_staging_file(path: &Path) -> Result<std::fs::File, LificError> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|e| LificError::Internal(format!("create staging file: {e}")))
+}
+
 /// Validate the extracted SQLite file before it can replace the live DB. This
 /// catches corrupt archives and ensures every metadata attachment reference is
 /// a safe content-addressed filename with matching staged bytes.
@@ -566,8 +602,10 @@ fn validate_staged_database(staging: &Path, manifest: &Manifest) -> Result<(), L
         ));
     }
 
-    if has_attachments {
+    if has_attachments && schema_version >= ATTACHMENT_INTEGRITY_SCHEMA_VERSION {
         validate_attachment_schema(&conn)?;
+    }
+    if has_attachments {
         let mime_placeholders = vec!["?"; crate::storage::ALLOWED_MIMES.len()].join(", ");
         let mut stmt = conn
             .prepare(&format!(
@@ -875,6 +913,8 @@ pub fn run_restore(
     std::fs::create_dir_all(&data_dir)
         .map_err(|e| LificError::Internal(format!("create data dir: {e}")))?;
 
+    let _restore_lock = RestoreLock::acquire(&data_dir)?;
+
     if db_path.exists() && !force {
         return Err(LificError::Conflict(format!(
             "{} already exists; pass --force to restore over it (stop the server first)",
@@ -883,12 +923,12 @@ pub fn run_restore(
     }
 
     // Stage and validate the complete restore before moving any live state.
-    let staging = data_dir.join(format!(".lific-restore-{}", archive_timestamp()));
-    if staging.exists() {
-        std::fs::remove_dir_all(&staging)
-            .map_err(|e| LificError::Internal(format!("clear staging dir: {e}")))?;
-    }
-    std::fs::create_dir_all(staging.join("attachments"))
+    let staging = tempfile::Builder::new()
+        .prefix(".lific-restore-")
+        .tempdir_in(&data_dir)
+        .map_err(|e| LificError::Internal(format!("create staging dir: {e}")))?;
+    let staging_path = staging.path();
+    std::fs::create_dir(staging_path.join("attachments"))
         .map_err(|e| LificError::Internal(format!("create staging dir: {e}")))?;
 
     let extract = (|| -> Result<u64, LificError> {
@@ -913,12 +953,13 @@ pub fn run_restore(
                 // Keep the manifest in staging for validation; return it to the
                 // caller in RestoreResult after the install succeeds.
                 let buf = read_entry_bounded(&mut entry, MAX_MANIFEST_BYTES, "manifest")?;
-                std::fs::write(staging.join(ARCHIVE_MANIFEST_NAME), &buf)
+                let mut output = create_staging_file(&staging_path.join(ARCHIVE_MANIFEST_NAME))?;
+                output
+                    .write_all(&buf)
                     .map_err(|e| LificError::Internal(format!("write manifest: {e}")))?;
             } else if name == ARCHIVE_DB_NAME {
-                let db = staging.join(ARCHIVE_DB_NAME);
-                let mut output = std::fs::File::create(&db)
-                    .map_err(|e| LificError::Internal(format!("create staged db: {e}")))?;
+                let db = staging_path.join(ARCHIVE_DB_NAME);
+                let mut output = create_staging_file(&db)?;
                 copy_entry_bounded(
                     &mut entry,
                     &mut output,
@@ -930,9 +971,8 @@ pub fn run_restore(
                     .map_err(|e| LificError::Internal(format!("chmod staged db: {e}")))?;
             } else if name.starts_with(ARCHIVE_ATTACHMENTS_PREFIX) {
                 let bare = validate_attachment_entry(&name)?;
-                let path = staging.join("attachments").join(&bare);
-                let mut output = std::fs::File::create(&path)
-                    .map_err(|e| LificError::Internal(format!("create staged attachment: {e}")))?;
+                let path = staging_path.join("attachments").join(&bare);
+                let mut output = create_staging_file(&path)?;
                 copy_entry_bounded(
                     &mut entry,
                     &mut output,
@@ -949,17 +989,16 @@ pub fn run_restore(
                 )));
             }
         }
-        if !staging.join(ARCHIVE_DB_NAME).exists() {
+        if !staging_path.join(ARCHIVE_DB_NAME).exists() {
             return Err(LificError::BadRequest("archive is missing lific.db".into()));
         }
-        validate_staged_database(&staging, &manifest)?;
+        validate_staged_database(staging_path, &manifest)?;
         Ok(attachment_count)
     })();
 
     let attachment_count = match extract {
         Ok(n) => n,
         Err(e) => {
-            let _ = std::fs::remove_dir_all(&staging);
             return Err(e);
         }
     };
@@ -967,7 +1006,6 @@ pub fn run_restore(
     // Recheck after staging in case another process created the destination
     // while the archive was being validated.
     if db_path.exists() && !force {
-        let _ = std::fs::remove_dir_all(&staging);
         return Err(LificError::Conflict(format!(
             "{} already exists; pass --force to restore over it (stop the server first)",
             db_path.display()
@@ -975,15 +1013,23 @@ pub fn run_restore(
     }
 
     let mut moved_existing_to = None;
+    let restore_id = staging
+        .path()
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("restore")
+        .to_string();
     if db_path.exists() {
-        if let Err(error) = checkpoint_db_file(db_path) {
-            let _ = std::fs::remove_dir_all(&staging);
-            return Err(error);
-        }
-        let suffix = format!("pre-restore-{}", archive_timestamp());
+        checkpoint_db_file(db_path)?;
+        let suffix = format!("pre-restore-{restore_id}");
         let dest = PathBuf::from(format!("{}.{suffix}", db_path.display()));
+        if std::fs::symlink_metadata(&dest).is_ok() {
+            return Err(LificError::Conflict(format!(
+                "restore backup already exists: {}",
+                dest.display()
+            )));
+        }
         if let Err(error) = std::fs::rename(db_path, &dest) {
-            let _ = std::fs::remove_dir_all(&staging);
             return Err(LificError::Internal(format!(
                 "move existing db aside: {error}"
             )));
@@ -991,7 +1037,6 @@ pub fn run_restore(
         for ext in ["-wal", "-shm"] {
             let side = PathBuf::from(format!("{}{ext}", db_path.display()));
             if let Err(error) = remove_file_if_present(&side) {
-                let _ = std::fs::remove_dir_all(&staging);
                 let cause = LificError::Internal(format!("remove old {ext}: {error}"));
                 return Err(rollback_moved_db(&dest, db_path, cause));
             }
@@ -1006,11 +1051,16 @@ pub fn run_restore(
     let attachments_backup = PathBuf::from(format!(
         "{}.pre-restore-{}",
         attachments_dest.display(),
-        archive_timestamp()
+        restore_id
     ));
     let had_attachments = attachments_dest.exists();
+    if had_attachments && std::fs::symlink_metadata(&attachments_backup).is_ok() {
+        return Err(LificError::Conflict(format!(
+            "restore attachment backup already exists: {}",
+            attachments_backup.display()
+        )));
+    }
     if had_attachments && let Err(e) = std::fs::rename(&attachments_dest, &attachments_backup) {
-        let _ = std::fs::remove_dir_all(&staging);
         let cause = LificError::Internal(format!("move existing attachments aside: {e}"));
         return Err(match &moved_existing_to {
             Some(moved) => rollback_moved_db(moved, db_path, cause),
@@ -1019,11 +1069,11 @@ pub fn run_restore(
     }
 
     let install_result = (|| -> Result<(), LificError> {
-        std::fs::rename(staging.join(ARCHIVE_DB_NAME), db_path)
+        std::fs::rename(staging_path.join(ARCHIVE_DB_NAME), db_path)
             .map_err(|e| LificError::Internal(format!("install restored db: {e}")))?;
         set_owner_only(db_path)
             .map_err(|e| LificError::Internal(format!("chmod restored db: {e}")))?;
-        std::fs::rename(staging.join("attachments"), &attachments_dest)
+        std::fs::rename(staging_path.join("attachments"), &attachments_dest)
             .map_err(|e| LificError::Internal(format!("install restored attachments: {e}")))?;
         Ok(())
     })();
@@ -1031,7 +1081,7 @@ pub fn run_restore(
     if let Err(error) = install_result {
         return Err(rollback_install(
             error,
-            &staging,
+            staging_path,
             db_path,
             &attachments_dest,
             &attachments_backup,
@@ -1043,8 +1093,6 @@ pub fn run_restore(
     if had_attachments {
         let _ = std::fs::remove_dir_all(&attachments_backup);
     }
-
-    let _ = std::fs::remove_dir_all(&staging);
 
     Ok(RestoreResult {
         manifest,
@@ -1573,6 +1621,50 @@ mod tests {
     }
 
     #[test]
+    fn staged_database_accepts_pre_integrity_attachment_schema() {
+        let dir_tmp = temp_dir("legacy_attachments");
+        let dir = dir_tmp.path();
+        let db = dir.join(ARCHIVE_DB_NAME);
+        let sha = crate::storage::AttachmentStore::hash_bytes(b"legacy");
+        {
+            let conn = rusqlite::Connection::open(&db).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE _migrations (version INTEGER PRIMARY KEY);
+                 INSERT INTO _migrations (version) VALUES (42);
+                 CREATE TABLE attachments (
+                     sha256 TEXT NOT NULL,
+                     filename TEXT NOT NULL,
+                     mime TEXT NOT NULL,
+                     size_bytes INTEGER NOT NULL
+                 );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO attachments (sha256, filename, mime, size_bytes)
+                 VALUES (?1, 'legacy.txt', 'text/plain', 6)",
+                rusqlite::params![sha],
+            )
+            .unwrap();
+        }
+
+        let staging = dir.join("staging");
+        fs::create_dir_all(staging.join("attachments")).unwrap();
+        fs::copy(&db, staging.join(ARCHIVE_DB_NAME)).unwrap();
+        fs::write(staging.join("attachments").join(&sha), b"legacy").unwrap();
+        let manifest = Manifest {
+            lific_version: "old".into(),
+            schema_version: 42,
+            created_at: "now".into(),
+            db_size_bytes: fs::metadata(&db).unwrap().len(),
+            attachment_count: 1,
+            attachment_bytes: 6,
+        };
+
+        validate_staged_database(&staging, &manifest)
+            .expect("pre-integrity archives remain restorable");
+    }
+
+    #[test]
     fn restore_rejects_path_traversal_entry() {
         let dir_tmp = temp_dir("traversal");
         let dir = dir_tmp.path();
@@ -1877,6 +1969,55 @@ mod tests {
 
         let error = validate_attachment_schema(&conn).unwrap_err();
         assert!(error.to_string().contains("integrity constraints"));
+    }
+
+    #[test]
+    fn staged_schema_probe_does_not_trust_source_triggers() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE attachments (
+                sha256 TEXT NOT NULL,
+                filename TEXT NOT NULL,
+                mime TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL
+            );
+            CREATE TRIGGER reject_probe_values BEFORE INSERT ON attachments
+            WHEN NEW.sha256 = '../outside'
+              OR NEW.mime = 'application/octet-stream'
+              OR NEW.size_bytes < 0
+            BEGIN
+                SELECT RAISE(ABORT, 'probe value rejected');
+            END;",
+        )
+        .unwrap();
+
+        let error = validate_attachment_schema(&conn).unwrap_err();
+        assert!(error.to_string().contains("integrity constraints"));
+    }
+
+    #[test]
+    fn restore_lock_serializes_restores() {
+        let dir = temp_dir("restore_lock");
+        let first = RestoreLock::acquire(dir.path()).unwrap();
+        assert!(matches!(
+            RestoreLock::acquire(dir.path()),
+            Err(LificError::Conflict(_))
+        ));
+        drop(first);
+        RestoreLock::acquire(dir.path()).expect("lock is released after restore");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staging_file_does_not_follow_symlinks() {
+        let dir = temp_dir("staging_symlink");
+        let target = dir.path().join("outside");
+        let link = dir.path().join("staged");
+        fs::write(&target, b"untouched").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert!(create_staging_file(&link).is_err());
+        assert_eq!(fs::read(target).unwrap(), b"untouched");
     }
 
     #[test]

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -13,7 +13,6 @@
 //! it back into a data dir. The interval backup task (`src/backup.rs`) emits
 //! the *same* artifact via [`write_dump`], so there is exactly one backup shape.
 
-use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
@@ -389,11 +388,27 @@ fn read_entry_bounded<R: Read>(
     Ok(buf)
 }
 
+fn bounded_archive_with_limit(
+    file: std::fs::File,
+    max_decompressed_bytes: u64,
+) -> tar::Archive<std::io::Take<flate2::read::GzDecoder<std::fs::File>>> {
+    let decoder = flate2::read::GzDecoder::new(file);
+    tar::Archive::new(decoder.take(max_decompressed_bytes))
+}
+
 fn bounded_archive(
     file: std::fs::File,
 ) -> tar::Archive<std::io::Take<flate2::read::GzDecoder<std::fs::File>>> {
-    let decoder = flate2::read::GzDecoder::new(file);
-    tar::Archive::new(decoder.take(MAX_ARCHIVE_DECOMPRESSED_BYTES))
+    bounded_archive_with_limit(file, MAX_ARCHIVE_DECOMPRESSED_BYTES)
+}
+
+fn validate_tar_entry_type<R: Read>(entry: &tar::Entry<'_, R>) -> Result<(), LificError> {
+    if !entry.header().entry_type().is_file() {
+        return Err(LificError::BadRequest(
+            "archive contains an unsupported tar entry type".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn copy_entry_bounded<R: Read, W: Write>(
@@ -490,68 +505,78 @@ fn validate_staged_database(staging: &Path, manifest: &Manifest) -> Result<(), L
             |row| row.get(0),
         )
         .map_err(|e| LificError::BadRequest(format!("inspect staged schema: {e}")))?;
-    if !has_attachments {
+    if !has_attachments
+        && (schema_version >= ATTACHMENTS_SCHEMA_VERSION
+            || manifest.attachment_count != 0
+            || manifest.attachment_bytes != 0)
+    {
         return Err(LificError::BadRequest(
             "staged database is missing the attachments table".into(),
         ));
     }
 
-    if schema_version < ATTACHMENTS_SCHEMA_VERSION {
+    if has_attachments && schema_version < ATTACHMENTS_SCHEMA_VERSION {
         return Err(LificError::BadRequest(
             "staged database has attachment tables at an unsupported schema version".into(),
         ));
     }
 
-    let mut stmt = conn
-        .prepare("SELECT sha256, mime, size_bytes FROM attachments")
-        .map_err(|e| LificError::BadRequest(format!("read staged attachments: {e}")))?;
-    let rows = stmt
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, i64>(2)?,
+    if has_attachments {
+        let mime_placeholders = vec!["?"; crate::storage::ALLOWED_MIMES.len()].join(", ");
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT sha256, MIN(size_bytes), MAX(size_bytes),
+                        SUM(CASE WHEN mime IN ({mime_placeholders}) THEN 0 ELSE 1 END)
+                 FROM attachments
+                 GROUP BY sha256"
             ))
-        })
-        .map_err(|e| LificError::BadRequest(format!("read staged attachment rows: {e}")))?;
-    let mut validated_sizes = HashMap::new();
-    for row in rows {
-        let (sha, mime, size) =
-            row.map_err(|e| LificError::BadRequest(format!("read staged attachment row: {e}")))?;
-        if !crate::storage::valid_sha256(&sha)
-            || size < 0
-            || size as u64 > MAX_ATTACHMENT_BYTES
-            || !crate::storage::ALLOWED_MIMES.contains(&mime.as_str())
-        {
-            return Err(LificError::BadRequest(
-                "staged attachment metadata has an invalid content address, MIME, or size".into(),
-            ));
+            .map_err(|e| LificError::BadRequest(format!("read staged attachment metadata: {e}")))?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params_from_iter(crate::storage::ALLOWED_MIMES.iter().copied()),
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                    ))
+                },
+            )
+            .map_err(|e| LificError::BadRequest(format!("read staged attachment metadata: {e}")))?;
+        for row in rows {
+            let (sha, min_size, max_size, invalid_mimes) = row.map_err(|e| {
+                LificError::BadRequest(format!("read staged attachment metadata: {e}"))
+            })?;
+            if !crate::storage::valid_sha256(&sha)
+                || min_size < 0
+                || min_size != max_size
+                || max_size as u64 > MAX_ATTACHMENT_BYTES
+                || invalid_mimes != 0
+            {
+                return Err(LificError::BadRequest(
+                    "staged attachment metadata has an invalid content address, MIME, or size"
+                        .into(),
+                ));
+            }
+            let size = max_size as u64;
+            let path = staging.join("attachments").join(&sha);
+            let metadata = std::fs::metadata(&path).map_err(|_| {
+                LificError::BadRequest(format!(
+                    "staged database references missing attachment {sha}"
+                ))
+            })?;
+            if !metadata.is_file() || metadata.len() != size {
+                return Err(LificError::BadRequest(format!(
+                    "staged attachment {sha} does not match database metadata"
+                )));
+            }
+            if hash_file(&path)? != sha {
+                return Err(LificError::BadRequest(format!(
+                    "staged attachment {sha} does not match its content address"
+                )));
+            }
         }
-        let size = size as u64;
-        if let Some(previous_size) = validated_sizes.get(&sha)
-            && *previous_size != size
-        {
-            return Err(LificError::BadRequest(format!(
-                "staged attachment {sha} has inconsistent sizes"
-            )));
-        }
-        let path = staging.join("attachments").join(&sha);
-        let metadata = std::fs::metadata(&path).map_err(|_| {
-            LificError::BadRequest(format!(
-                "staged database references missing attachment {sha}"
-            ))
-        })?;
-        if !metadata.is_file() || metadata.len() != size {
-            return Err(LificError::BadRequest(format!(
-                "staged attachment {sha} does not match database metadata"
-            )));
-        }
-        if !validated_sizes.contains_key(&sha) && hash_file(&path)? != sha {
-            return Err(LificError::BadRequest(format!(
-                "staged attachment {sha} does not match its content address"
-            )));
-        }
-        validated_sizes.insert(sha, size);
     }
 
     let attachments_dir = staging.join("attachments");
@@ -618,8 +643,10 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
     for entry in tar
         .entries()
         .map_err(|e| LificError::BadRequest(format!("read archive entries: {e}")))?
+        .raw(true)
     {
         let entry = entry.map_err(|e| LificError::BadRequest(format!("read entry: {e}")))?;
+        validate_tar_entry_type(&entry)?;
         entry_count += 1;
         if entry_count > MAX_RESTORE_ENTRIES + 2 {
             return Err(LificError::BadRequest(
@@ -715,8 +742,10 @@ fn read_manifest(archive: &Path) -> Result<Manifest, LificError> {
     for entry in tar
         .entries()
         .map_err(|e| LificError::BadRequest(format!("read archive entries: {e}")))?
+        .raw(true)
     {
         let mut entry = entry.map_err(|e| LificError::BadRequest(format!("read entry: {e}")))?;
+        validate_tar_entry_type(&entry)?;
         entry_count += 1;
         if entry_count > MAX_RESTORE_ENTRIES + 2 {
             return Err(LificError::BadRequest(
@@ -802,9 +831,11 @@ pub fn run_restore(
         for entry in tar
             .entries()
             .map_err(|e| LificError::BadRequest(format!("read archive entries: {e}")))?
+            .raw(true)
         {
             let mut entry =
                 entry.map_err(|e| LificError::BadRequest(format!("read entry: {e}")))?;
+            validate_tar_entry_type(&entry)?;
             let epath = entry
                 .path()
                 .map_err(|e| LificError::BadRequest(format!("entry path: {e}")))?;
@@ -876,7 +907,10 @@ pub fn run_restore(
 
     let mut moved_existing_to = None;
     if db_path.exists() {
-        checkpoint_db_file(db_path);
+        if let Err(error) = checkpoint_db_file(db_path) {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(error);
+        }
         let suffix = format!("pre-restore-{}", archive_timestamp());
         let dest = PathBuf::from(format!("{}.{suffix}", db_path.display()));
         if let Err(error) = std::fs::rename(db_path, &dest) {
@@ -1033,12 +1067,20 @@ fn rollback_moved_db(moved: &Path, db_path: &Path, cause: LificError) -> LificEr
 
 /// Checkpoint a database file's WAL into the main file, so the `.db` is
 /// self-contained (used before moving an existing db aside under `--force`).
-/// Best-effort: opening or checkpointing failure is ignored (nothing on disk
-/// changes for the worse).
-fn checkpoint_db_file(db_path: &Path) {
-    if let Ok(conn) = rusqlite::Connection::open(db_path) {
-        let _ = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);");
+/// Failing closed is important: deleting the sidecars after a failed
+/// checkpoint could discard committed WAL-backed data.
+fn checkpoint_db_file(db_path: &Path) -> Result<(), LificError> {
+    let conn = rusqlite::Connection::open(db_path)
+        .map_err(|e| LificError::Internal(format!("open database for WAL checkpoint: {e}")))?;
+    let busy: i64 = conn
+        .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get(0))
+        .map_err(|e| LificError::Internal(format!("checkpoint database WAL: {e}")))?;
+    if busy != 0 {
+        return Err(LificError::Conflict(
+            "database WAL is busy; stop the server before forcing a restore".into(),
+        ));
     }
+    Ok(())
 }
 
 /// True when a hot WAL warns the server may be running. Exposed so the CLI can
@@ -1367,6 +1409,28 @@ mod tests {
     }
 
     #[test]
+    fn force_restore_refuses_an_uncheckpointable_database() {
+        let (src_dir_tmp, src_db) = seed_data_dir("checkpoint_src");
+        let archive = src_dir_tmp.path().join("backup.tar.gz");
+        write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
+
+        let destination = temp_dir("checkpoint_dst");
+        let db_path = destination.path().join(ARCHIVE_DB_NAME);
+        fs::create_dir(&db_path).unwrap();
+        let sentinel = db_path.join("must-survive");
+        fs::write(&sentinel, b"original state").unwrap();
+
+        let error = run_restore(&archive, &db_path, true).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("open database for WAL checkpoint")
+        );
+        assert!(db_path.is_dir());
+        assert_eq!(fs::read(sentinel).unwrap(), b"original state");
+    }
+
+    #[test]
     fn restore_refuses_newer_schema_version() {
         let (src_dir_tmp, src_db) = seed_data_dir("newer_src");
         let src_dir = src_dir_tmp.path();
@@ -1386,6 +1450,56 @@ mod tests {
         assert!(
             !dst_db.exists(),
             "nothing should be restored on schema refusal"
+        );
+    }
+
+    #[test]
+    fn restore_accepts_pre_attachment_schema_without_attachment_table() {
+        let dir_tmp = temp_dir("legacy_schema");
+        let dir = dir_tmp.path();
+        let legacy_db = dir.join("legacy.db");
+        {
+            let conn = rusqlite::Connection::open(&legacy_db).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE _migrations (version INTEGER PRIMARY KEY);
+                 INSERT INTO _migrations (version) VALUES (30);",
+            )
+            .unwrap();
+        }
+
+        let archive = dir.join("legacy.tar.gz");
+        let manifest = Manifest {
+            lific_version: "old".into(),
+            schema_version: 30,
+            created_at: "now".into(),
+            db_size_bytes: fs::metadata(&legacy_db).unwrap().len(),
+            attachment_count: 0,
+            attachment_bytes: 0,
+        };
+        let file = fs::File::create(&archive).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        append_bytes(
+            &mut builder,
+            ARCHIVE_MANIFEST_NAME,
+            &serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        builder
+            .append_path_with_name(&legacy_db, ARCHIVE_DB_NAME)
+            .unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let destination = temp_dir("legacy_schema_dst");
+        let db_path = destination.path().join(ARCHIVE_DB_NAME);
+        run_restore(&archive, &db_path, false).expect("older empty backups remain restorable");
+        assert!(db_path.exists());
+        assert!(
+            !destination
+                .path()
+                .join("attachments")
+                .join("unexpected")
+                .exists()
         );
     }
 
@@ -1567,6 +1681,60 @@ mod tests {
     }
 
     #[test]
+    fn compressed_archive_expansion_is_bounded() {
+        const TEST_LIMIT: u64 = 1024 * 1024;
+        let dir_tmp = temp_dir("compressed_expansion");
+        let archive = dir_tmp.path().join("bomb.tar.gz");
+        let expanded_bytes = vec![b'x'; (TEST_LIMIT * 2) as usize];
+        let file = fs::File::create(&archive).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::best());
+        let mut builder = tar::Builder::new(encoder);
+        append_bytes(&mut builder, "payload", &expanded_bytes).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        assert!(
+            fs::metadata(&archive).unwrap().len() < expanded_bytes.len() as u64 / 100,
+            "the fixture must be much smaller while expanding past the reader limit"
+        );
+        let file = fs::File::open(&archive).unwrap();
+        let mut archive = bounded_archive_with_limit(file, TEST_LIMIT);
+        let mut entries = archive.entries().unwrap().raw(true);
+        let mut entry = entries.next().unwrap().unwrap();
+        let mut total_bytes = 0;
+        let error = copy_entry_bounded(
+            &mut entry,
+            &mut std::io::sink(),
+            MAX_ATTACHMENT_BYTES,
+            &mut total_bytes,
+            "payload",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("expected 2097152 bytes"));
+    }
+
+    #[test]
+    fn inspect_rejects_tar_extension_entries_before_reading_their_body() {
+        let dir_tmp = temp_dir("tar_extension");
+        let archive = dir_tmp.path().join("extension.tar.gz");
+        let file = fs::File::create(&archive).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::best());
+        let mut builder = tar::Builder::new(encoder);
+        let extension = vec![b'x'; MAX_MANIFEST_BYTES as usize + 1];
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::XHeader);
+        header.set_size(extension.len() as u64);
+        header.set_mode(0o600);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "pax", extension.as_slice())
+            .unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let error = inspect_archive(&archive).unwrap_err();
+        assert!(error.to_string().contains("unsupported tar entry type"));
+    }
+
+    #[test]
     fn manifest_scan_rejects_excessive_entries_before_manifest() {
         let dir_tmp = temp_dir("manifest_entries");
         let archive = dir_tmp.path().join("too-many.tar.gz");
@@ -1642,7 +1810,7 @@ mod tests {
             )
             .unwrap();
         }
-        checkpoint_db_file(&db_path);
+        checkpoint_db_file(&db_path).unwrap();
         let staging = dir.join("staging");
         fs::create_dir_all(staging.join("attachments")).unwrap();
         fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
@@ -1661,11 +1829,51 @@ mod tests {
     }
 
     #[test]
+    fn staged_database_rejects_duplicate_hashes_with_inconsistent_sizes() {
+        let (dir_tmp, db_path) = seed_data_dir("duplicate_sizes");
+        let dir = dir_tmp.path();
+        let pool = crate::db::open(&db_path).unwrap();
+        let sha = crate::storage::AttachmentStore::hash_bytes(b"good");
+        {
+            let conn = pool.write().unwrap();
+            for (filename, size) in [("one.txt", 4), ("two.txt", 5)] {
+                crate::db::queries::attachments::create_attachment(
+                    &conn,
+                    &sha,
+                    filename,
+                    "text/plain",
+                    size,
+                    None,
+                )
+                .unwrap();
+            }
+        }
+        checkpoint_db_file(&db_path).unwrap();
+        let staging = dir.join("staging");
+        fs::create_dir_all(staging.join("attachments")).unwrap();
+        fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
+        fs::write(staging.join("attachments").join(&sha), b"good").unwrap();
+        let manifest = Manifest {
+            lific_version: env!("CARGO_PKG_VERSION").into(),
+            schema_version: crate::db::migrate::latest_version(),
+            created_at: String::new(),
+            db_size_bytes: fs::metadata(&db_path).unwrap().len(),
+            attachment_count: 1,
+            attachment_bytes: 4,
+        };
+
+        let error = validate_staged_database(&staging, &manifest).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("invalid content address, MIME, or size"));
+    }
+
+    #[test]
     fn staged_database_rejects_unreferenced_blob_content_hash_mismatch() {
         let (dir_tmp, db_path) = seed_data_dir("unreferenced_content_hash");
         let dir = dir_tmp.path();
         let pool = crate::db::open(&db_path).unwrap();
-        checkpoint_db_file(&db_path);
+        checkpoint_db_file(&db_path).unwrap();
         drop(pool);
 
         let staging = dir.join("staging");
@@ -1690,7 +1898,7 @@ mod tests {
     fn staged_database_requires_attachment_table() {
         let (dir_tmp, db_path) = seed_data_dir("missing_attachments_table");
         let dir = dir_tmp.path();
-        checkpoint_db_file(&db_path);
+        checkpoint_db_file(&db_path).unwrap();
         let staging = dir.join("staging");
         fs::create_dir_all(staging.join("attachments")).unwrap();
         fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
@@ -1735,7 +1943,7 @@ mod tests {
             )
             .unwrap();
         }
-        checkpoint_db_file(&db_path);
+        checkpoint_db_file(&db_path).unwrap();
         let staging = dir.join("staging");
         fs::create_dir_all(staging.join("attachments")).unwrap();
         fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -28,6 +28,15 @@ pub const ARCHIVE_MANIFEST_NAME: &str = "manifest.json";
 /// The prefix under which attachment blobs are stored inside the archive.
 pub const ARCHIVE_ATTACHMENTS_PREFIX: &str = "attachments/";
 
+/// Restore limits apply to the uncompressed archive contents. They prevent a
+/// tiny gzip/tar upload from allocating unbounded memory or filling the data
+/// volume before validation can reject it.
+pub const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+pub const MAX_DB_BYTES: u64 = 512 * 1024 * 1024;
+pub const MAX_ATTACHMENT_BYTES: u64 = 64 * 1024 * 1024;
+pub const MAX_TOTAL_RESTORE_BYTES: u64 = 1024 * 1024 * 1024;
+pub const MAX_RESTORE_ENTRIES: u64 = 10_000;
+
 /// Metadata describing an archive's contents. Serialized as `manifest.json`
 /// at the root of every dump so a restore can validate compatibility and print
 /// a summary without opening the DB.
@@ -325,11 +334,114 @@ fn validate_attachment_entry(name: &str) -> Result<String, LificError> {
     Ok(rest.to_string())
 }
 
+fn validate_manifest_limits(manifest: &Manifest) -> Result<(), LificError> {
+    if manifest.db_size_bytes > MAX_DB_BYTES {
+        return Err(LificError::BadRequest(format!(
+            "archive database exceeds restore limit ({} > {} bytes)",
+            manifest.db_size_bytes, MAX_DB_BYTES
+        )));
+    }
+    if manifest.attachment_count > MAX_RESTORE_ENTRIES {
+        return Err(LificError::BadRequest(format!(
+            "archive has too many attachments ({} > {})",
+            manifest.attachment_count, MAX_RESTORE_ENTRIES
+        )));
+    }
+    if manifest.attachment_bytes > MAX_TOTAL_RESTORE_BYTES
+        || manifest.db_size_bytes > MAX_TOTAL_RESTORE_BYTES - manifest.attachment_bytes
+    {
+        return Err(LificError::BadRequest(
+            "archive contents exceed total restore size limit".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_entry_bounded<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    max_bytes: u64,
+    label: &str,
+) -> Result<Vec<u8>, LificError> {
+    let size = entry.size();
+    if size > max_bytes {
+        return Err(LificError::BadRequest(format!(
+            "{label} exceeds restore limit ({size} > {max_bytes} bytes)"
+        )));
+    }
+    let mut buf = Vec::with_capacity(size as usize);
+    entry
+        .read_to_end(&mut buf)
+        .map_err(|e| LificError::BadRequest(format!("read {label}: {e}")))?;
+    Ok(buf)
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+/// Validate the extracted SQLite file before it can replace the live DB. This
+/// catches corrupt archives and ensures every metadata attachment reference is
+/// a safe content-addressed filename with matching staged bytes.
+fn validate_staged_database(staging: &Path) -> Result<(), LificError> {
+    let db = staging.join(ARCHIVE_DB_NAME);
+    let conn = rusqlite::Connection::open_with_flags(
+        &db,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .map_err(|e| LificError::BadRequest(format!("open staged database: {e}")))?;
+    let check: String = conn
+        .query_row("PRAGMA quick_check", [], |row| row.get(0))
+        .map_err(|e| LificError::BadRequest(format!("validate staged database: {e}")))?;
+    if check != "ok" {
+        return Err(LificError::BadRequest(format!(
+            "staged database integrity check failed: {check}"
+        )));
+    }
+
+    let has_attachments: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'attachments')",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| LificError::BadRequest(format!("inspect staged schema: {e}")))?;
+    if !has_attachments {
+        return Ok(());
+    }
+
+    let mut stmt = conn
+        .prepare("SELECT sha256, size_bytes FROM attachments")
+        .map_err(|e| LificError::BadRequest(format!("read staged attachments: {e}")))?;
+    let rows = stmt
+        .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))
+        .map_err(|e| LificError::BadRequest(format!("read staged attachment rows: {e}")))?;
+    for row in rows {
+        let (sha, size) = row
+            .map_err(|e| LificError::BadRequest(format!("read staged attachment row: {e}")))?;
+        if !valid_sha256(&sha) || size < 0 || size as u64 > MAX_ATTACHMENT_BYTES {
+            return Err(LificError::BadRequest(
+                "staged attachment metadata has an invalid content address or size".into(),
+            ));
+        }
+        let path = staging.join("attachments").join(&sha);
+        let metadata = std::fs::metadata(&path).map_err(|_| {
+            LificError::BadRequest(format!("staged database references missing attachment {sha}"))
+        })?;
+        if !metadata.is_file() || metadata.len() != size as u64 {
+            return Err(LificError::BadRequest(format!(
+                "staged attachment {sha} does not match database metadata"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Read and validate an archive's manifest + entry list without extracting.
 /// Returns the parsed manifest. Rejects archives missing `manifest.json` or
 /// `lific.db`, and any attachment entry that fails [`validate_attachment_entry`].
 pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
     let manifest = read_manifest(archive)?;
+    validate_manifest_limits(&manifest)?;
 
     // Second pass: validate every entry name (traversal guard) and require the
     // DB member is present.
@@ -338,11 +450,19 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
     let dec = flate2::read::GzDecoder::new(file);
     let mut tar = tar::Archive::new(dec);
     let mut has_db = false;
+    let mut entry_count = 0u64;
+    let mut attachment_count = 0u64;
+    let mut attachment_bytes = 0u64;
     for entry in tar
         .entries()
         .map_err(|e| LificError::BadRequest(format!("read archive entries: {e}")))?
     {
         let entry = entry.map_err(|e| LificError::BadRequest(format!("read entry: {e}")))?;
+        entry_count += 1;
+        if entry_count > MAX_RESTORE_ENTRIES + 2 {
+            return Err(LificError::BadRequest("archive has too many entries".into()));
+        }
+        let size = entry.size();
         let path = entry
             .path()
             .map_err(|e| LificError::BadRequest(format!("entry path: {e}")))?;
@@ -350,9 +470,26 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
         if name == ARCHIVE_MANIFEST_NAME {
             continue;
         } else if name == ARCHIVE_DB_NAME {
+            if size > MAX_DB_BYTES {
+                return Err(LificError::BadRequest("archive database exceeds restore limit".into()));
+            }
             has_db = true;
         } else if name.starts_with(ARCHIVE_ATTACHMENTS_PREFIX) {
             validate_attachment_entry(&name)?;
+            if size > MAX_ATTACHMENT_BYTES {
+                return Err(LificError::BadRequest("archive attachment exceeds restore limit".into()));
+            }
+            attachment_count += 1;
+            attachment_bytes = attachment_bytes
+                .checked_add(size)
+                .ok_or_else(|| LificError::BadRequest("archive attachment size overflow".into()))?;
+            if attachment_count > MAX_RESTORE_ENTRIES
+                || attachment_bytes > manifest.attachment_bytes
+            {
+                return Err(LificError::BadRequest(
+                    "archive attachment contents exceed manifest limits".into(),
+                ));
+            }
         } else {
             return Err(LificError::BadRequest(format!(
                 "rejected unexpected archive entry: {name}"
@@ -362,6 +499,11 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
     if !has_db {
         return Err(LificError::BadRequest(
             "archive is missing lific.db".into(),
+        ));
+    }
+    if attachment_count != manifest.attachment_count || attachment_bytes != manifest.attachment_bytes {
+        return Err(LificError::BadRequest(
+            "archive attachment entries do not match manifest".into(),
         ));
     }
     Ok(manifest)
@@ -382,10 +524,9 @@ fn read_manifest(archive: &Path) -> Result<Manifest, LificError> {
             .path()
             .map_err(|e| LificError::BadRequest(format!("entry path: {e}")))?;
         if path.to_string_lossy() == ARCHIVE_MANIFEST_NAME {
-            let mut buf = String::new();
-            entry
-                .read_to_string(&mut buf)
-                .map_err(|e| LificError::BadRequest(format!("read manifest: {e}")))?;
+            let bytes = read_entry_bounded(&mut entry, MAX_MANIFEST_BYTES, "manifest")?;
+            let buf = String::from_utf8(bytes)
+                .map_err(|e| LificError::BadRequest(format!("manifest is not UTF-8: {e}")))?;
             return serde_json::from_str(&buf)
                 .map_err(|e| LificError::BadRequest(format!("parse manifest.json: {e}")));
         }
@@ -474,6 +615,7 @@ pub fn run_restore(
         let dec = flate2::read::GzDecoder::new(file);
         let mut tar = tar::Archive::new(dec);
         let mut attachment_count = 0u64;
+        let mut total_bytes = 0u64;
         for entry in tar
             .entries()
             .map_err(|e| LificError::BadRequest(format!("read archive entries: {e}")))?
@@ -486,25 +628,32 @@ pub fn run_restore(
             let name = epath.to_string_lossy().replace('\\', "/");
             if name == ARCHIVE_MANIFEST_NAME {
                 // Persist the manifest alongside the restored DB for provenance.
-                let mut buf = Vec::new();
-                entry
-                    .read_to_end(&mut buf)
-                    .map_err(|e| LificError::BadRequest(format!("read manifest: {e}")))?;
+                let buf = read_entry_bounded(&mut entry, MAX_MANIFEST_BYTES, "manifest")?;
                 std::fs::write(staging.join(ARCHIVE_MANIFEST_NAME), &buf)
                     .map_err(|e| LificError::Internal(format!("write manifest: {e}")))?;
             } else if name == ARCHIVE_DB_NAME {
-                let mut buf = Vec::new();
-                entry
-                    .read_to_end(&mut buf)
-                    .map_err(|e| LificError::BadRequest(format!("read db from archive: {e}")))?;
+                let buf = read_entry_bounded(&mut entry, MAX_DB_BYTES, "database")?;
+                total_bytes = total_bytes
+                    .checked_add(buf.len() as u64)
+                    .ok_or_else(|| LificError::BadRequest("archive size overflow".into()))?;
+                if total_bytes > MAX_TOTAL_RESTORE_BYTES {
+                    return Err(LificError::BadRequest(
+                        "archive contents exceed total restore size limit".into(),
+                    ));
+                }
                 std::fs::write(staging.join(ARCHIVE_DB_NAME), &buf)
                     .map_err(|e| LificError::Internal(format!("write db: {e}")))?;
             } else if name.starts_with(ARCHIVE_ATTACHMENTS_PREFIX) {
                 let bare = validate_attachment_entry(&name)?;
-                let mut buf = Vec::new();
-                entry
-                    .read_to_end(&mut buf)
-                    .map_err(|e| LificError::BadRequest(format!("read attachment: {e}")))?;
+                let buf = read_entry_bounded(&mut entry, MAX_ATTACHMENT_BYTES, "attachment")?;
+                total_bytes = total_bytes
+                    .checked_add(buf.len() as u64)
+                    .ok_or_else(|| LificError::BadRequest("archive size overflow".into()))?;
+                if total_bytes > MAX_TOTAL_RESTORE_BYTES {
+                    return Err(LificError::BadRequest(
+                        "archive contents exceed total restore size limit".into(),
+                    ));
+                }
                 std::fs::write(staging.join("attachments").join(&bare), &buf)
                     .map_err(|e| LificError::Internal(format!("write attachment: {e}")))?;
                 attachment_count += 1;
@@ -519,6 +668,7 @@ pub fn run_restore(
                 "archive is missing lific.db".into(),
             ));
         }
+        validate_staged_database(&staging)?;
         Ok(attachment_count)
     })();
 
@@ -1037,11 +1187,55 @@ mod tests {
         assert!(validate_attachment_entry("attachments/.hidden").is_err());
     }
 
+    #[test]
+    fn inspect_rejects_manifest_size_bomb() {
+        let (dir, db_path) = seed_data_dir("manifest_limit");
+        let out = dir.join("source.tar.gz");
+        write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap();
+        let mut manifest = read_manifest(&out).unwrap();
+        manifest.attachment_bytes = MAX_TOTAL_RESTORE_BYTES;
+        let rewritten = dir.join("oversized.tar.gz");
+        rewrite_archive_manifest(&out, &rewritten, &manifest);
+        let error = inspect_archive(&rewritten).unwrap_err();
+        assert!(error.to_string().contains("total restore size"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn staged_database_rejects_missing_or_mismatched_attachment_metadata() {
+        let (dir, db_path) = seed_data_dir("staged_metadata");
+        let pool = crate::db::open(&db_path).unwrap();
+        let sha = "a".repeat(64);
+        {
+            let conn = pool.write().unwrap();
+            crate::db::queries::attachments::create_attachment(
+                &conn,
+                &sha,
+                "note.txt",
+                "text/plain",
+                4,
+                None,
+            )
+            .unwrap();
+        }
+        checkpoint_db_file(&db_path);
+        let staging = dir.join("staging");
+        fs::create_dir_all(staging.join("attachments")).unwrap();
+        fs::copy(&db_path, staging.join(ARCHIVE_DB_NAME)).unwrap();
+        let error = validate_staged_database(&staging).unwrap_err();
+        assert!(error.to_string().contains("missing attachment"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
     // Test helper: re-pack an archive but overwrite the manifest's
     // schema_version, to simulate an archive from a newer binary.
     fn rewrite_archive_with_schema(src: &Path, dst: &Path, schema_version: i64) {
         let mut manifest = read_manifest(src).unwrap();
         manifest.schema_version = schema_version;
+        rewrite_archive_manifest(src, dst, &manifest);
+    }
+
+    fn rewrite_archive_manifest(src: &Path, dst: &Path, manifest: &Manifest) {
         let mj = serde_json::to_vec_pretty(&manifest).unwrap();
 
         let out = fs::File::create(dst).unwrap();

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -6414,8 +6414,9 @@ mod tests {
         let attachment_id = m
             .write(|conn| {
                 use crate::db::queries::attachments as att;
+                let sha = crate::storage::AttachmentStore::hash_bytes(b"sha");
                 let attachment =
-                    att::create_attachment(conn, "sha", "server.log", "text/plain", 64, None)?;
+                    att::create_attachment(conn, &sha, "server.log", "text/plain", 64, None)?;
                 att::link_attachment(
                     conn,
                     attachment.id,
@@ -7059,9 +7060,10 @@ mod tests {
     /// concern; all the link table needs is a real attachment id to point at.
     fn seed_attachment(m: &LificMcp, name: &str) -> i64 {
         let conn = m.db.write().unwrap();
+        let sha = crate::storage::AttachmentStore::hash_bytes(name.as_bytes());
         let attachment = crate::db::queries::attachments::create_attachment(
             &conn,
-            &format!("sha-{name}"),
+            &sha,
             name,
             "image/png",
             3,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1024,11 +1024,7 @@ mod tests {
         assert!(!expects_thumbnail("image/png", Some(480), Some(480)));
         assert!(!expects_thumbnail("image/png", None, None));
         assert!(!expects_thumbnail("video/mp4", Some(1920), Some(1080)));
-        assert!(!expects_thumbnail(
-            "application/pdf",
-            Some(1920),
-            Some(1080)
-        ));
+        assert!(!expects_thumbnail("application/pdf", Some(1920), Some(1080)));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,6 +27,13 @@ pub struct AttachmentStore {
     dir: PathBuf,
 }
 
+pub(crate) fn valid_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
 impl AttachmentStore {
     /// Build a store rooted at `<parent-of-db>/attachments`. Mirrors
     /// `Config::backup_dir`'s "resolve relative to the database file" rule so
@@ -58,22 +65,32 @@ impl AttachmentStore {
     /// Absolute path to the sidecar file for a given content hash. Kept
     /// private-ish (only `pub(crate)`) so callers go through
     /// `read`/`write`/`delete` rather than hand-building paths.
-    pub(crate) fn path_for(&self, sha256: &str) -> PathBuf {
-        self.dir.join(sha256)
+    pub(crate) fn path_for(&self, sha256: &str) -> Result<PathBuf, LificError> {
+        if !valid_sha256(sha256) {
+            return Err(LificError::BadRequest(
+                "attachment hash must be 64 lowercase hexadecimal characters".into(),
+            ));
+        }
+        Ok(self.dir.join(sha256))
     }
 
     /// Absolute path to the cached thumbnail for a content hash. Thumbnails
     /// live in a `thumbs/` subdirectory so a plain `read_dir` of the store
     /// still enumerates exactly the original blobs, and so a hash can never
     /// collide with its own derivative.
-    pub(crate) fn thumb_path_for(&self, sha256: &str) -> PathBuf {
-        self.dir.join("thumbs").join(format!("{sha256}.webp"))
+    pub(crate) fn thumb_path_for(&self, sha256: &str) -> Result<PathBuf, LificError> {
+        if !valid_sha256(sha256) {
+            return Err(LificError::BadRequest(
+                "attachment hash must be 64 lowercase hexadecimal characters".into(),
+            ));
+        }
+        Ok(self.dir.join("thumbs").join(format!("{sha256}.webp")))
     }
 
     /// Cache a generated thumbnail. Same temp-file-then-rename dance as
     /// [`Self::write`], so a concurrent reader never sees a partial webp.
     pub fn write_thumb(&self, sha256: &str, bytes: &[u8]) -> Result<(), LificError> {
-        let path = self.thumb_path_for(sha256);
+        let path = self.thumb_path_for(sha256)?;
         let parent = path
             .parent()
             .ok_or_else(|| LificError::Internal("thumbnail path has no parent".into()))?;
@@ -96,7 +113,7 @@ impl AttachmentStore {
     /// which is the ordinary state for an attachment uploaded before
     /// thumbnails existed.
     pub fn read_thumb(&self, sha256: &str) -> Result<Option<Vec<u8>>, LificError> {
-        match std::fs::read(self.thumb_path_for(sha256)) {
+        match std::fs::read(self.thumb_path_for(sha256)?) {
             Ok(bytes) => Ok(Some(bytes)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(e) => Err(LificError::Internal(format!("read thumbnail: {e}"))),
@@ -106,7 +123,7 @@ impl AttachmentStore {
     /// Drop a cached thumbnail. Missing file is success: thumbnails are a
     /// cache, so every delete here is best-effort and repeatable.
     pub fn delete_thumb(&self, sha256: &str) -> Result<(), LificError> {
-        match std::fs::remove_file(self.thumb_path_for(sha256)) {
+        match std::fs::remove_file(self.thumb_path_for(sha256)?) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(LificError::Internal(format!("delete thumbnail: {e}"))),
@@ -127,7 +144,7 @@ impl AttachmentStore {
         let sha = Self::hash_bytes(bytes);
         std::fs::create_dir_all(&self.dir)
             .map_err(|e| LificError::Internal(format!("create attachments dir: {e}")))?;
-        let path = self.path_for(&sha);
+        let path = self.path_for(&sha)?;
         if path.exists() {
             return Ok(sha);
         }
@@ -149,7 +166,7 @@ impl AttachmentStore {
     /// Read the bytes for a content hash. `NotFound` when the sidecar file is
     /// missing (e.g. the DB row survived but the blob was manually removed).
     pub fn read(&self, sha256: &str) -> Result<Vec<u8>, LificError> {
-        let path = self.path_for(sha256);
+        let path = self.path_for(sha256)?;
         std::fs::read(&path).map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 LificError::NotFound("attachment bytes not found on disk".into())
@@ -167,7 +184,7 @@ impl AttachmentStore {
         // them. Best-effort: a failure to remove a cache file must not block
         // the blob delete the caller actually asked for.
         let _ = self.delete_thumb(sha256);
-        let path = self.path_for(sha256);
+        let path = self.path_for(sha256)?;
         match std::fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -679,6 +696,19 @@ mod tests {
     }
 
     #[test]
+    fn invalid_hashes_cannot_escape_the_store() {
+        let (store, tmp) = tmp_store();
+        let outside = tmp.path().join("outside");
+        std::fs::write(&outside, b"must survive").unwrap();
+
+        assert!(store.read("../outside").is_err());
+        assert!(store.delete("../outside").is_err());
+        assert!(store.read_thumb("../outside").is_err());
+        assert!(store.delete_thumb("../outside").is_err());
+        assert_eq!(std::fs::read(outside).unwrap(), b"must survive");
+    }
+
+    #[test]
     fn from_db_path_puts_attachments_next_to_db() {
         let store = AttachmentStore::from_db_path(Path::new("/data/lific/lific.db"));
         assert_eq!(store.dir(), Path::new("/data/lific/attachments"));
@@ -722,8 +752,8 @@ mod tests {
         // A row whose blob is missing from disk must be skipped, not fatal.
         {
             let conn = pool.write().unwrap();
-            q::create_attachment(&conn, "no-such-blob", "ghost.log", "text/plain", 10, None)
-                .unwrap();
+            let sha = AttachmentStore::hash_bytes(b"no-such-blob");
+            q::create_attachment(&conn, &sha, "ghost.log", "text/plain", 10, None).unwrap();
         }
 
         assert_eq!(backfill_attachment_text(&pool, &store).unwrap(), 1);
@@ -994,7 +1024,11 @@ mod tests {
         assert!(!expects_thumbnail("image/png", Some(480), Some(480)));
         assert!(!expects_thumbnail("image/png", None, None));
         assert!(!expects_thumbnail("video/mp4", Some(1920), Some(1080)));
-        assert!(!expects_thumbnail("application/pdf", Some(1920), Some(1080)));
+        assert!(!expects_thumbnail(
+            "application/pdf",
+            Some(1920),
+            Some(1080)
+        ));
     }
 
     #[test]
@@ -1006,7 +1040,7 @@ mod tests {
         store.write_thumb(&sha, b"pretend webp").unwrap();
         assert_eq!(store.read_thumb(&sha).unwrap().unwrap(), b"pretend webp");
         assert_eq!(
-            store.thumb_path_for(&sha).parent().unwrap(),
+            store.thumb_path_for(&sha).unwrap().parent().unwrap(),
             store.dir().join("thumbs")
         );
 


### PR DESCRIPTION
## Summary

Harden restore against malformed or untrusted dump archives while preserving normal dump/restore behavior.

- Stream manifest, database, and attachment entries through explicit size, entry-count, total-expansion, and decompression limits.
- Reject duplicate control entries, unsafe archive paths, unsupported tar entry types, and manifest/member size or count mismatches before installation.
- Validate the staged database before it can replace live state: SQLite integrity, schema compatibility, attachment hash/MIME/size metadata, blob existence, content hashes, and detected content types.
- Enforce canonical attachment hashes and allowed metadata at both the SQLite schema and storage boundaries.
- Stage database and attachment swaps together, serialize concurrent restores, preserve pre-restore state, and roll back ordinary installation failures.
- Continue accepting older attachment archives whose pending migrations can be applied on the next start.

The branch-added tests cover compressed expansion bombs, oversized entries, excessive entry counts, duplicate control entries, traversal attempts, legacy schema compatibility, invalid attachment metadata, blob hash and MIME mismatches, missing blobs, symlink-safe staging, concurrent restore locking, rollback behavior, and successful dump/restore round trips.