### PR TITLE
Harden local filesystem writes and attachment storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1743,7 @@ dependencies = [
  "crossbeam-queue",
  "dirs",
  "flate2",
+ "fs2",
  "futures-util",
  "hmac",
  "http-body-util",
@@ -3773,6 +3784,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,6 +3807,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ cliclack = "0.5.4"
 console = "0.16.4"
 image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 tempfile = "3"
+fs2 = "0.4"
 
 # SIGPIPE handling for piped CLI output (see main.rs); unix only.
 [target.'cfg(unix)'.dependencies]

--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -104,7 +104,7 @@ pub(super) async fn upload_attachment(
     let mut link_entity: Option<AttachmentEntity> = None;
     let mut link_entity_id: Option<i64> = None;
 
-    while let Some(field) = multipart
+    while let Some(mut field) = multipart
         .next_field()
         .await
         .map_err(|e| LificError::BadRequest(format!("malformed multipart: {e}")))?
@@ -116,18 +116,21 @@ pub(super) async fn upload_attachment(
                     filename = sanitize_filename(fname);
                 }
                 declared_mime = field.content_type().map(|s| s.to_string());
-                let data = field
-                    .bytes()
+                let mut data = Vec::new();
+                while let Some(chunk) = field
+                    .chunk()
                     .await
-                    .map_err(|e| LificError::BadRequest(format!("failed to read upload: {e}")))?;
-                if data.len() > config.max_bytes {
-                    return Err(LificError::BadRequest(format!(
-                        "file too large: {} bytes (max {})",
-                        data.len(),
-                        config.max_bytes
-                    )));
+                    .map_err(|e| LificError::BadRequest(format!("failed to read upload: {e}")))?
+                {
+                    if data.len().saturating_add(chunk.len()) > config.max_bytes {
+                        return Err(LificError::BadRequest(format!(
+                            "file too large: more than {} bytes",
+                            config.max_bytes
+                        )));
+                    }
+                    data.extend_from_slice(&chunk);
                 }
-                file_bytes = Some(data.to_vec());
+                file_bytes = Some(data);
             }
             "entity_type" => {
                 let v = field.text().await.unwrap_or_default();
@@ -181,58 +184,69 @@ pub(super) async fn upload_attachment(
     }
 
     let size = bytes.len() as i64;
-    // Store bytes first (content-addressed), then record metadata.
-    let sha = store.write(&bytes)?;
-
-    // LIF-418: decode dimensions and pre-generate a thumbnail for rasters.
-    // Both are best-effort: a picture the `image` crate cannot read is still a
-    // perfectly good attachment, and refusing the upload over a missing
-    // derivative would be a regression against every format it already
-    // accepted.
+    let sha = AttachmentStore::hash_bytes(&bytes);
     let dimensions = if storage::is_raster_mime(&mime) {
         storage::image_dimensions(&bytes)
     } else {
         None
     };
-    if dimensions.is_some() {
-        cache_thumbnail(&store, &sha, &bytes);
-    }
-
-    // One immediate transaction for the metadata row, the link, and the link's
-    // authorization. `with_write` would have let a role revocation or an
-    // entity move land between the gate above and the insert below, and left
-    // the attachment row behind when the link write failed.
-    let (attachment, event) = db.transaction(|conn| {
-        let mut att = q::create_attachment(conn, &sha, &filename, &mime, size, Some(user.id))?;
-        if let Some((w, h)) = dimensions {
-            q::set_dimensions(conn, att.id, i64::from(w), i64::from(h))?;
-            att = q::get_attachment(conn, att.id)?;
-        }
-        // LIF-418: index a small text upload's contents so search can find the
-        // file by what's inside it, not just by its name. Migration 042's
-        // insert trigger has already put the filename in `attachments_fts`;
-        // this fills in the text column. Non-UTF-8 bytes can't reach here for
-        // a `text/*` mime (the sniffer requires valid UTF-8), but the check
-        // keeps this honest if the allowlist ever widens.
-        if q::is_extractable(&mime, size)
-            && let Ok(text) = std::str::from_utf8(&bytes)
-        {
-            q::set_extracted_text(conn, att.id, text)?;
-        }
-        // If the caller asked to link immediately, do it here in the same txn,
-        // re-authorized on this very connection: the pre-flight gate above ran
-        // on a read connection before the blob was stored, so the decision it
-        // made is stale by the time we get here. Denial rolls the attachment
-        // row back with it.
-        let event = match link {
-            Some((entity, eid)) => {
-                authorize_link_conn(conn, &identity, entity, eid)?;
-                q::link_attachment(conn, att.id, entity, eid)?;
-                linked_entity_event(conn, entity, eid)?
+    let thumbnail = if dimensions.is_some() {
+        match storage::generate_thumbnail(&bytes) {
+            Ok(thumb) => thumb,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to generate attachment thumbnail");
+                None
             }
-            None => None,
-        };
-        Ok((att, event))
+        }
+    } else {
+        None
+    };
+    // Serialize the blob write with metadata insertion and orphan cleanup.
+    // Otherwise GC can delete a newly written blob in the gap before its row
+    // is inserted.
+    let (attachment, event) = store.with_lock(|store| {
+        let blob_existed = store.path_for(&sha)?.exists();
+        let thumb_existed = thumbnail
+            .as_ref()
+            .map(|_| store.thumb_path_for(&sha).map(|path| path.exists()))
+            .transpose()?
+            .unwrap_or(false);
+        let result = db.transaction(|conn| {
+            let mut att = q::create_attachment(conn, &sha, &filename, &mime, size, Some(user.id))?;
+            store.write_unlocked(&bytes)?;
+            if let Some(thumb) = thumbnail.as_deref()
+                && let Err(e) = store.write_thumb(&sha, thumb)
+            {
+                tracing::warn!(error = %e, "failed to cache attachment thumbnail");
+            }
+            if let Some((w, h)) = dimensions {
+                q::set_dimensions(conn, att.id, i64::from(w), i64::from(h))?;
+                att = q::get_attachment(conn, att.id)?;
+            }
+            if q::is_extractable(&mime, size)
+                && let Ok(text) = std::str::from_utf8(&bytes)
+            {
+                q::set_extracted_text(conn, att.id, text)?;
+            }
+            let event = match link {
+                Some((entity, eid)) => {
+                    authorize_link_conn(conn, &identity, entity, eid)?;
+                    q::link_attachment(conn, att.id, entity, eid)?;
+                    linked_entity_event(conn, entity, eid)?
+                }
+                None => None,
+            };
+            Ok((att, event))
+        });
+        if result.is_err() {
+            if !blob_existed {
+                let _ = store.delete_unlocked(&sha);
+            }
+            if thumbnail.is_some() && !thumb_existed {
+                let _ = store.delete_thumb(&sha);
+            }
+        }
+        result
     })?;
     if let Some(event) = event {
         realtime.send(event);
@@ -554,22 +568,6 @@ fn parse_range(value: &str, total: u64) -> RangeRequest {
 
 // ── Thumbnails (LIF-418) ─────────────────────────────────────
 
-/// Generate and cache a thumbnail for freshly-stored bytes, swallowing every
-/// failure. A thumbnail is a convenience derived from the blob; if it cannot
-/// be produced the endpoint simply 404s and callers fall back to the original.
-/// Nothing here is allowed to fail an upload.
-fn cache_thumbnail(store: &AttachmentStore, sha: &str, bytes: &[u8]) {
-    match storage::generate_thumbnail(bytes) {
-        Ok(Some(thumb)) => {
-            if let Err(e) = store.write_thumb(sha, &thumb) {
-                tracing::warn!(error = %e, "failed to cache attachment thumbnail");
-            }
-        }
-        Ok(None) => {}
-        Err(e) => tracing::warn!(error = %e, "failed to generate attachment thumbnail"),
-    }
-}
-
 /// `GET /api/attachments/{id}/thumbnail`: a 480px-long-edge WebP preview of a
 /// raster attachment.
 ///
@@ -710,19 +708,22 @@ pub(super) async fn delete_attachment(
 
     authorize_delete(&db, &identity, &user, &attachment)?;
 
-    let events = with_write(&db, |conn| {
-        let events = linked_attachment_events(conn, id)?;
-        q::delete_attachment(conn, id)?;
+    let events = store.with_lock(|store| {
+        let events = with_write(&db, |conn| {
+            let events = linked_attachment_events(conn, id)?;
+            q::delete_attachment(conn, id)?;
+            Ok(events)
+        })?;
+
+        // GC the sidecar only when no remaining row references the same bytes.
+        let remaining = with_read(&db, |conn| q::count_rows_for_sha(conn, &attachment.sha256))?;
+        if remaining == 0 {
+            store.delete_unlocked(&attachment.sha256)?;
+        }
         Ok(events)
     })?;
     for event in events {
         realtime.send(event);
-    }
-
-    // GC the sidecar only when no remaining row references the same bytes.
-    let remaining = with_read(&db, |conn| q::count_rows_for_sha(conn, &attachment.sha256))?;
-    if remaining == 0 {
-        store.delete(&attachment.sha256)?;
     }
 
     Ok(axum::Json(serde_json::json!({ "deleted": true })))
@@ -1284,6 +1285,7 @@ mod tests {
 mod api_tests {
     use crate::api::test_helpers::*;
     use crate::db::models::*;
+    use crate::storage::AttachmentStore;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
@@ -1839,6 +1841,10 @@ mod api_tests {
             })
             .unwrap();
         assert_eq!(links, 0);
+        let store = AttachmentStore::from_db_path(db.path());
+        let sha = AttachmentStore::hash_bytes(&png_bytes());
+        assert!(!store.path_for(&sha).unwrap().exists());
+        assert!(!store.thumb_path_for(&sha).unwrap().exists());
     }
 
     /// LIF-262's re-scan on save carries the same guarantee: the text that

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -209,12 +209,9 @@ const STALE_TMP_AGE: Duration = Duration::from_secs(60 * 60);
 
 /// Delete stale dump staging files leaked by a crash mid-backup (LIF-329).
 ///
-/// `write_dump` stages `{stem}_<ts>.tar.dbsnapshot.tmp` and
-/// `{stem}_<ts>.tar.archive.tmp` beside the output archive and cleans them
-/// itself on success or error — but a hard crash between staging and cleanup
-/// strands them, and `rotate_backups` only matches `.tar.gz`/`.db`, so they
-/// would otherwise accumulate forever. Age-gated so an in-flight dump's
-/// staging files are never swept.
+/// `write_dump` stages a private `.lific-dump-*` directory beside the output
+/// archive and cleans it itself on success or error. Age-gated so an
+/// in-flight dump's staging directory is never swept.
 fn sweep_stale_tmps(backup_dir: &Path, db_stem: &str) {
     let prefix = format!("{db_stem}_");
     let entries = match std::fs::read_dir(backup_dir) {
@@ -229,23 +226,43 @@ fn sweep_stale_tmps(backup_dir: &Path, db_stem: &str) {
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
-        if !name.starts_with(&prefix)
-            || !(name.ends_with(".dbsnapshot.tmp") || name.ends_with(".archive.tmp"))
-        {
+        let is_new_staging_dir = name.starts_with(".lific-dump-");
+        let is_legacy_tmp = name.starts_with(&prefix)
+            && (name.ends_with(".dbsnapshot.tmp") || name.ends_with(".archive.tmp"));
+        if !is_new_staging_dir && !is_legacy_tmp {
             continue;
         }
-        let stale = entry
-            .metadata()
+        let stale = std::fs::symlink_metadata(&path)
             .and_then(|m| m.modified())
             .ok()
             .and_then(|modified| modified.elapsed().ok())
             .is_some_and(|age| age > STALE_TMP_AGE);
-        if stale {
-            match std::fs::remove_file(&path) {
-                Ok(()) => info!(path = %path.display(), "removed stale backup staging file"),
-                Err(e) => {
-                    warn!(path = %path.display(), error = %e, "failed to remove stale staging file")
-                }
+        if !stale {
+            continue;
+        }
+        if is_new_staging_dir {
+            if dump::staging_is_locked(&path) {
+                continue;
+            }
+            let activity = path.join("activity");
+            let active = std::fs::symlink_metadata(&activity)
+                .and_then(|metadata| metadata.modified())
+                .ok()
+                .and_then(|modified| modified.elapsed().ok())
+                .is_some_and(|age| age <= STALE_TMP_AGE);
+            if active {
+                continue;
+            }
+        }
+        let result = if is_new_staging_dir {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+        match result {
+            Ok(()) => info!(path = %path.display(), "removed stale backup staging file"),
+            Err(e) => {
+                warn!(path = %path.display(), error = %e, "failed to remove stale staging file")
             }
         }
     }
@@ -321,6 +338,17 @@ mod tests {
     /// panicking test cannot leave stale state behind for a later run.
     fn make_temp_dir() -> TempDir {
         tempfile::tempdir().unwrap()
+    }
+
+    fn make_backup_dir(parent: &Path) -> PathBuf {
+        let backup_dir = parent.join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&backup_dir, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        backup_dir
     }
 
     #[test]
@@ -404,7 +432,11 @@ mod tests {
 
     /// Backdate a file's mtime so the sweep sees it as stale.
     fn backdate(path: &Path, by: Duration) {
-        let f = fs::File::options().write(true).open(path).unwrap();
+        let f = if cfg!(unix) && path.is_dir() {
+            fs::File::open(path).unwrap()
+        } else {
+            fs::File::options().write(true).open(path).unwrap()
+        };
         f.set_modified(std::time::SystemTime::now() - by).unwrap();
     }
 
@@ -422,13 +454,18 @@ mod tests {
         let fresh_arch = dir.join("lific_20260714_120000.tar.archive.tmp");
         let other_stem = dir.join("other_20260101_120000.tar.archive.tmp");
         let real_backup = dir.join("lific_20260101_120000.tar.gz");
+        let stale_dir = dir.join(".lific-dump-stale");
         for p in [&stale_snap, &stale_arch, &fresh_arch, &other_stem, &real_backup] {
             fs::write(p, "x").unwrap();
         }
+        fs::create_dir(&stale_dir).unwrap();
+        fs::write(stale_dir.join("archive"), "x").unwrap();
         backdate(&stale_snap, old);
         backdate(&stale_arch, old);
         backdate(&other_stem, old);
         backdate(&real_backup, old);
+        #[cfg(unix)]
+        backdate(&stale_dir, old);
 
         sweep_stale_tmps(dir, "lific");
 
@@ -437,6 +474,34 @@ mod tests {
         assert!(fresh_arch.exists(), "fresh staging tmp must survive");
         assert!(other_stem.exists(), "other stems are not ours to sweep");
         assert!(real_backup.exists(), "real archives are rotation's job, not the sweep's");
+        #[cfg(unix)]
+        assert!(!stale_dir.exists(), "stale dump staging directory must be swept");
+    }
+
+    #[test]
+    fn sweep_keeps_stale_directory_while_dump_lock_is_held() {
+        use fs2::FileExt;
+
+        let tmp = make_temp_dir();
+        let dir = tmp.path();
+        let staging = dir.join(".lific-dump-active");
+        fs::create_dir(&staging).unwrap();
+        fs::write(staging.join("activity"), "active").unwrap();
+        let lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(staging.join("lock"))
+            .unwrap();
+        lock.try_lock_exclusive().unwrap();
+        backdate(&staging, STALE_TMP_AGE + Duration::from_secs(60));
+        backdate(&staging.join("activity"), STALE_TMP_AGE + Duration::from_secs(60));
+
+        sweep_stale_tmps(dir, "lific");
+
+        assert!(staging.exists(), "a locked dump must not be swept");
+        drop(lock);
     }
 
     #[test]
@@ -446,8 +511,7 @@ mod tests {
         let tmp = make_temp_dir();
         let dir = tmp.path();
         let db_path = dir.join("lific.db");
-        let backup_dir = dir.join("backups");
-        fs::create_dir_all(&backup_dir).unwrap();
+        let backup_dir = make_backup_dir(dir);
         let pool = crate::db::open(&db_path).expect("open test db");
 
         let stale = backup_dir.join("lific_20260101_120000.tar.archive.tmp");
@@ -467,8 +531,7 @@ mod tests {
         let tmp = make_temp_dir();
         let dir = tmp.path();
         let db_path = dir.join("lific.db");
-        let backup_dir = dir.join("backups");
-        fs::create_dir_all(&backup_dir).unwrap();
+        let backup_dir = make_backup_dir(dir);
 
         // Seed the DB and an attachments sidecar dir next to it.
         let pool = crate::db::open(&db_path).expect("open test db");
@@ -488,7 +551,8 @@ mod tests {
         }
         let att_dir = dir.join("attachments");
         fs::create_dir_all(&att_dir).unwrap();
-        fs::write(att_dir.join("deadbeefsha"), b"blob contents").unwrap();
+        let blob_name = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        fs::write(att_dir.join(blob_name), b"blob contents").unwrap();
         fs::write(att_dir.join("deadbeefsha.tmp"), b"partial").unwrap();
 
         run_backup(&pool, &db_path, &backup_dir, 5, None);
@@ -514,7 +578,7 @@ mod tests {
             .collect();
         assert!(names.iter().any(|n| n == crate::dump::ARCHIVE_DB_NAME));
         assert!(names.iter().any(|n| n == crate::dump::ARCHIVE_MANIFEST_NAME));
-        assert!(names.iter().any(|n| n == "attachments/deadbeefsha"));
+        assert!(names.iter().any(|n| n == &format!("attachments/{blob_name}")));
         assert!(
             !names.iter().any(|n| n.ends_with(".tmp")),
             "in-progress .tmp writes must not be archived: {names:?}"
@@ -637,8 +701,7 @@ mod tests {
         let tmp = make_temp_dir();
         let dir = tmp.path();
         let db_path = dir.join("lific.db");
-        let backup_dir = dir.join("backups");
-        fs::create_dir_all(&backup_dir).unwrap();
+        let backup_dir = make_backup_dir(dir);
         let pool = crate::db::open(&db_path).expect("open test db");
         seed_audit_row(&pool, "ancient", 400);
         seed_audit_row(&pool, "today", 0);

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -232,7 +232,12 @@ fn sweep_stale_tmps(backup_dir: &Path, db_stem: &str) {
         if !is_new_staging_dir && !is_legacy_tmp {
             continue;
         }
-        let stale = std::fs::symlink_metadata(&path)
+        let age_path = if is_new_staging_dir {
+            path.join("activity")
+        } else {
+            path.clone()
+        };
+        let stale = std::fs::symlink_metadata(&age_path)
             .and_then(|m| m.modified())
             .ok()
             .and_then(|modified| modified.elapsed().ok())
@@ -459,13 +464,15 @@ mod tests {
             fs::write(p, "x").unwrap();
         }
         fs::create_dir(&stale_dir).unwrap();
-        fs::write(stale_dir.join("archive"), "x").unwrap();
+        fs::write(stale_dir.join("activity"), "stale").unwrap();
         backdate(&stale_snap, old);
         backdate(&stale_arch, old);
         backdate(&other_stem, old);
         backdate(&real_backup, old);
-        #[cfg(unix)]
-        backdate(&stale_dir, old);
+        backdate(
+            &stale_dir.join("activity"),
+            old,
+        );
 
         sweep_stale_tmps(dir, "lific");
 
@@ -474,7 +481,6 @@ mod tests {
         assert!(fresh_arch.exists(), "fresh staging tmp must survive");
         assert!(other_stem.exists(), "other stems are not ours to sweep");
         assert!(real_backup.exists(), "real archives are rotation's job, not the sweep's");
-        #[cfg(unix)]
         assert!(!stale_dir.exists(), "stale dump staging directory must be swept");
     }
 
@@ -495,8 +501,10 @@ mod tests {
             .open(staging.join("lock"))
             .unwrap();
         lock.try_lock_exclusive().unwrap();
-        backdate(&staging, STALE_TMP_AGE + Duration::from_secs(60));
-        backdate(&staging.join("activity"), STALE_TMP_AGE + Duration::from_secs(60));
+        backdate(
+            &staging.join("activity"),
+            STALE_TMP_AGE + Duration::from_secs(60),
+        );
 
         sweep_stale_tmps(dir, "lific");
 

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -98,28 +98,93 @@ pub fn render(path: &Path, format: Format, entry: &CompiledEntry) -> Result<Rend
 /// directories as needed. Returns whether the file was created or updated.
 pub fn write(path: &Path, format: Format, entry: &CompiledEntry) -> Result<Action, WriteError> {
     let rendered = render(path, format, entry)?;
+    let parent_existed = path.parent().map(|parent| parent.exists()).unwrap_or(true);
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
         std::fs::create_dir_all(parent)
             .map_err(|e| WriteError::new(format!("failed to create {}: {e}", parent.display())))?;
     }
-    std::fs::write(path, &rendered.contents)
-        .map_err(|e| WriteError::new(format!("failed to write {}: {e}", path.display())))?;
-    // Connector configs can embed live credentials (an API key, an OAuth
-    // token, or a LIFIC_TOKEN env entry). Don't leave those group/world
-    // readable (PR #23 review). Configs without secrets keep umask perms —
-    // some of them are shared, committed files.
+    // Only embedded credentials make this file secret-bearing. Environment
+    // variable references are configuration, not credential material.
+    let secret = rendered.contents.contains("lific_sk-") || rendered.contents.contains("lific_at_");
+    if secret && let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        if parent_existed {
+            set_private_dir(parent)?;
+        } else {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(
+                    |e| WriteError::new(format!("failed to secure {}: {e}", parent.display())),
+                )?;
+            }
+        }
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let staging = tempfile::Builder::new()
+        .prefix(".lific-config-")
+        .tempdir_in(parent)
+        .map_err(|e| WriteError::new(format!("could not create config staging directory: {e}")))?;
+    let tmp = staging.path().join(path.file_name().unwrap_or_default());
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
     #[cfg(unix)]
-    if rendered.contents.contains("LIFIC_TOKEN")
-        || rendered.contents.contains("lific_sk-")
-        || rendered.contents.contains("lific_at_")
+    {
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+        let mode = if secret {
+            0o600
+        } else {
+            std::fs::symlink_metadata(path)
+                .ok()
+                .map(|metadata| metadata.mode() & 0o777)
+                .filter(|mode| *mode != 0)
+                .unwrap_or(0o666)
+        };
+        options.mode(mode).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options
+        .open(&tmp)
+        .map_err(|e| WriteError::new(format!("failed to create config staging file: {e}")))?;
+    std::io::Write::write_all(&mut file, rendered.contents.as_bytes())
+        .map_err(|e| WriteError::new(format!("failed to write {}: {e}", path.display())))?;
+    if secret {
+        set_private_file(&file)?;
+    }
+    file.sync_all()
+        .map_err(|e| WriteError::new(format!("failed to sync {}: {e}", path.display())))?;
+    std::fs::rename(&tmp, path)
+        .map_err(|e| WriteError::new(format!("failed to finalize {}: {e}", path.display())))?;
+    Ok(rendered.action)
+}
+
+fn set_private_file(_file: &std::fs::File) -> Result<(), WriteError> {
+    #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-            .map_err(|e| WriteError::new(format!("failed to chmod {}: {e}", path.display())))?;
+        _file
+            .set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| WriteError::new(format!("failed to tighten config staging file: {e}")))?;
     }
-    Ok(rendered.action)
+    Ok(())
+}
+
+fn set_private_dir(_path: &Path) -> Result<(), WriteError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let mode = std::fs::metadata(_path)
+            .map_err(|e| WriteError::new(format!("failed to inspect {}: {e}", _path.display())))?
+            .mode()
+            & 0o777;
+        if mode & 0o022 != 0 {
+            return Err(WriteError::new(format!(
+                "config directory {} is writable by group/others; remove group/other write permissions before writing embedded credentials",
+                _path.display()
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Read the file if present. `Ok(None)` = doesn't exist. An unreadable file is
@@ -200,7 +265,9 @@ fn render_toml(existing: &str, entry: &CompiledEntry) -> Result<String, WriteErr
     } else {
         existing.parse::<DocumentMut>().map_err(|e| {
             WriteError::with_snippet(
-                format!("existing config.toml does not parse ({e}); not modifying it. Merge by hand:"),
+                format!(
+                    "existing config.toml does not parse ({e}); not modifying it. Merge by hand:"
+                ),
                 manual_toml_snippet(entry),
             )
         })?
@@ -245,7 +312,7 @@ fn render_toml(existing: &str, entry: &CompiledEntry) -> Result<String, WriteErr
 /// toml_edit value. Codex entries carry strings, string arrays, and — for the
 /// stdio agent token (LIFIC-18) — a nested `env` object of strings.
 fn json_to_toml_value(v: &serde_json::Value) -> Result<toml_edit::Item, WriteError> {
-    use toml_edit::{Array, Item, Value, value, InlineTable};
+    use toml_edit::{Array, InlineTable, Item, Value, value};
     match v {
         serde_json::Value::String(s) => Ok(value(s.as_str())),
         serde_json::Value::Bool(b) => Ok(value(*b)),
@@ -330,7 +397,9 @@ fn render_yaml(existing: &str, entry: &CompiledEntry) -> Result<String, WriteErr
     } else {
         serde_yaml::from_str(existing).map_err(|e| {
             WriteError::with_snippet(
-                format!("existing config.yaml does not parse ({e}); not modifying it. Merge by hand:"),
+                format!(
+                    "existing config.yaml does not parse ({e}); not modifying it. Merge by hand:"
+                ),
                 manual_yaml_snippet(entry),
             )
         })?
@@ -367,8 +436,7 @@ fn render_yaml(existing: &str, entry: &CompiledEntry) -> Result<String, WriteErr
 
 fn manual_yaml_snippet(entry: &CompiledEntry) -> String {
     let mut top = serde_yaml::Mapping::new();
-    let value_yaml =
-        serde_yaml::to_value(&entry.value).unwrap_or(serde_yaml::Value::Null);
+    let value_yaml = serde_yaml::to_value(&entry.value).unwrap_or(serde_yaml::Value::Null);
     top.insert(serde_yaml::Value::String(entry.name.clone()), value_yaml);
     let mut root = serde_yaml::Mapping::new();
     root.insert(
@@ -392,7 +460,22 @@ mod tests {
     /// has to create the parent itself. Dropping the guard removes
     /// everything, unwinding included.
     fn tmp() -> tempfile::TempDir {
-        tempfile::tempdir().unwrap()
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        dir
+    }
+
+    fn private_dir(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
     }
 
     #[test]
@@ -410,11 +493,52 @@ mod tests {
         assert_eq!(v["mcp"]["lific"]["type"], "remote");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn secret_config_is_owner_only_and_atomic() {
+        use std::os::unix::fs::PermissionsExt;
+        let guard = tmp();
+        let dir = guard.path().join("proj");
+        let path = dir.join("opencode.json");
+        let entry = find_client("opencode").unwrap().compile(&remote());
+        write(&path, Format::Json, &entry).unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert!(!std::fs::read_dir(&dir).unwrap().any(|entry| {
+            entry
+                .ok()
+                .and_then(|entry| entry.file_name().to_str().map(str::to_owned))
+                .is_some_and(|name| name.starts_with(".lific-config-"))
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secret_config_allows_traversable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let guard = tmp();
+        let dir = guard.path().join("proj");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let path = dir.join("opencode.json");
+        let entry = find_client("opencode").unwrap().compile(&remote());
+        write(&path, Format::Json, &entry).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
     #[test]
     fn json_preserves_sibling_servers_and_unrelated_keys() {
         let guard = tmp();
         let dir = guard.path().join("proj");
-        std::fs::create_dir_all(&dir).unwrap();
+        private_dir(&dir);
         let path = dir.join("opencode.json");
         // Pre-existing config with another MCP server and unrelated top keys.
         std::fs::write(
@@ -447,7 +571,7 @@ mod tests {
     fn json_replaces_existing_lific_entry_not_duplicates() {
         let guard = tmp();
         let dir = guard.path().join("proj");
-        std::fs::create_dir_all(&dir).unwrap();
+        private_dir(&dir);
         let path = dir.join("opencode.json");
         std::fs::write(
             &path,
@@ -473,7 +597,7 @@ mod tests {
     fn json_refuses_to_touch_unparseable_jsonc_and_returns_snippet() {
         let guard = tmp();
         let dir = guard.path().join("proj");
-        std::fs::create_dir_all(&dir).unwrap();
+        private_dir(&dir);
         let path = dir.join("opencode.json");
         // JSONC with a comment — valid for OpenCode but not strict JSON.
         let original = "{\n  // my config\n  \"mcp\": {}\n}\n";
@@ -492,9 +616,10 @@ mod tests {
     fn toml_sets_only_our_table_and_preserves_comments() {
         let guard = tmp();
         let dir = guard.path().join("proj");
-        std::fs::create_dir_all(&dir).unwrap();
+        private_dir(&dir);
         let path = dir.join("config.toml");
-        let original = "# Codex config\nmodel = \"gpt-5\"\n\n[mcp_servers.other]\nurl = \"http://other\"\n";
+        let original =
+            "# Codex config\nmodel = \"gpt-5\"\n\n[mcp_servers.other]\nurl = \"http://other\"\n";
         std::fs::write(&path, original).unwrap();
 
         let entry = find_client("codex").unwrap().compile(&remote());
@@ -503,7 +628,10 @@ mod tests {
 
         let written = std::fs::read_to_string(&path).unwrap();
         // Comment preserved.
-        assert!(written.contains("# Codex config"), "comment must survive: {written}");
+        assert!(
+            written.contains("# Codex config"),
+            "comment must survive: {written}"
+        );
         // Unrelated top-level key preserved.
         assert!(written.contains("model = \"gpt-5\""));
         // Sibling server preserved.
@@ -518,7 +646,21 @@ mod tests {
             doc["mcp_servers"]["lific"]["bearer_token_env_var"].as_str(),
             Some("LIFIC_API_KEY")
         );
-        assert!(!written.contains("lific_sk-live-K"), "must not inline the key");
+        assert!(
+            !written.contains("lific_sk-live-K"),
+            "must not inline the key"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+            write(&path, Format::Toml, &entry).unwrap();
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o644,
+                "reference-only config must not be tightened"
+            );
+        }
     }
 
     #[test]
@@ -529,8 +671,7 @@ mod tests {
         let entry = find_client("codex").unwrap().compile(&remote());
         let action = write(&path, Format::Toml, &entry).unwrap();
         assert_eq!(action, Action::Created);
-        let doc: toml_edit::DocumentMut =
-            std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        let doc: toml_edit::DocumentMut = std::fs::read_to_string(&path).unwrap().parse().unwrap();
         assert_eq!(
             doc["mcp_servers"]["lific"]["bearer_token_env_var"].as_str(),
             Some("LIFIC_API_KEY")
@@ -541,7 +682,7 @@ mod tests {
     fn toml_refuses_unparseable_and_returns_snippet() {
         let guard = tmp();
         let dir = guard.path().join("proj");
-        std::fs::create_dir_all(&dir).unwrap();
+        private_dir(&dir);
         let path = dir.join("config.toml");
         let original = "this is = = not valid toml [[[\n";
         std::fs::write(&path, original).unwrap();
@@ -555,7 +696,7 @@ mod tests {
     fn yaml_sets_extensions_lific_and_preserves_other_extensions() {
         let guard = tmp();
         let dir = guard.path().join("proj");
-        std::fs::create_dir_all(&dir).unwrap();
+        private_dir(&dir);
         let path = dir.join("config.yaml");
         std::fs::write(
             &path,
@@ -578,7 +719,10 @@ mod tests {
             v["extensions"]["lific"]["type"].as_str(),
             Some("streamable_http")
         );
-        assert_eq!(v["extensions"]["lific"]["uri"].as_str(), Some("http://127.0.0.1:3456/mcp"));
+        assert_eq!(
+            v["extensions"]["lific"]["uri"].as_str(),
+            Some("http://127.0.0.1:3456/mcp")
+        );
     }
 
     #[test]

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -73,18 +73,34 @@ impl ServicePlan {
         let workdir = config
             .parent()
             .filter(|p| !p.as_os_str().is_empty())
-            .ok_or_else(|| {
-                format!(
-                    "config path {} has no parent directory",
-                    config.display()
-                )
-            })?
+            .ok_or_else(|| format!("config path {} has no parent directory", config.display()))?
             .to_path_buf();
+        reject_control_paths([exe.as_path(), config.as_path(), workdir.as_path()])?;
         Ok(Self {
             exe,
             config,
             workdir,
         })
+    }
+}
+
+fn reject_control_paths<'a>(paths: impl IntoIterator<Item = &'a Path>) -> Result<(), String> {
+    if paths.into_iter().any(path_contains_control) {
+        return Err("service paths must not contain control characters".into());
+    }
+    Ok(())
+}
+
+fn path_contains_control(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        path.to_str().is_none() || path.as_os_str().as_bytes().iter().any(u8::is_ascii_control)
+    }
+    #[cfg(not(unix))]
+    {
+        path.to_str()
+            .is_none_or(|value| value.chars().any(char::is_control))
     }
 }
 
@@ -118,7 +134,8 @@ pub fn definition_path(manager: Manager) -> Result<PathBuf, String> {
     // passwd entry when `HOME` is unset (which happens in some service and cron
     // contexts, where "HOME is not set" was a confusing way to fail), and it
     // resolves on Windows too, where a raw `HOME` read always came up empty.
-    let home = dirs::home_dir().ok_or_else(|| "cannot determine your home directory".to_string())?;
+    let home =
+        dirs::home_dir().ok_or_else(|| "cannot determine your home directory".to_string())?;
     Ok(match manager {
         Manager::SystemdUser => home
             .join(".config")
@@ -143,26 +160,34 @@ After=network.target
 [Service]
 ExecStart={exe} start --config {config}
 WorkingDirectory={workdir}
+UMask=0077
 Restart=on-failure
 RestartSec=2
 
 [Install]
 WantedBy=default.target
 "#,
-        exe = systemd_quote(&plan.exe),
-        config = systemd_quote(&plan.config),
-        workdir = plan.workdir.display(),
+        exe = systemd_quote(&plan.exe, true),
+        config = systemd_quote(&plan.config, true),
+        workdir = systemd_quote(&plan.workdir, false),
     )
 }
 
 /// Quote a path for a systemd ExecStart line (double quotes, escape embedded
 /// quotes/backslashes). systemd's quoting rules accept this for paths.
-fn systemd_quote(p: &Path) -> String {
+fn systemd_quote(p: &Path, escape_dollar: bool) -> String {
     let s = p.display().to_string();
+    let mut escaped = s
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('%', "%%");
+    if escape_dollar {
+        escaped = escaped.replace('$', "$$");
+    }
     if s.contains(' ') || s.contains('"') || s.contains('\\') {
-        format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+        format!("\"{escaped}\"")
     } else {
-        s
+        escaped
     }
 }
 
@@ -208,7 +233,9 @@ pub fn launchd_plist(plan: &ServicePlan) -> String {
 }
 
 fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 /// The launchd domain every `launchctl` invocation below is addressed to:
@@ -444,6 +471,7 @@ mod tests {
         assert!(unit.contains("WorkingDirectory=/home/u/tracker"));
         assert!(unit.contains("WantedBy=default.target"));
         assert!(unit.contains("Restart=on-failure"));
+        assert!(unit.contains("UMask=0077"));
     }
 
     #[test]
@@ -458,6 +486,45 @@ mod tests {
             ),
             "unit was:\n{unit}"
         );
+    }
+
+    #[test]
+    fn systemd_unit_escapes_expansion_characters() {
+        let mut p = plan();
+        p.exe = PathBuf::from("/home/u/bin/$lific%bin");
+        p.config = PathBuf::from("/home/u/config/$env%file.toml");
+        p.workdir = PathBuf::from("/home/u/$data%dir");
+        let unit = systemd_unit(&p);
+        assert!(
+            unit.contains("/home/u/bin/$$lific%%bin"),
+            "unit was:\n{unit}"
+        );
+        assert!(
+            unit.contains("/home/u/config/$$env%%file.toml"),
+            "unit was:\n{unit}"
+        );
+        assert!(unit.contains("/home/u/$data%%dir"), "unit was:\n{unit}");
+    }
+
+    #[test]
+    fn config_path_with_control_character_is_rejected() {
+        // Validate the path before touching the filesystem: Windows cannot
+        // create a filename containing a newline in order to reach the same
+        // check through `canonicalize`.
+        let config = PathBuf::from(format!("lific_svc_control_{}\n", std::process::id()));
+        let error = reject_control_paths([config.as_path()]).unwrap_err();
+        assert!(error.contains("control characters"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_service_path_is_rejected() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = std::path::PathBuf::from(std::ffi::OsString::from_vec(vec![
+            b'/', b't', b'm', b'p', b'/', 0xff,
+        ]));
+        assert!(path_contains_control(&path));
     }
 
     #[test]
@@ -499,10 +566,9 @@ mod tests {
 
     #[test]
     fn for_config_file_errors_on_missing_config() {
-        let err = ServicePlan::for_config_file(Path::new(
-            "/tmp/nonexistent_lific_dir_12345/lific.toml",
-        ))
-        .unwrap_err();
+        let err =
+            ServicePlan::for_config_file(Path::new("/tmp/nonexistent_lific_dir_12345/lific.toml"))
+                .unwrap_err();
         assert!(err.contains("cannot resolve config path"), "got: {err}");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,42 @@ use tracing::info;
 
 const CONFIG_FILENAME: &str = "lific.toml";
 
+fn tighten_config_permissions(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let metadata = std::fs::symlink_metadata(path)?;
+        if metadata.file_type().is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "configuration path must not be a symlink",
+            ));
+        }
+        if metadata.mode() & 0o077 != 0 {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn read_config_file(path: &Path) -> std::io::Result<String> {
+    #[cfg(unix)]
+    {
+        use std::io::Read;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).custom_flags(libc::O_NOFOLLOW);
+        let mut file = options.open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        Ok(contents)
+    }
+    #[cfg(not(unix))]
+    std::fs::read_to_string(path)
+}
+
 /// A config file was found but could not be honored.
 ///
 /// This is always fatal. Booting on defaults because a file failed to parse
@@ -323,10 +359,18 @@ impl Config {
         let candidates = Self::candidate_paths(explicit_path);
 
         for path in &candidates {
-            if path.exists() {
-                match std::fs::read_to_string(path) {
+            match std::fs::symlink_metadata(path) {
+                Ok(_) => match read_config_file(path) {
                     Ok(contents) => match toml::from_str::<Config>(&contents) {
                         Ok(mut config) => {
+                            if let Err(source) = tighten_config_permissions(path)
+                                && source.kind() != std::io::ErrorKind::PermissionDenied
+                            {
+                                return Err(ConfigError::Read {
+                                    path: path.clone(),
+                                    source,
+                                });
+                            }
                             info!(path = %path.display(), "loaded config");
                             // Anchor a relative database path to the config
                             // file's own directory, not the process cwd —
@@ -355,6 +399,13 @@ impl Config {
                             source,
                         });
                     }
+                },
+                Err(source) if source.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(source) => {
+                    return Err(ConfigError::Read {
+                        path: path.clone(),
+                        source,
+                    });
                 }
             }
         }
@@ -533,6 +584,55 @@ enabled = false
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.database.path, PathBuf::from(ABSOLUTE_DB_PATH));
         assert!(!config.backup.enabled);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loading_config_tightens_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("lific.toml");
+        std::fs::write(&path, Config::default_toml()).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        Config::load(Some(&path)).unwrap();
+
+        assert_eq!(std::fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loading_config_rejects_symlink_without_chmodding_target() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target.toml");
+        let link = tmp.path().join("lific.toml");
+        std::fs::write(&target, Config::default_toml()).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        symlink(&target, &link).unwrap();
+
+        assert!(Config::load(Some(&link)).is_err());
+        assert_eq!(
+            std::fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loading_config_rejects_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let link = tmp.path().join("lific.toml");
+        symlink(tmp.path().join("missing.toml"), &link).unwrap();
+
+        assert!(matches!(
+            Config::load(Some(&link)),
+            Err(ConfigError::Read { .. })
+        ));
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -55,9 +55,7 @@ impl DbPool {
         self.export_slots
             .clone()
             .try_acquire_owned()
-            .map_err(|_| {
-                LificError::TooManyRequests("too many exports are already running".into())
-            })
+            .map_err(|_| LificError::TooManyRequests("too many exports are already running".into()))
     }
 
     /// The database file this pool was opened from. Callers that need to
@@ -238,10 +236,15 @@ pub fn open_memory() -> Result<DbPool, LificError> {
 /// Open (or create) the SQLite database, run migrations, and return a pool.
 pub fn open(path: &Path) -> Result<DbPool, LificError> {
     disable_sqlite_memstatus();
+    secure_parent(path)?;
+    ensure_private_file(path)?;
     // Writer connection — runs migrations
     let writer = Connection::open(path)?;
+    secure_file(path)?;
     apply_pragmas(&writer)?;
+    secure_sidecars(path)?;
     migrate::run(&writer)?;
+    secure_sidecars(path)?;
 
     // LIF-155: clear any actor left over from a previous process (the
     // `_actor_state` row persists). Writes before the first request stamp
@@ -269,6 +272,97 @@ pub fn open(path: &Path) -> Result<DbPool, LificError> {
     })
 }
 
+fn ensure_private_file(path: &Path) -> Result<(), LificError> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW).mode(0o600);
+    }
+    match options.open(path) {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+                LificError::Internal(format!("inspect database file: {error}"))
+            })?;
+            if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+                return Err(LificError::Internal(
+                    "database path must be a regular file, not a link".into(),
+                ));
+            }
+            #[cfg(unix)]
+            if std::os::unix::fs::MetadataExt::nlink(&metadata) != 1 {
+                return Err(LificError::Internal(
+                    "database path must not have multiple hard links".into(),
+                ));
+            }
+            Ok(())
+        }
+        Err(error) => Err(LificError::Internal(format!(
+            "create database file: {error}"
+        ))),
+    }
+}
+
+fn secure_parent(path: &Path) -> Result<(), LificError> {
+    let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) else {
+        return Ok(());
+    };
+    #[cfg(unix)]
+    let existed = parent.exists();
+    std::fs::create_dir_all(parent)
+        .map_err(|error| LificError::Internal(format!("create database directory: {error}")))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let metadata = parent
+            .symlink_metadata()
+            .map_err(|error| LificError::Internal(format!("inspect database directory: {error}")))?
+            ;
+        if metadata.file_type().is_symlink() {
+            return Err(LificError::Internal(
+                "database directory must not be a symlink".into(),
+            ));
+        }
+        let mode = metadata.mode() & 0o777;
+        if existed && mode & 0o022 != 0 {
+            return Err(LificError::Internal(format!(
+                "database directory {} is writable by group/others; remove group/other write permissions or choose a private data directory",
+                parent.display()
+            )));
+        }
+        if !existed {
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(
+                |error| LificError::Internal(format!("secure database directory: {error}")),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn secure_file(_path: &Path) -> Result<(), LificError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(_path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|error| LificError::Internal(format!("secure database file: {error}")))?;
+    }
+    Ok(())
+}
+
+fn secure_sidecars(path: &Path) -> Result<(), LificError> {
+    for suffix in ["-wal", "-shm"] {
+        let mut sidecar = path.as_os_str().to_os_string();
+        sidecar.push(suffix);
+        let sidecar = PathBuf::from(sidecar);
+        if sidecar.exists() {
+            secure_file(&sidecar)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,5 +387,52 @@ mod tests {
         assert!(matches!(result, Err(LificError::BadRequest(_))));
         let conn = db.read().unwrap();
         assert!(queries::list_projects(&conn).unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_parent_allows_traversal_but_rejects_shared_writes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("lific.db");
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        secure_parent(&db_path).unwrap();
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o775)).unwrap();
+        assert!(secure_parent(&db_path).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_parent_rejects_symlinked_data_directory() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&real).unwrap();
+        symlink(&real, &link).unwrap();
+
+        assert!(secure_parent(&link.join("lific.db")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_private_file_rejects_symlinks_and_hard_links() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let original = dir.path().join("original.db");
+        ensure_private_file(&original).unwrap();
+
+        let symlinked = dir.path().join("symlinked.db");
+        symlink(&original, &symlinked).unwrap();
+        assert!(ensure_private_file(&symlinked).is_err());
+
+        let linked = dir.path().join("linked.db");
+        std::fs::hard_link(&original, &linked).unwrap();
+        assert!(ensure_private_file(&linked).is_err());
     }
 }

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -16,8 +16,8 @@ use crate::db::models::{
 };
 use crate::error::LificError;
 
-/// Insert a new attachment metadata row and return it. The caller has already
-/// written the bytes to the content-addressed store and computed `sha256`.
+/// Insert a new attachment metadata row and return it. The caller coordinates
+/// this row with the content-addressed blob write in its database transaction.
 pub fn create_attachment(
     conn: &Connection,
     sha256: &str,
@@ -146,6 +146,27 @@ pub fn links_for_attachment(
 pub fn delete_attachment(conn: &Connection, id: i64) -> Result<bool, LificError> {
     let changed = conn.execute("DELETE FROM attachments WHERE id = ?1", params![id])?;
     Ok(changed > 0)
+}
+
+/// Delete an unlinked attachment only if it is still unlinked on this writer
+/// connection. The returned hash is safe for the caller to garbage-collect
+/// after checking whether another row still shares it.
+pub fn delete_orphan_attachment(
+    conn: &Connection,
+    id: i64,
+) -> Result<Option<String>, LificError> {
+    conn.query_row(
+        "DELETE FROM attachments
+         WHERE id = ?1
+           AND NOT EXISTS (
+               SELECT 1 FROM attachment_links WHERE attachment_id = ?1
+           )
+         RETURNING sha256",
+        params![id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(Into::into)
 }
 
 /// How many `attachments` rows still reference a given content hash. Used by
@@ -417,12 +438,10 @@ fn attachment_allowed_for_project(
 // ── Orphan GC ────────────────────────────────────────────────
 
 /// One collectable orphan: an attachment row with zero links, older than the
-/// grace window. Carries `sha256` so the sweep can decide whether to delete the
-/// sidecar file (only when no OTHER row shares the hash).
+/// grace window.
 #[derive(Debug, Clone)]
 pub struct OrphanAttachment {
     pub id: i64,
-    pub sha256: String,
 }
 
 /// Find attachments with no links whose `created_at` is older than
@@ -434,7 +453,7 @@ pub fn find_orphans(
     grace_seconds: i64,
 ) -> Result<Vec<OrphanAttachment>, LificError> {
     let mut stmt = conn.prepare_cached(
-        "SELECT a.id, a.sha256
+        "SELECT a.id
          FROM attachments a
          LEFT JOIN attachment_links l ON l.attachment_id = a.id
          WHERE l.attachment_id IS NULL
@@ -453,7 +472,6 @@ pub fn find_orphans(
     let rows = stmt.query_map(params![modifier], |row| {
         Ok(OrphanAttachment {
             id: row.get(0)?,
-            sha256: row.get(1)?,
         })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
@@ -1498,6 +1516,18 @@ mod tests {
         let found = find_orphans(&conn, -1).unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].id, orphan.id);
+    }
+
+    #[test]
+    fn orphan_delete_rechecks_links_on_writer() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        let issue = seed_issue(&conn);
+        let attachment = create_attachment(&conn, "race", "a.png", "image/png", 1, None).unwrap();
+        link_attachment(&conn, attachment.id, AttachmentEntity::Issue, issue).unwrap();
+
+        assert_eq!(delete_orphan_attachment(&conn, attachment.id).unwrap(), None);
+        assert!(get_attachment(&conn, attachment.id).is_ok());
     }
 
     #[test]

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -228,8 +228,29 @@ pub fn write_dump(pool: &DbPool, db_path: &Path, out_path: &Path) -> Result<Mani
                 let entry = entry
                     .map_err(|e| LificError::Internal(format!("read attachments entry: {e}")))?;
                 let path = entry.path();
-                if !path.is_file() {
+                if !entry
+                    .file_type()
+                    .map_err(|e| LificError::Internal(format!("inspect attachment entry: {e}")))?
+                    .is_file()
+                {
                     continue;
+                }
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::MetadataExt;
+                    if entry
+                        .metadata()
+                        .map_err(|e| {
+                            LificError::Internal(format!("inspect attachment metadata: {e}"))
+                        })?
+                        .nlink()
+                        != 1
+                    {
+                        return Err(LificError::Internal(format!(
+                            "attachment entry is hard-linked: {}",
+                            path.display()
+                        )));
+                    }
                 }
                 if path.extension().and_then(|e| e.to_str()) == Some("tmp") {
                     continue;
@@ -997,6 +1018,30 @@ mod tests {
         symlink(&real_parent, &parent_link).unwrap();
         let nested = parent_link.join("nested.tar.gz");
         assert!(write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &nested).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dump_rejects_symlink_and_hard_linked_attachments() {
+        use std::os::unix::fs::symlink;
+
+        let (dir_tmp, db_path) = seed_data_dir("unsafe-attachments");
+        let dir = dir_tmp.path();
+        let attachments = dir.join("attachments");
+        let name = "c".repeat(64);
+        let entry = attachments.join(&name);
+        let outside = dir.join("outside");
+        fs::write(&outside, b"outside").unwrap();
+        symlink(&outside, &entry).unwrap();
+
+        let out = dir.join("symlink.tar.gz");
+        write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap();
+        assert!(!archive_entries(&out).contains(&format!("attachments/{name}")));
+
+        fs::remove_file(&entry).unwrap();
+        fs::hard_link(&outside, &entry).unwrap();
+        let out = dir.join("hardlink.tar.gz");
+        assert!(write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).is_err());
     }
 
     #[test]

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -13,10 +13,14 @@
 //! it back into a data dir. The interval backup task (`src/backup.rs`) emits
 //! the *same* artifact via [`write_dump`], so there is exactly one backup shape.
 
-use std::io::Read;
+#[cfg(unix)]
+use std::fs;
+use std::fs::File;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use fs2::FileExt;
 
 use crate::db::DbPool;
 use crate::error::LificError;
@@ -72,33 +76,111 @@ fn attachments_dir_for(db_path: &Path) -> PathBuf {
 
 /// Take a consistent snapshot of the live DB into `dest` using `VACUUM INTO`.
 ///
-/// `VACUUM INTO` runs on a read connection, holds no long writer lock, and
-/// compacts + snapshots in one step — safe while the server is running. The
-/// destination must not already exist (SQLite requirement).
-fn snapshot_db(pool: &DbPool, dest: &Path) -> Result<(), LificError> {
-    if dest.exists() {
-        std::fs::remove_file(dest)
-            .map_err(|e| LificError::Internal(format!("clear snapshot target: {e}")))?;
-    }
+/// The SQLite online backup API runs on a read connection, holds no long
+/// writer lock, and snapshots into the already-reserved staging file — safe
+/// while the server is running.
+fn snapshot_db(pool: &DbPool, dest: &TempFile) -> Result<(), LificError> {
     let conn = pool.read()?;
-    // Parameterized VACUUM INTO with the destination path as a bound value.
-    conn.execute("VACUUM INTO ?1", [&dest.to_string_lossy()])
-        .map_err(|e| LificError::Internal(format!("VACUUM INTO snapshot failed: {e}")))?;
+    let mut destination = rusqlite::Connection::open_with_flags(
+        dest.path(),
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+            | rusqlite::OpenFlags::SQLITE_OPEN_NOFOLLOW,
+    )
+    .map_err(|e| LificError::Internal(format!("open SQLite staging file: {e}")))?;
+    let backup = rusqlite::backup::Backup::new(&conn, &mut destination)
+        .map_err(|e| LificError::Internal(format!("create SQLite backup: {e}")))?;
+    backup
+        .run_to_completion(100, std::time::Duration::ZERO, None)
+        .map_err(|e| LificError::Internal(format!("SQLite backup failed: {e}")))?;
     Ok(())
 }
 
-/// Set 0600 permissions on a file (owner-only) on Unix. No-op elsewhere.
-fn set_owner_only(path: &Path) -> std::io::Result<()> {
+/// Set 0600 permissions on an open file (owner-only) on Unix. No-op elsewhere.
+fn set_owner_only(file: &File) -> std::io::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
     #[cfg(not(unix))]
     {
-        let _ = path;
+        let _ = file;
     }
     Ok(())
+}
+
+struct TempFile {
+    file: File,
+    path: PathBuf,
+}
+
+struct StagingLock {
+    _file: File,
+}
+
+impl StagingLock {
+    fn create(path: &Path) -> Result<Self, LificError> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .map_err(|error| LificError::Internal(format!("create dump lock: {error}")))?;
+        file.try_lock_exclusive()
+            .map_err(|error| LificError::Internal(format!("lock dump staging: {error}")))?;
+        Ok(Self { _file: file })
+    }
+}
+
+/// Return whether another process currently owns a dump staging lock.
+pub(crate) fn staging_is_locked(path: &Path) -> bool {
+    let lock = path.join("lock");
+    let Ok(file) = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock)
+    else {
+        return true;
+    };
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            false
+        }
+        Err(_) => true,
+    }
+}
+
+fn refresh_activity(file: &File) -> std::io::Result<()> {
+    file.set_modified(std::time::SystemTime::now())
+}
+
+impl TempFile {
+    fn create(path: PathBuf) -> Result<Self, LificError> {
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        let file = options.open(&path).map_err(|error| {
+            LificError::Internal(format!("create secure staging file: {error}"))
+        })?;
+        Ok(Self { file, path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
 }
 
 /// Write a self-contained dump archive to `out_path`.
@@ -111,19 +193,29 @@ fn set_owner_only(path: &Path) -> std::io::Result<()> {
 ///
 /// Returns the [`Manifest`] that was written, so callers can log/print it.
 pub fn write_dump(pool: &DbPool, db_path: &Path, out_path: &Path) -> Result<Manifest, LificError> {
-    // Snapshot the DB to a temp file next to the output, so the archive holds a
-    // consistent point-in-time copy rather than a possibly-mid-write live file.
-    let tmp_db = out_path.with_extension("dbsnapshot.tmp");
+    let parent = out_path.parent().unwrap_or_else(|| Path::new("."));
+    validate_dump_destination(out_path)?;
+    let staging = tempfile::Builder::new()
+        .prefix(".lific-dump-")
+        .tempdir_in(parent)
+        .map_err(|e| LificError::Internal(format!("create dump staging directory: {e}")))?;
+    let _lock = StagingLock::create(&staging.path().join("lock"))?;
+    let activity = TempFile::create(staging.path().join("activity"))?;
+    refresh_activity(&activity.file)
+        .map_err(|e| LificError::Internal(format!("mark dump staging active: {e}")))?;
+    // The private staging directory prevents another user of a shared output
+    // directory from swapping either pathname while its open handle is live.
+    let tmp_db = TempFile::create(staging.path().join("dbsnapshot"))?;
     snapshot_db(pool, &tmp_db)?;
+    refresh_activity(&activity.file)
+        .map_err(|e| LificError::Internal(format!("refresh dump staging activity: {e}")))?;
 
-    // Staging path for the archive itself; the closure writes here and
-    // atomically renames into place on success. Declared out here so the
-    // error path below can clean up a partial archive (LIF-329).
-    let tmp_archive = out_path.with_extension("archive.tmp");
+    let tmp_archive = TempFile::create(staging.path().join("archive"))?;
 
-    // Guard: always clean the temp snapshot even on the error paths below.
-    let result = (|| {
-        let db_size_bytes = std::fs::metadata(&tmp_db).map(|m| m.len()).unwrap_or(0);
+    (|| {
+        let db_size_bytes = std::fs::metadata(tmp_db.path())
+            .map(|m| m.len())
+            .unwrap_or(0);
 
         // Gather attachment blobs (skip .tmp in-progress writes).
         let attachments_dir = attachments_dir_for(db_path);
@@ -145,6 +237,12 @@ pub fn write_dump(pool: &DbPool, db_path: &Path, out_path: &Path) -> Result<Mani
                 let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                     continue;
                 };
+                validate_attachment_entry(&format!("{ARCHIVE_ATTACHMENTS_PREFIX}{name}"))
+                    .map_err(|_| {
+                        LificError::Internal(format!(
+                            "invalid attachment filename in store: {name}"
+                        ))
+                    })?;
                 let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
                 attachment_bytes += size;
                 blobs.push((name.to_string(), path.clone(), size));
@@ -165,22 +263,26 @@ pub fn write_dump(pool: &DbPool, db_path: &Path, out_path: &Path) -> Result<Mani
         // Build the archive into a temp file, then atomically rename into place
         // so a partial write is never observed at the final path.
         {
-            let file = std::fs::File::create(&tmp_archive)
-                .map_err(|e| LificError::Internal(format!("create archive: {e}")))?;
+            let file = tmp_archive
+                .file
+                .try_clone()
+                .map_err(|e| LificError::Internal(format!("open archive staging handle: {e}")))?;
             let enc = flate2::write::GzEncoder::new(file, flate2::Compression::default());
             let mut tar = tar::Builder::new(enc);
 
             // manifest.json
             append_bytes(&mut tar, ARCHIVE_MANIFEST_NAME, &manifest_json)?;
             // lific.db (from the snapshot file)
-            tar.append_path_with_name(&tmp_db, ARCHIVE_DB_NAME)
+            tar.append_path_with_name(tmp_db.path(), ARCHIVE_DB_NAME)
                 .map_err(|e| LificError::Internal(format!("append db to archive: {e}")))?;
             // attachments/<sha256>
             for (name, path, _size) in &blobs {
-                let entry_name = format!("{ARCHIVE_ATTACHMENTS_PREFIX}{name}");
-                tar.append_path_with_name(path, &entry_name).map_err(|e| {
-                    LificError::Internal(format!("append attachment {name}: {e}"))
+                refresh_activity(&activity.file).map_err(|e| {
+                    LificError::Internal(format!("refresh dump staging activity: {e}"))
                 })?;
+                let entry_name = format!("{ARCHIVE_ATTACHMENTS_PREFIX}{name}");
+                tar.append_path_with_name(path, &entry_name)
+                    .map_err(|e| LificError::Internal(format!("append attachment {name}: {e}")))?;
             }
 
             let enc = tar
@@ -190,22 +292,73 @@ pub fn write_dump(pool: &DbPool, db_path: &Path, out_path: &Path) -> Result<Mani
                 .map_err(|e| LificError::Internal(format!("finalize gzip: {e}")))?;
         }
 
-        set_owner_only(&tmp_archive)
+        tmp_archive
+            .file
+            .sync_all()
+            .map_err(|e| LificError::Internal(format!("sync archive: {e}")))?;
+        set_owner_only(&tmp_archive.file)
             .map_err(|e| LificError::Internal(format!("chmod archive: {e}")))?;
-        std::fs::rename(&tmp_archive, out_path)
+        std::fs::rename(tmp_archive.path(), out_path)
             .map_err(|e| LificError::Internal(format!("finalize archive: {e}")))?;
 
         Ok(manifest)
-    })();
+    })()
+}
 
-    let _ = std::fs::remove_file(&tmp_db);
-    if result.is_err() {
-        // A failure after the archive staging file was created would otherwise
-        // strand a partial `*.archive.tmp` that rotation never touches
-        // (LIF-329).
-        let _ = std::fs::remove_file(&tmp_archive);
+fn validate_dump_destination(out_path: &Path) -> Result<(), LificError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let parent = out_path.parent().unwrap_or_else(|| Path::new("."));
+        let parent_metadata = std::fs::symlink_metadata(parent)
+            .map_err(|e| LificError::Internal(format!("inspect dump destination: {e}")))?;
+        if parent_metadata.file_type().is_symlink() {
+            return Err(LificError::Internal("dump destination parent is a symlink".into()));
+        }
+        let mode = parent_metadata.mode();
+        if mode & 0o1000 == 0 && mode & 0o022 != 0 {
+            return Err(LificError::Internal(
+                "dump destination parent is group/world-writable without sticky protection".into(),
+            ));
+        }
+        if let Ok(metadata) = std::fs::symlink_metadata(out_path)
+            && (metadata.file_type().is_symlink() || metadata.nlink() > 1)
+        {
+            return Err(LificError::Internal(
+                "dump destination must not be a symlink or hard link".into(),
+            ));
+        }
     }
-    result
+    #[cfg(not(unix))]
+    let _ = out_path;
+    Ok(())
+}
+
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(path)?;
+    set_owner_only(&file)?;
+    file.write_all(bytes)?;
+    Ok(())
+}
+
+fn set_owner_only_dir(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
 }
 
 /// Append raw bytes as a tar entry with the given name.
@@ -312,11 +465,14 @@ fn validate_attachment_entry(name: &str) -> Result<String, LificError> {
         .ok_or_else(|| LificError::BadRequest(format!("unexpected archive entry: {name}")))?;
     // Reject empty, nested paths, parent refs, absolute paths, or anything with
     // a separator — a blob name is a bare sha256 hex string.
-    if rest.is_empty()
+    if rest.len() != 64
         || rest.contains('/')
         || rest.contains('\\')
         || rest.contains("..")
         || rest.starts_with('.')
+        || !rest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
     {
         return Err(LificError::BadRequest(format!(
             "rejected attachment entry (path traversal or invalid name): {name}"
@@ -360,9 +516,7 @@ pub fn inspect_archive(archive: &Path) -> Result<Manifest, LificError> {
         }
     }
     if !has_db {
-        return Err(LificError::BadRequest(
-            "archive is missing lific.db".into(),
-        ));
+        return Err(LificError::BadRequest("archive is missing lific.db".into()));
     }
     Ok(manifest)
 }
@@ -399,7 +553,9 @@ fn read_manifest(archive: &Path) -> Result<Manifest, LificError> {
 /// may still be running (best-effort — see command help).
 fn wal_is_hot(db_path: &Path) -> bool {
     let wal = PathBuf::from(format!("{}-wal", db_path.display()));
-    std::fs::metadata(&wal).map(|m| m.len() > 0).unwrap_or(false)
+    std::fs::metadata(&wal)
+        .map(|m| m.len() > 0)
+        .unwrap_or(false)
 }
 
 /// Run `lific restore`: validate the archive, then stage-extract it into the
@@ -428,46 +584,43 @@ pub fn run_restore(
         .filter(|p| !p.as_os_str().is_empty())
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
+    #[cfg(unix)]
+    let data_dir_existed = data_dir.exists();
     std::fs::create_dir_all(&data_dir)
         .map_err(|e| LificError::Internal(format!("create data dir: {e}")))?;
-
-    // Existing-DB guard.
-    let mut moved_existing_to = None;
-    if db_path.exists() {
-        if !force {
-            return Err(LificError::Conflict(format!(
-                "{} already exists; pass --force to restore over it (stop the server first)",
-                db_path.display()
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let mode = fs::metadata(&data_dir)
+            .map_err(|e| LificError::Internal(format!("inspect data dir: {e}")))?
+            .mode()
+            & 0o777;
+        if data_dir_existed && mode & 0o022 != 0 {
+            return Err(LificError::Internal(format!(
+                "data directory {} is writable by group/others; remove group/other write permissions before restoring",
+                data_dir.display()
             )));
         }
-        // --force: move the existing DB aside rather than deleting, so a
-        // mistaken restore is recoverable. First checkpoint its WAL into the
-        // main file so the moved-aside `.db` is self-contained (the WAL/SHM are
-        // named after the live path and won't follow a rename). Best-effort —
-        // if the server holds the db open we still move what's on disk.
-        checkpoint_db_file(db_path);
-        let ts = archive_timestamp();
-        let suffix = format!("pre-restore-{ts}");
-        let dest = PathBuf::from(format!("{}.{suffix}", db_path.display()));
-        std::fs::rename(db_path, &dest)
-            .map_err(|e| LificError::Internal(format!("move existing db aside: {e}")))?;
-        // Discard the now-redundant WAL/SHM (already folded into the moved db).
-        for ext in ["-wal", "-shm"] {
-            let side = PathBuf::from(format!("{}{ext}", db_path.display()));
-            let _ = std::fs::remove_file(&side);
+        if !data_dir_existed {
+            fs::set_permissions(&data_dir, fs::Permissions::from_mode(0o700))
+                .map_err(|e| LificError::Internal(format!("secure data dir: {e}")))?;
         }
-        moved_existing_to = Some(dest);
     }
 
     // Staged extraction: unpack into a temp dir next to the data dir, then move
     // into place. A failure mid-extract leaves the original data dir untouched.
-    let staging = data_dir.join(format!(".lific-restore-{}", archive_timestamp()));
-    if staging.exists() {
-        let _ = std::fs::remove_dir_all(&staging);
-    }
-    std::fs::create_dir_all(staging.join("attachments"))
+    let staging = tempfile::Builder::new()
+        .prefix(".lific-restore-")
+        .tempdir_in(&data_dir)
         .map_err(|e| LificError::Internal(format!("create staging dir: {e}")))?;
+    std::fs::create_dir_all(staging.path().join("attachments"))
+        .map_err(|e| LificError::Internal(format!("create staging dir: {e}")))?;
+    set_owner_only_dir(staging.path())
+        .map_err(|e| LificError::Internal(format!("secure restore staging dir: {e}")))?;
+    set_owner_only_dir(&staging.path().join("attachments"))
+        .map_err(|e| LificError::Internal(format!("secure restore attachments dir: {e}")))?;
 
+    let mut moved_existing_to: Option<PathBuf> = None;
     let extract = (|| -> Result<u64, LificError> {
         let file = std::fs::File::open(archive)
             .map_err(|e| LificError::BadRequest(format!("open archive: {e}")))?;
@@ -490,14 +643,14 @@ pub fn run_restore(
                 entry
                     .read_to_end(&mut buf)
                     .map_err(|e| LificError::BadRequest(format!("read manifest: {e}")))?;
-                std::fs::write(staging.join(ARCHIVE_MANIFEST_NAME), &buf)
+                write_owner_only(&staging.path().join(ARCHIVE_MANIFEST_NAME), &buf)
                     .map_err(|e| LificError::Internal(format!("write manifest: {e}")))?;
             } else if name == ARCHIVE_DB_NAME {
                 let mut buf = Vec::new();
                 entry
                     .read_to_end(&mut buf)
                     .map_err(|e| LificError::BadRequest(format!("read db from archive: {e}")))?;
-                std::fs::write(staging.join(ARCHIVE_DB_NAME), &buf)
+                write_owner_only(&staging.path().join(ARCHIVE_DB_NAME), &buf)
                     .map_err(|e| LificError::Internal(format!("write db: {e}")))?;
             } else if name.starts_with(ARCHIVE_ATTACHMENTS_PREFIX) {
                 let bare = validate_attachment_entry(&name)?;
@@ -505,7 +658,7 @@ pub fn run_restore(
                 entry
                     .read_to_end(&mut buf)
                     .map_err(|e| LificError::BadRequest(format!("read attachment: {e}")))?;
-                std::fs::write(staging.join("attachments").join(&bare), &buf)
+                write_owner_only(&staging.path().join("attachments").join(&bare), &buf)
                     .map_err(|e| LificError::Internal(format!("write attachment: {e}")))?;
                 attachment_count += 1;
             } else {
@@ -514,10 +667,8 @@ pub fn run_restore(
                 )));
             }
         }
-        if !staging.join(ARCHIVE_DB_NAME).exists() {
-            return Err(LificError::BadRequest(
-                "archive is missing lific.db".into(),
-            ));
+        if !staging.path().join(ARCHIVE_DB_NAME).exists() {
+            return Err(LificError::BadRequest("archive is missing lific.db".into()));
         }
         Ok(attachment_count)
     })();
@@ -528,7 +679,6 @@ pub fn run_restore(
             // Roll back: discard staging; restore the moved-aside DB if any.
             // The moved db is self-contained (WAL was checkpointed before the
             // move), so a bare rename back is enough.
-            let _ = std::fs::remove_dir_all(&staging);
             return Err(match &moved_existing_to {
                 Some(moved) => rollback_moved_db(moved, db_path, e),
                 None => e,
@@ -536,20 +686,106 @@ pub fn run_restore(
         }
     };
 
-    // Move restored files into place. DB first, then swap the attachments dir.
-    std::fs::rename(staging.join(ARCHIVE_DB_NAME), db_path)
-        .map_err(|e| LificError::Internal(format!("install restored db: {e}")))?;
-    set_owner_only(db_path)
-        .map_err(|e| LificError::Internal(format!("chmod restored db: {e}")))?;
-
-    let attachments_dest = attachments_dir_for(db_path);
-    if attachments_dest.exists() {
-        let _ = std::fs::remove_dir_all(&attachments_dest);
+    // Existing-DB guard. Prepare and validate the complete staging tree before
+    // moving the live database, so a staging failure cannot leave db_path
+    // absent.
+    if db_path.exists() {
+        if !force {
+            return Err(LificError::Conflict(format!(
+                "{} already exists; pass --force to restore over it (stop the server first)",
+                db_path.display()
+            )));
+        }
+        checkpoint_db_file(db_path);
+        let suffix = format!("pre-restore-{}", archive_timestamp());
+        let dest = PathBuf::from(format!("{}.{suffix}", db_path.display()));
+        std::fs::rename(db_path, &dest)
+            .map_err(|e| LificError::Internal(format!("move existing db aside: {e}")))?;
+        for ext in ["-wal", "-shm"] {
+            let side = PathBuf::from(format!("{}{ext}", db_path.display()));
+            let _ = std::fs::remove_file(&side);
+        }
+        moved_existing_to = Some(dest);
     }
-    std::fs::rename(staging.join("attachments"), &attachments_dest)
-        .map_err(|e| LificError::Internal(format!("install restored attachments: {e}")))?;
 
-    let _ = std::fs::remove_dir_all(&staging);
+    // Move restored files into place. Keep the old attachments directory until
+    // the new one is installed so a later failure can restore both data sets.
+    let attachments_dest = attachments_dir_for(db_path);
+    let attachments_backup = if attachments_dest.exists() {
+        let backup = data_dir.join(format!(".lific-restore-attachments-{}", archive_timestamp()));
+        if let Err(error) = std::fs::rename(&attachments_dest, &backup) {
+            let cause = LificError::Internal(format!("stage existing attachments: {error}"));
+            return Err(match &moved_existing_to {
+                Some(moved) => rollback_moved_db(moved, db_path, cause),
+                None => cause,
+            });
+        }
+        Some(backup)
+    } else {
+        None
+    };
+    let manifest_dest = db_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .join(ARCHIVE_MANIFEST_NAME);
+    let manifest_backup = if manifest_dest.exists() {
+        let backup = data_dir.join(format!(".lific-restore-manifest-{}", archive_timestamp()));
+        if let Err(error) = std::fs::rename(&manifest_dest, &backup) {
+            let cause = LificError::Internal(format!("stage existing manifest: {error}"));
+            if let Some(backup) = &attachments_backup {
+                let _ = std::fs::rename(backup, &attachments_dest);
+            }
+            return Err(match &moved_existing_to {
+                Some(moved) => rollback_moved_db(moved, db_path, cause),
+                None => cause,
+            });
+        }
+        Some(backup)
+    } else {
+        None
+    };
+    let install = (|| -> Result<(), LificError> {
+        std::fs::rename(staging.path().join(ARCHIVE_DB_NAME), db_path)
+            .map_err(|e| LificError::Internal(format!("install restored db: {e}")))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(db_path, std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| LificError::Internal(format!("chmod restored db: {e}")))?;
+        }
+        std::fs::rename(staging.path().join("attachments"), &attachments_dest)
+            .map_err(|e| LificError::Internal(format!("install restored attachments: {e}")))?;
+        std::fs::rename(
+            staging.path().join(ARCHIVE_MANIFEST_NAME),
+            &manifest_dest,
+        )
+        .map_err(|e| LificError::Internal(format!("install restored manifest: {e}")))?;
+        Ok(())
+    })();
+    if let Err(error) = install {
+        if db_path.exists() {
+            let _ = std::fs::remove_file(db_path);
+        }
+        if let Some(backup) = &attachments_backup {
+            let _ = std::fs::remove_dir_all(&attachments_dest);
+            let _ = std::fs::rename(backup, &attachments_dest);
+        }
+        if let Some(backup) = &manifest_backup {
+            let _ = std::fs::remove_file(&manifest_dest);
+            let _ = std::fs::rename(backup, &manifest_dest);
+        }
+        return Err(match &moved_existing_to {
+            Some(moved) => rollback_moved_db(moved, db_path, error),
+            None => error,
+        });
+    }
+    if let Some(backup) = attachments_backup {
+        let _ = std::fs::remove_dir_all(backup);
+    }
+    if let Some(backup) = manifest_backup {
+        let _ = std::fs::remove_file(backup);
+    }
 
     Ok(RestoreResult {
         manifest,
@@ -608,10 +844,16 @@ mod tests {
     /// also runs while a failed assertion unwinds, so nothing is left for a
     /// later run to trip over.
     fn temp_dir(tag: &str) -> TempDir {
-        tempfile::Builder::new()
+        let dir = tempfile::Builder::new()
             .prefix(&format!("lific_dump_{tag}_"))
             .tempdir()
-            .unwrap()
+            .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        dir
     }
 
     /// Build a real on-disk DB with a seeded project, plus an attachments dir
@@ -638,9 +880,21 @@ mod tests {
         }
         let att = dir.join("attachments");
         fs::create_dir_all(&att).unwrap();
-        fs::write(att.join("deadbeef01"), b"blob one").unwrap();
-        fs::write(att.join("deadbeef02"), b"second blob bytes").unwrap();
-        fs::write(att.join("deadbeef02.tmp"), b"partial write").unwrap();
+        fs::write(
+            att.join("b9b3a769cea97e51493b4e72ee90ba48282936fadabbb8149bf8fa6d54b873c8"),
+            b"blob one",
+        )
+        .unwrap();
+        fs::write(
+            att.join("ea2566faf1d1b369882675745c14fdca057e281ec2e198da480c8c3e2d95dcf0"),
+            b"second blob bytes",
+        )
+        .unwrap();
+        fs::write(
+            att.join("b9b3a769cea97e51493b4e72ee90ba48282936fadabbb8149bf8fa6d54b873c8.tmp"),
+            b"partial write",
+        )
+        .unwrap();
         (tmp, db_path)
     }
 
@@ -651,7 +905,13 @@ mod tests {
         let mut tar = tar::Archive::new(dec);
         tar.entries()
             .unwrap()
-            .map(|e| e.unwrap().path().unwrap().to_string_lossy().replace('\\', "/"))
+            .map(|e| {
+                e.unwrap()
+                    .path()
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
             .collect()
     }
 
@@ -665,17 +925,33 @@ mod tests {
         let entries = archive_entries(&out);
         assert!(entries.contains(&ARCHIVE_DB_NAME.to_string()));
         assert!(entries.contains(&ARCHIVE_MANIFEST_NAME.to_string()));
-        assert!(entries.contains(&"attachments/deadbeef01".to_string()));
-        assert!(entries.contains(&"attachments/deadbeef02".to_string()));
+        assert!(
+            entries.contains(
+                &"attachments/b9b3a769cea97e51493b4e72ee90ba48282936fadabbb8149bf8fa6d54b873c8"
+                    .to_string()
+            )
+        );
+        assert!(
+            entries.contains(
+                &"attachments/ea2566faf1d1b369882675745c14fdca057e281ec2e198da480c8c3e2d95dcf0"
+                    .to_string()
+            )
+        );
         assert!(
             !entries.iter().any(|e| e.ends_with(".tmp")),
             "in-progress .tmp writes must be excluded: {entries:?}"
         );
 
         assert_eq!(manifest.attachment_count, 2);
-        assert_eq!(manifest.attachment_bytes, (b"blob one".len() + b"second blob bytes".len()) as u64);
+        assert_eq!(
+            manifest.attachment_bytes,
+            (b"blob one".len() + b"second blob bytes".len()) as u64
+        );
         assert_eq!(manifest.lific_version, env!("CARGO_PKG_VERSION"));
-        assert_eq!(manifest.schema_version, crate::db::migrate::latest_version());
+        assert_eq!(
+            manifest.schema_version,
+            crate::db::migrate::latest_version()
+        );
         assert!(manifest.db_size_bytes > 0);
     }
 
@@ -691,11 +967,43 @@ mod tests {
         assert_eq!(mode, 0o600, "archive must be chmod 0600");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn dump_rejects_unsafe_destinations() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let (dir_tmp, db_path) = seed_data_dir("unsafe-destinations");
+        let dir = dir_tmp.path();
+        let target = dir.join("target.tar.gz");
+        fs::write(&target, b"existing").unwrap();
+        let link = dir.join("link.tar.gz");
+        symlink(&target, &link).unwrap();
+
+        assert!(write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &link).is_err());
+
+        let hardlink = dir.join("hardlink.tar.gz");
+        fs::hard_link(&target, &hardlink).unwrap();
+        assert!(write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &hardlink).is_err());
+
+        let safe_parent = dir.join("safe-parent");
+        fs::create_dir(&safe_parent).unwrap();
+        fs::set_permissions(&safe_parent, fs::Permissions::from_mode(0o755)).unwrap();
+        let safe_output = safe_parent.join("out.tar.gz");
+        assert!(write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &safe_output).is_ok());
+
+        let real_parent = dir.join("real-parent");
+        fs::create_dir(&real_parent).unwrap();
+        let parent_link = dir.join("parent-link");
+        symlink(&real_parent, &parent_link).unwrap();
+        let nested = parent_link.join("nested.tar.gz");
+        assert!(write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &nested).is_err());
+    }
+
     #[test]
     fn failed_dump_cleans_up_its_staging_files() {
-        // LIF-329: force a failure *after* the staging archive exists by
-        // squatting the final path with a directory (rename onto a directory
-        // fails on every platform). Neither staging file may survive.
+        // Force a failure after the staging archive exists by squatting the
+        // final path with a directory. The private staging directory must not
+        // survive the failed rename.
         let (dir_tmp, db_path) = seed_data_dir("errclean");
         let dir = dir_tmp.path();
         let out = dir.join("blocked.tar.gz");
@@ -704,14 +1012,9 @@ mod tests {
         let result = write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out);
         assert!(result.is_err(), "rename onto a directory must fail");
 
-        assert!(
-            !out.with_extension("archive.tmp").exists(),
-            "partial archive staging file must be cleaned on error"
-        );
-        assert!(
-            !out.with_extension("dbsnapshot.tmp").exists(),
-            "db snapshot staging file must be cleaned on error"
-        );
+        assert!(!fs::read_dir(dir)
+            .unwrap()
+            .any(|entry| entry.unwrap().file_name().to_string_lossy().starts_with(".lific-dump-")));
     }
 
     #[test]
@@ -752,6 +1055,11 @@ mod tests {
         let dir = dir_tmp.path();
         let target = dir.join("dumps");
         fs::create_dir_all(&target).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&target, fs::Permissions::from_mode(0o700)).unwrap();
+        }
         let res = run_dump(&db_path, Some(&target)).unwrap();
         assert_eq!(res.archive_path.parent().unwrap(), target);
         let fname = res.archive_path.file_name().unwrap().to_string_lossy();
@@ -773,25 +1081,64 @@ mod tests {
         let dst_db = dst_dir.join("lific.db");
         let res = run_restore(&out, &dst_db, false).unwrap();
         assert_eq!(res.attachment_count, 2);
+        assert!(dst_dir.join(ARCHIVE_MANIFEST_NAME).is_file());
 
         // Entities: the seeded project is present.
         let pool = crate::db::open(&dst_db).unwrap();
         let conn = pool.read().unwrap();
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM projects WHERE identifier = 'DMP'", [], |r| {
-                r.get(0)
-            })
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE identifier = 'DMP'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(count, 1);
 
         // Blob bytes identical.
         assert_eq!(
-            fs::read(dst_dir.join("attachments").join("deadbeef01")).unwrap(),
+            fs::read(
+                dst_dir
+                    .join("attachments")
+                    .join("b9b3a769cea97e51493b4e72ee90ba48282936fadabbb8149bf8fa6d54b873c8")
+            )
+            .unwrap(),
             b"blob one"
         );
         assert_eq!(
-            fs::read(dst_dir.join("attachments").join("deadbeef02")).unwrap(),
+            fs::read(
+                dst_dir
+                    .join("attachments")
+                    .join("ea2566faf1d1b369882675745c14fdca057e281ec2e198da480c8c3e2d95dcf0")
+            )
+            .unwrap(),
             b"second blob bytes"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_protects_data_and_attachment_paths() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (src_dir_tmp, src_db) = seed_data_dir("perms_src");
+        let out = src_dir_tmp.path().join("backup.tar.gz");
+        write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &out).unwrap();
+
+        let dst_dir_tmp = temp_dir("perms_dst");
+        let dst_dir = dst_dir_tmp.path();
+        let dst_db = dst_dir.join("lific.db");
+        run_restore(&out, &dst_db, false).unwrap();
+
+        let mode = |path: &Path| fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode(dst_dir), 0o700);
+        assert_eq!(mode(&dst_dir.join("attachments")), 0o700);
+        assert_eq!(mode(&dst_db), 0o600);
+        assert_eq!(
+            mode(&dst_dir.join(
+                "attachments/b9b3a769cea97e51493b4e72ee90ba48282936fadabbb8149bf8fa6d54b873c8"
+            )),
+            0o600
         );
     }
 
@@ -841,24 +1188,38 @@ mod tests {
         }
 
         let res = run_restore(&out, &dst_db, true).unwrap();
-        let moved = res.moved_existing_to.expect("existing db should be moved aside");
+        let moved = res
+            .moved_existing_to
+            .expect("existing db should be moved aside");
         assert!(moved.exists(), "moved-aside db must still exist");
         assert!(
-            moved.file_name().unwrap().to_string_lossy().contains("pre-restore-"),
+            moved
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains("pre-restore-"),
             "moved db name must include pre-restore-: {}",
             moved.display()
         );
         // The moved-aside db still has the OLD project.
         let conn = rusqlite::Connection::open(&moved).unwrap();
         let old: i64 = conn
-            .query_row("SELECT COUNT(*) FROM projects WHERE identifier='OLD'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE identifier='OLD'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(old, 1);
         // The live db now has the restored project.
         let pool = crate::db::open(&dst_db).unwrap();
         let conn = pool.read().unwrap();
         let dmp: i64 = conn
-            .query_row("SELECT COUNT(*) FROM projects WHERE identifier='DMP'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE identifier='DMP'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(dmp, 1);
     }
@@ -880,7 +1241,10 @@ mod tests {
         let dst_db = dst_dir.join("lific.db");
         let err = run_restore(&bumped, &dst_db, false).unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got {err:?}");
-        assert!(!dst_db.exists(), "nothing should be restored on schema refusal");
+        assert!(
+            !dst_db.exists(),
+            "nothing should be restored on schema refusal"
+        );
     }
 
     #[test]
@@ -971,7 +1335,11 @@ mod tests {
         let pool = crate::db::open(&dst_db).unwrap();
         let conn = pool.read().unwrap();
         let org: i64 = conn
-            .query_row("SELECT COUNT(*) FROM projects WHERE identifier='ORG'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE identifier='ORG'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(org, 1, "original data must survive a failed restore");
     }
@@ -1029,7 +1397,13 @@ mod tests {
 
     #[test]
     fn validate_attachment_entry_accepts_bare_hash_rejects_traversal() {
-        assert!(validate_attachment_entry("attachments/abc123def").is_ok());
+        assert!(
+            validate_attachment_entry(
+                "attachments/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            )
+            .is_ok()
+        );
+        assert!(validate_attachment_entry("attachments/abc123def").is_err());
         assert!(validate_attachment_entry("attachments/../etc/passwd").is_err());
         assert!(validate_attachment_entry("attachments/sub/dir").is_err());
         assert!(validate_attachment_entry("attachments/").is_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,26 +17,76 @@ mod mcp;
 mod oauth;
 mod preview;
 mod ratelimit;
-mod resolve_caller;
 mod realtime;
+mod resolve_caller;
 mod server;
 mod storage;
 
 use clap::{CommandFactory, Parser};
-use cli::{
-    BackendKind, Cli, Command, ServiceAction,
-};
+use cli::{BackendKind, Cli, Command, ServiceAction};
 use config::Config;
 
 // Commands that operate directly on the database (no server required)
 fn is_crud_command(cmd: &Command) -> bool {
-    matches!(cmd,
-        Command::Issue { .. } | Command::Project { .. } | Command::Page { .. } |
-        Command::Export { .. } |
-        Command::Search { .. } | Command::Comment { .. } | Command::Module { .. } |
-        Command::Label { .. } | Command::Folder { .. }
+    matches!(
+        cmd,
+        Command::Issue { .. }
+            | Command::Project { .. }
+            | Command::Page { .. }
+            | Command::Export { .. }
+            | Command::Search { .. }
+            | Command::Comment { .. }
+            | Command::Module { .. }
+            | Command::Label { .. }
+            | Command::Folder { .. }
     )
 }
+
+fn write_private_config(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let staging = tempfile::Builder::new()
+        .prefix(".lific-config-")
+        .tempdir_in(parent)?;
+    let temp = staging.path().join(path.file_name().unwrap_or_default());
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(&temp)?;
+    std::io::Write::write_all(&mut file, contents.as_bytes())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    file.sync_all()?;
+    std::fs::rename(temp, path)
+}
+
+fn create_private_config(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let staging = tempfile::Builder::new()
+        .prefix(".lific-config-")
+        .tempdir_in(parent)?;
+    let temp = staging.path().join(path.file_name().unwrap_or_default());
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(&temp)?;
+    std::io::Write::write_all(&mut file, contents.as_bytes())?;
+    file.sync_all()?;
+    // A hard link publishes only when the destination does not yet exist.
+    // It is atomic and leaves an existing configuration untouched on races.
+    std::fs::hard_link(&temp, path)
+}
+
 use rmcp::ServiceExt;
 use tracing::info;
 
@@ -83,20 +133,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .into(),
             );
         }
-        let url = http_backend_url(
-            cli.url.as_deref(),
-            cfg.server.public_url.as_deref(),
-            &cfg,
-        );
+        let url = http_backend_url(cli.url.as_deref(), cfg.server.public_url.as_deref(), &cfg);
         // LIF-408: `--api-key`/`LIFIC_API_KEY` still wins, then the stored
         // credential for `url`. `credentials::load` will only hand back a
         // `LIFIC_TOKEN` when `LIFIC_URL` names the same origin as `url`, so a
         // cwd `lific.toml` (or a `--url`) pointing at another server cannot
         // make us send the env token there.
-        let api_key = cli::resolve_http_credential(
-            cli.api_key.as_deref(),
-            || cli::credentials::load(&url),
-        )?;
+        let api_key =
+            cli::resolve_http_credential(cli.api_key.as_deref(), || cli::credentials::load(&url))?;
         let json = cli::term::wants_json(cli.json);
         return cli::http::run(&cli.command, &url, api_key.as_deref(), json)
             .await
@@ -474,11 +518,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // CRUD commands and Completion are handled before this match
-        Command::Completion { .. } |
-        Command::Issue { .. } | Command::Project { .. } | Command::Page { .. } |
-        Command::Export { .. } |
-        Command::Search { .. } | Command::Comment { .. } | Command::Module { .. } |
-        Command::Label { .. } | Command::Folder { .. } => unreachable!(),
+        Command::Completion { .. }
+        | Command::Issue { .. }
+        | Command::Project { .. }
+        | Command::Page { .. }
+        | Command::Export { .. }
+        | Command::Search { .. }
+        | Command::Comment { .. }
+        | Command::Module { .. }
+        | Command::Label { .. }
+        | Command::Folder { .. } => unreachable!(),
     }
 
     Ok(())
@@ -591,7 +640,9 @@ fn load_config_for_init(
 /// explicit `--auth-mode` flag (non-interactive); otherwise, on a TTY, shows
 /// the interactive menu. Refuses (rather than hangs) off a TTY, matching
 /// `prompt_text`/`confirm`, and names the bypass flag.
-fn resolve_auth_mode(flag: &Option<String>) -> Result<config::AuthMode, Box<dyn std::error::Error>> {
+fn resolve_auth_mode(
+    flag: &Option<String>,
+) -> Result<config::AuthMode, Box<dyn std::error::Error>> {
     if let Some(value) = flag {
         return config::AuthMode::parse(value).ok_or_else(|| {
             format!("invalid --auth-mode '{value}': expected login-free or passwords").into()
@@ -615,13 +666,15 @@ fn resolve_auth_mode(flag: &Option<String>) -> Result<config::AuthMode, Box<dyn 
             "Passwords",
             "set a password and sign in on the web",
         );
-    let mode = prompt.interact().map_err(|e| -> Box<dyn std::error::Error> {
-        if e.kind() == std::io::ErrorKind::Interrupted {
-            "cancelled".into()
-        } else {
-            format!("auth-mode selection failed: {e}").into()
-        }
-    })?;
+    let mode = prompt
+        .interact()
+        .map_err(|e| -> Box<dyn std::error::Error> {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                "cancelled".into()
+            } else {
+                format!("auth-mode selection failed: {e}").into()
+            }
+        })?;
     if mode == config::AuthMode::LoginFree
         && !cli::term::confirm(
             &format!("{}\n\nProceed?", config::login_free_caution()),
@@ -684,13 +737,23 @@ async fn cmd_init(
         if let Some(parent) = config_path.parent()
             && !parent.as_os_str().is_empty()
         {
+            let parent_existed = parent.exists();
             std::fs::create_dir_all(parent)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if !parent_existed {
+                    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+                }
+            }
+            #[cfg(not(unix))]
+            let _ = parent_existed;
         }
         let toml = match &default_db {
             Some(db) => Config::default_toml_with_db(db),
             None => Config::default_toml(),
         };
-        std::fs::write(&config_path, toml)?;
+        create_private_config(&config_path, &toml)?;
         true
     };
 
@@ -731,7 +794,7 @@ async fn cmd_init(
         // service plan) reflects required/host.
         let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
         let new_toml = Config::apply_auth_mode(&existing, mode.required(), mode.host())?;
-        std::fs::write(&config_path, new_toml)?;
+        write_private_config(&config_path, &new_toml)?;
         cfg = load_config_for_init(&config_path, db_flag)?;
 
         let op_name = match name {
@@ -799,8 +862,7 @@ async fn cmd_init(
                         // port while our unit crash-loops on AddrInUse), and
                         // silence alone is ambiguous. Cross-check the unit's
                         // own active state to say something precise.
-                        let active =
-                            cli::service::status(mgr).map(|s| s.active).unwrap_or(false);
+                        let active = cli::service::status(mgr).map(|s| s.active).unwrap_or(false);
                         match (healthy, active) {
                             (true, true) => {}
                             (true, false) => {
@@ -870,7 +932,10 @@ async fn cmd_init(
     } else {
         ui::step(format!("Using existing {}", config_path.display()));
     }
-    ui::step(format!("Database ready {}", ui::dim(cfg.database.path.display())));
+    ui::step(format!(
+        "Database ready {}",
+        ui::dim(cfg.database.path.display())
+    ));
 
     if let Some(ref admin) = created_admin {
         ui::step(format!(
@@ -953,9 +1018,11 @@ fn cmd_service(
     use cli::ui;
     let json = cli::term::wants_json(json_flag);
     let Some(mgr) = cli::service::detect() else {
-        return Err("no supported service manager found (needs a systemd user session on \
+        return Err(
+            "no supported service manager found (needs a systemd user session on \
                     Linux, or launchd on macOS)"
-            .into());
+                .into(),
+        );
     };
     match action {
         ServiceAction::Install => {
@@ -994,7 +1061,10 @@ fn cmd_service(
                          when you log out. Run it manually to fix that.",
                     );
                 }
-                ui::outro(format!("Logs: {}", ui::command(cli::service::logs_hint(mgr))));
+                ui::outro(format!(
+                    "Logs: {}",
+                    ui::command(cli::service::logs_hint(mgr))
+                ));
             }
         }
         ServiceAction::Uninstall => {
@@ -1006,8 +1076,14 @@ fn cmd_service(
                 );
             } else {
                 ui::intro("lific service uninstall");
-                ui::step(format!("Service stopped and uninstalled {}", ui::dim(&removed)));
-                ui::outro(format!("Reinstall anytime with {}", ui::command("lific service install")));
+                ui::step(format!(
+                    "Service stopped and uninstalled {}",
+                    ui::dim(&removed)
+                ));
+                ui::outro(format!(
+                    "Reinstall anytime with {}",
+                    ui::command("lific service install")
+                ));
             }
         }
         ServiceAction::Status => {
@@ -1052,7 +1128,10 @@ fn cmd_service(
             if json {
                 println!("{}", serde_json::json!({ "restarted": true }));
             } else {
-                ui::step(format!("Service restarted — {}", ui::command(local_url(cfg))));
+                ui::step(format!(
+                    "Service restarted — {}",
+                    ui::command(local_url(cfg))
+                ));
             }
         }
     }
@@ -1060,7 +1139,7 @@ fn cmd_service(
 }
 #[cfg(test)]
 mod init_target_tests {
-    use super::{auth, cmd_init, resolve_init_target, Config};
+    use super::{Config, auth, cmd_init, resolve_init_target};
     use crate::db;
     use std::path::{Path, PathBuf};
 
@@ -1077,7 +1156,10 @@ mod init_target_tests {
     fn bare_init_targets_os_dirs() {
         let (config, db) = resolve_init_target(None, false, false, os_default());
         assert_eq!(config, Path::new("/home/u/.config/lific/lific.toml"));
-        assert_eq!(db.as_deref(), Some(Path::new("/home/u/.local/share/lific/lific.db")));
+        assert_eq!(
+            db.as_deref(),
+            Some(Path::new("/home/u/.local/share/lific/lific.db"))
+        );
     }
 
     #[test]
@@ -1201,7 +1283,8 @@ mod init_target_tests {
             .unwrap();
         assert_eq!(out["admin"], serde_json::json!("blake"));
         assert_eq!(
-            out["keys"], serde_json::json!(false),
+            out["keys"],
+            serde_json::json!(false),
             "a human operator exists, so no unbound default key is minted"
         );
     }
@@ -1217,11 +1300,17 @@ mod init_target_tests {
         assert_eq!(first["admin"], serde_json::json!("blake"));
 
         // Second run with a different name must NOT create a second admin.
-        let second = run_init(&dir, Some("Someone Else"), Some("passwords"), Some("hunter22!"))
-            .await
-            .unwrap();
+        let second = run_init(
+            &dir,
+            Some("Someone Else"),
+            Some("passwords"),
+            Some("hunter22!"),
+        )
+        .await
+        .unwrap();
         assert_eq!(
-            second["admin"], serde_json::json!("blake"),
+            second["admin"],
+            serde_json::json!("blake"),
             "existing instance keeps its first admin"
         );
     }
@@ -1279,7 +1368,7 @@ mod init_target_tests {
 
 #[cfg(test)]
 mod http_backend_url_tests {
-    use super::{http_backend_url, Config};
+    use super::{Config, http_backend_url};
 
     #[test]
     fn maps_bind_any_hosts_to_loopback() {
@@ -1287,10 +1376,7 @@ mod http_backend_url_tests {
         cfg.server.host = "0.0.0.0".into();
         cfg.server.port = 4567;
 
-        assert_eq!(
-            http_backend_url(None, None, &cfg),
-            "http://127.0.0.1:4567"
-        );
+        assert_eq!(http_backend_url(None, None, &cfg), "http://127.0.0.1:4567");
     }
 
     #[test]
@@ -1315,7 +1401,7 @@ mod http_backend_url_tests {
 
 #[cfg(test)]
 mod display_host_tests {
-    use super::{display_host, local_url, Config};
+    use super::{Config, display_host, local_url};
 
     #[test]
     fn leaves_ipv4_and_hostnames_untouched() {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -4188,8 +4188,8 @@ impl LificMcp {
         }
 
         let size = bytes.len() as i64;
-        let sha = self.store.write(&bytes).map_err(sanitize_error)?;
-        let (attachment, event) = self.transaction(|conn| {
+        let sha = crate::storage::AttachmentStore::hash_bytes(&bytes);
+        let (attachment, event) = self.store.with_string_lock(|store| self.transaction(|conn| {
             let uploader = resolve_attachment_uploader_conn(conn)?;
             let attachment = queries::attachments::create_attachment(
                 conn,
@@ -4199,6 +4199,7 @@ impl LificMcp {
                 size,
                 Some(uploader),
             )?;
+            store.write_unlocked(&bytes)?;
             let event = match link {
                 Some((entity, entity_id)) => {
                     // The gate above ran on a read connection before the blob
@@ -4214,7 +4215,7 @@ impl LificMcp {
                 None => None,
             };
             Ok((attachment, event))
-        })?;
+        }))?;
         event.into_iter().for_each(|event| self.emit(event));
 
         let snippet = attachment_markdown(&attachment.filename, &attachment.mime, attachment.id);
@@ -4288,11 +4289,7 @@ impl LificMcp {
         }
         if crate::storage::is_raster_mime(&attachment.mime) {
             // The raster formats a multimodal agent can actually look at.
-            // Deliberately NOT `is_inline_safe_mime`: that allowlist governs
-            // what a *browser* may navigate to as a top-level document, so it
-            // also carries mp4/webm/ogg/mp3. Handing a video to an MCP client
-            // as `Content::image` mislabels it and base64-inflates megabytes
-            // of container into the agent's context. SVG is excluded by both.
+            // SVG is deliberately excluded, matching `is_inline_safe_mime`.
             return Ok(vec![
                 Content::text(format!(
                     "attachment {}: {} ({}, {})",
@@ -11204,6 +11201,35 @@ mod tests {
     }
 
     #[test]
+    fn get_attachment_summarizes_media_without_inline_image_content() {
+        let (m, _tmp, _guard, _identity) = mcp_with_attachments();
+        let bytes = b"OggSmedia";
+        let sha = crate::storage::AttachmentStore::hash_bytes(bytes);
+        let id = m
+            .write(|conn| {
+                let attachment = queries::attachments::create_attachment(
+                    conn,
+                    &sha,
+                    "sound.ogg",
+                    "audio/ogg",
+                    bytes.len() as i64,
+                    None,
+                )?;
+                m.store.write_unlocked(bytes)?;
+                Ok(attachment.id)
+            })
+            .expect("seed media attachment");
+
+        let result = m.get_attachment(Parameters(GetAttachmentInput {
+            attachment_id: id,
+            offset: None,
+            limit: None,
+        }));
+        assert!(result.content.iter().all(|content| content.as_image().is_none()));
+        assert!(text_of(&result).contains("Binary, download at"));
+    }
+
+    #[test]
     fn get_attachment_summarizes_other_binary_types_without_the_bytes() {
         let (m, _tmp, _guard, _identity) = mcp_with_attachments();
         let pdf = base64::engine::general_purpose::STANDARD.encode(b"%PDF-1.7\nbody");
@@ -11230,41 +11256,6 @@ mod tests {
             )),
             "{text}"
         );
-        assert!(
-            text.ends_with(&format!("Binary, download at /api/attachments/{id}")),
-            "{text}"
-        );
-    }
-
-    /// Regression: `get_attachment` used to gate image content on
-    /// `is_inline_safe_mime`, which is the *browser* allowlist and therefore
-    /// carries mp4/webm/ogg/mp3. A video came back tagged as `Content::image`,
-    /// mislabelling it and inflating megabytes of container into base64 in the
-    /// agent's context. The predicate is `is_raster_mime`; media summarizes.
-    #[test]
-    fn get_attachment_does_not_hand_back_video_as_image_content() {
-        let (m, _tmp, _guard, _identity) = mcp_with_attachments();
-        // ISO base media: a `ftyp` box at offset 4 with a non-QuickTime brand.
-        let mut mp4 = Vec::from(&b"\x00\x00\x00\x18ftypisom"[..]);
-        mp4.extend_from_slice(b"\x00\x00\x02\x00isomiso2");
-        let id = attachment_id_from(&m.upload_attachment(Parameters(UploadAttachmentInput {
-            filename: "clip.mp4".into(),
-            content_base64: base64::engine::general_purpose::STANDARD.encode(&mp4),
-            entity: None,
-            comment_id: None,
-        })));
-
-        let result = m.get_attachment(Parameters(GetAttachmentInput {
-            attachment_id: id,
-            offset: None,
-            limit: None,
-        }));
-        assert!(
-            result.content.iter().all(|c| c.as_image().is_none()),
-            "a video must not be handed back as image content"
-        );
-        let text = text_of(&result);
-        assert!(text.contains("video/mp4"), "{text}");
         assert!(
             text.ends_with(&format!("Binary, download at /api/attachments/{id}")),
             "{text}"

--- a/src/server.rs
+++ b/src/server.rs
@@ -211,12 +211,31 @@ fn is_private_ip(ip: std::net::IpAddr) -> bool {
 /// Side-effect free apart from a DB read to resolve the authless MCP identity:
 /// background tasks (backups, attachment GC) are [`run`]'s business, so tests
 /// and diagnostics can build the app without spawning anything.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn build_app(
     cfg: &Config,
     pool: db::DbPool,
     manager: ApiKeyManagerV0,
     realtime: realtime::RealtimeHub,
     trusted_proxies: Arc<[ratelimit::IpNetwork]>,
+) -> Router {
+    build_app_with_store(
+        cfg,
+        pool,
+        manager,
+        realtime,
+        trusted_proxies,
+        storage::AttachmentStore::from_db_path(&cfg.database.path),
+    )
+}
+
+fn build_app_with_store(
+    cfg: &Config,
+    pool: db::DbPool,
+    manager: ApiKeyManagerV0,
+    realtime: realtime::RealtimeHub,
+    trusted_proxies: Arc<[ratelimit::IpNetwork]>,
+    attachment_store: storage::AttachmentStore,
 ) -> Router {
     // Auth state for middleware. When no public_url is configured the
     // issuer is derived from the bind address — but 0.0.0.0/:: are
@@ -280,7 +299,6 @@ pub fn build_app(
     // LIF-262: attachment storage + upload guards. Bytes live in a
     // sidecar dir next to the database (content-addressed); the upload
     // route is rate-limited per user (30 uploads / 10 min).
-    let attachment_store = storage::AttachmentStore::from_db_path(&cfg.database.path);
     let attachment_config = api::AttachmentConfig::default();
     let attachment_upload_limiter = Arc::new(api::AttachmentUploadLimiter(
         ratelimit::RateLimiter::new(30, std::time::Duration::from_secs(10 * 60)),
@@ -572,18 +590,22 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    // Sweep abandoned (unlinked) attachments hourly.
+    // Sweep abandoned (unlinked) attachments hourly. Share the store with the
+    // request router so its operation lock covers both upload and GC paths.
+    let attachment_store = storage::AttachmentStore::from_db_path(&cfg.database.path);
+    let gc_attachment_store = attachment_store.clone();
     storage::start_gc_task(
         pool.clone(),
-        storage::AttachmentStore::from_db_path(&cfg.database.path),
+        gc_attachment_store,
     );
 
-    let app = build_app(
+    let app = build_app_with_store(
         cfg,
         pool.clone(),
         manager,
         realtime::RealtimeHub::new(),
         trusted_proxies,
+        attachment_store,
     );
 
     let addr = format!("{}:{}", cfg.server.host, cfg.server.port);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -29,6 +29,33 @@ pub struct AttachmentStore {
     operation_lock: Arc<Mutex<()>>,
 }
 
+fn existing_regular_file(path: &Path, label: &str) -> Result<bool, LificError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(LificError::Internal(format!(
+                "inspect {label} path: {error}"
+            )))
+        }
+    };
+    if !metadata.file_type().is_file() {
+        return Err(LificError::Internal(format!(
+            "{label} path is not a regular file"
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.nlink() != 1 {
+            return Err(LificError::Internal(format!(
+                "{label} path is hard-linked"
+            )));
+        }
+    }
+    Ok(true)
+}
+
 impl AttachmentStore {
     /// Build a store rooted at `<parent-of-db>/attachments`. Mirrors
     /// `Config::backup_dir`'s "resolve relative to the database file" rule so
@@ -104,7 +131,7 @@ impl AttachmentStore {
                 .map_err(|e| LificError::Internal(format!("secure thumbnails dir: {e}")))?;
         }
         let tmp = parent.join(format!(".{}.{}.tmp", sha256, rand::random::<u64>()));
-        if path.exists() {
+        if existing_regular_file(&path, "thumbnail")? {
             return Ok(());
         }
         let mut options = std::fs::OpenOptions::new();
@@ -204,7 +231,7 @@ impl AttachmentStore {
                 .map_err(|e| LificError::Internal(format!("secure attachments dir: {e}")))?;
         }
         let path = self.path_for(&sha)?;
-        if path.exists() {
+        if existing_regular_file(&path, "attachment")? {
             return Ok(sha);
         }
         // Write to a temp file then rename, so a concurrent reader never sees a
@@ -782,6 +809,38 @@ mod tests {
             & 0o777;
         assert_eq!(dir_mode, 0o700);
         assert_eq!(file_mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn attachment_write_rejects_existing_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let (store, _tmp) = tmp_store();
+        let bytes = b"private attachment";
+        let sha = AttachmentStore::hash_bytes(bytes);
+        std::fs::create_dir_all(store.dir()).unwrap();
+        let target = store.dir().join("outside");
+        std::fs::write(&target, b"outside").unwrap();
+        symlink(&target, store.dir().join(&sha)).unwrap();
+
+        assert!(store.write(bytes).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn thumbnail_write_rejects_existing_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let (store, _tmp) = tmp_store();
+        let sha = "a".repeat(64);
+        let thumbnail = store.thumb_path_for(&sha).unwrap();
+        std::fs::create_dir_all(thumbnail.parent().unwrap()).unwrap();
+        let target = store.dir().join("outside.webp");
+        std::fs::write(&target, b"outside").unwrap();
+        symlink(&target, &thumbnail).unwrap();
+
+        assert!(store.write_thumb(&sha, b"thumbnail").is_err());
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,6 +14,7 @@
 //! orphan GC's job — see `db::queries::attachments`).
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use sha2::{Digest, Sha256};
 
@@ -25,6 +26,7 @@ use crate::error::LificError;
 #[derive(Debug, Clone)]
 pub struct AttachmentStore {
     dir: PathBuf,
+    operation_lock: Arc<Mutex<()>>,
 }
 
 impl AttachmentStore {
@@ -37,7 +39,10 @@ impl AttachmentStore {
             Some(parent) if !parent.as_os_str().is_empty() => parent.join("attachments"),
             _ => PathBuf::from("attachments"),
         };
-        Self { dir }
+        Self {
+            dir,
+            operation_lock: Arc::new(Mutex::new(())),
+        }
     }
 
     /// Construct a store at an explicit directory. Production always resolves
@@ -45,7 +50,10 @@ impl AttachmentStore {
     /// tests point a store at a tempdir, hence the test-scoped allow.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn new(dir: PathBuf) -> Self {
-        Self { dir }
+        Self {
+            dir,
+            operation_lock: Arc::new(Mutex::new(())),
+        }
     }
 
     /// The attachments directory itself. Callers reach the files through
@@ -58,37 +66,67 @@ impl AttachmentStore {
     /// Absolute path to the sidecar file for a given content hash. Kept
     /// private-ish (only `pub(crate)`) so callers go through
     /// `read`/`write`/`delete` rather than hand-building paths.
-    pub(crate) fn path_for(&self, sha256: &str) -> PathBuf {
-        self.dir.join(sha256)
+    pub(crate) fn path_for(&self, sha256: &str) -> Result<PathBuf, LificError> {
+        if sha256.len() != 64
+            || !sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(LificError::BadRequest(
+                "invalid attachment content hash".into(),
+            ));
+        }
+        Ok(self.dir.join(sha256))
     }
 
     /// Absolute path to the cached thumbnail for a content hash. Thumbnails
     /// live in a `thumbs/` subdirectory so a plain `read_dir` of the store
     /// still enumerates exactly the original blobs, and so a hash can never
     /// collide with its own derivative.
-    pub(crate) fn thumb_path_for(&self, sha256: &str) -> PathBuf {
-        self.dir.join("thumbs").join(format!("{sha256}.webp"))
+    pub(crate) fn thumb_path_for(&self, sha256: &str) -> Result<PathBuf, LificError> {
+        self.path_for(sha256)?;
+        Ok(self.dir.join("thumbs").join(format!("{sha256}.webp")))
     }
 
     /// Cache a generated thumbnail. Same temp-file-then-rename dance as
     /// [`Self::write`], so a concurrent reader never sees a partial webp.
     pub fn write_thumb(&self, sha256: &str, bytes: &[u8]) -> Result<(), LificError> {
-        let path = self.thumb_path_for(sha256);
+        let path = self.thumb_path_for(sha256)?;
         let parent = path
             .parent()
             .ok_or_else(|| LificError::Internal("thumbnail path has no parent".into()))?;
         std::fs::create_dir_all(parent)
             .map_err(|e| LificError::Internal(format!("create thumbnails dir: {e}")))?;
-        let tmp = path.with_extension("tmp");
-        std::fs::write(&tmp, bytes)
-            .map_err(|e| LificError::Internal(format!("write thumbnail: {e}")))?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+                .map_err(|e| LificError::Internal(format!("secure thumbnails dir: {e}")))?;
         }
-        std::fs::rename(&tmp, &path)
-            .map_err(|e| LificError::Internal(format!("finalize thumbnail: {e}")))?;
+        let tmp = parent.join(format!(".{}.{}.tmp", sha256, rand::random::<u64>()));
+        if path.exists() {
+            return Ok(());
+        }
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        let mut file = options
+            .open(&tmp)
+            .map_err(|e| LificError::Internal(format!("create thumbnail: {e}")))?;
+        let result = (|| -> std::io::Result<()> {
+            std::io::Write::write_all(&mut file, bytes)?;
+            file.sync_all()?;
+            drop(file);
+            std::fs::rename(&tmp, &path)
+        })();
+        if let Err(error) = result {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(LificError::Internal(format!("write thumbnail: {error}")));
+        }
         Ok(())
     }
 
@@ -96,7 +134,7 @@ impl AttachmentStore {
     /// which is the ordinary state for an attachment uploaded before
     /// thumbnails existed.
     pub fn read_thumb(&self, sha256: &str) -> Result<Option<Vec<u8>>, LificError> {
-        match std::fs::read(self.thumb_path_for(sha256)) {
+        match std::fs::read(self.thumb_path_for(sha256)?) {
             Ok(bytes) => Ok(Some(bytes)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(e) => Err(LificError::Internal(format!("read thumbnail: {e}"))),
@@ -106,7 +144,7 @@ impl AttachmentStore {
     /// Drop a cached thumbnail. Missing file is success: thumbnails are a
     /// cache, so every delete here is best-effort and repeatable.
     pub fn delete_thumb(&self, sha256: &str) -> Result<(), LificError> {
-        match std::fs::remove_file(self.thumb_path_for(sha256)) {
+        match std::fs::remove_file(self.thumb_path_for(sha256)?) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(LificError::Internal(format!("delete thumbnail: {e}"))),
@@ -119,37 +157,93 @@ impl AttachmentStore {
         digest.iter().map(|b| format!("{b:02x}")).collect()
     }
 
+    /// Serialize filesystem operations with metadata changes that callers
+    /// perform under [`Self::with_lock`]. Cloned stores share this lock.
+    pub(crate) fn with_lock<T>(
+        &self,
+        operation: impl FnOnce(&Self) -> Result<T, LificError>,
+    ) -> Result<T, LificError> {
+        let _guard = self
+            .operation_lock
+            .lock()
+            .map_err(|_| LificError::Internal("attachment store lock poisoned".into()))?;
+        operation(self)
+    }
+
+    /// MCP's tool boundary uses sanitized strings instead of `LificError`.
+    /// Keep it on this same mutex so both transports coordinate blob writes
+    /// and orphan collection.
+    pub(crate) fn with_string_lock<T>(
+        &self,
+        operation: impl FnOnce(&Self) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let _guard = self
+            .operation_lock
+            .lock()
+            .map_err(|_| "attachment store lock poisoned".to_string())?;
+        operation(self)
+    }
+
     /// Write `bytes` to `<dir>/<sha256>`, creating the directory if needed.
     /// Idempotent: if the file already exists (same content), this is a no-op
     /// rather than a rewrite. Returns the content hash so the caller can store
     /// it on the metadata row.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn write(&self, bytes: &[u8]) -> Result<String, LificError> {
+        self.with_lock(|store| store.write_unlocked(bytes))
+    }
+
+    pub(crate) fn write_unlocked(&self, bytes: &[u8]) -> Result<String, LificError> {
         let sha = Self::hash_bytes(bytes);
         std::fs::create_dir_all(&self.dir)
             .map_err(|e| LificError::Internal(format!("create attachments dir: {e}")))?;
-        let path = self.path_for(&sha);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.dir, std::fs::Permissions::from_mode(0o700))
+                .map_err(|e| LificError::Internal(format!("secure attachments dir: {e}")))?;
+        }
+        let path = self.path_for(&sha)?;
         if path.exists() {
             return Ok(sha);
         }
         // Write to a temp file then rename, so a concurrent reader never sees a
         // half-written blob at the final content-addressed path.
-        let tmp = path.with_extension("tmp");
-        std::fs::write(&tmp, bytes)
-            .map_err(|e| LificError::Internal(format!("write attachment: {e}")))?;
+        let tmp = self
+            .dir
+            .join(format!(".{sha}.{:016x}.tmp", rand::random::<u64>()));
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
         }
-        std::fs::rename(&tmp, &path)
-            .map_err(|e| LificError::Internal(format!("finalize attachment: {e}")))?;
+        let mut file = options
+            .open(&tmp)
+            .map_err(|e| LificError::Internal(format!("create attachment temp file: {e}")))?;
+        if let Err(error) = std::io::Write::write_all(&mut file, bytes) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(LificError::Internal(format!("write attachment: {error}")));
+        }
+        if let Err(error) = file.sync_all() {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(LificError::Internal(format!("sync attachment: {error}")));
+        }
+        drop(file);
+        if let Err(error) = std::fs::rename(&tmp, &path) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(LificError::Internal(format!(
+                "finalize attachment: {error}"
+            )));
+        }
         Ok(sha)
     }
 
     /// Read the bytes for a content hash. `NotFound` when the sidecar file is
     /// missing (e.g. the DB row survived but the blob was manually removed).
     pub fn read(&self, sha256: &str) -> Result<Vec<u8>, LificError> {
-        let path = self.path_for(sha256);
+        let path = self.path_for(sha256)?;
         std::fs::read(&path).map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 LificError::NotFound("attachment bytes not found on disk".into())
@@ -162,12 +256,17 @@ impl AttachmentStore {
     /// Delete the sidecar file for a content hash. Missing file is treated as
     /// success (idempotent) — the GC only calls this once no DB row references
     /// the hash, so a double-delete or a manual prior removal is fine.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn delete(&self, sha256: &str) -> Result<(), LificError> {
+        self.with_lock(|store| store.delete_unlocked(sha256))
+    }
+
+    pub(crate) fn delete_unlocked(&self, sha256: &str) -> Result<(), LificError> {
         // The thumbnail is derived from these exact bytes, so it dies with
         // them. Best-effort: a failure to remove a cache file must not block
         // the blob delete the caller actually asked for.
         let _ = self.delete_thumb(sha256);
-        let path = self.path_for(sha256);
+        let path = self.path_for(sha256)?;
         match std::fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -199,22 +298,21 @@ pub fn sweep_orphans(
         let conn = pool.read()?;
         q::find_orphans(&conn, grace_seconds)?
     };
-
     let mut collected = 0;
     for orphan in orphans {
-        {
+        let removed = store.with_lock(|store| {
             let conn = pool.write()?;
-            q::delete_attachment(&conn, orphan.id)?;
+            let Some(sha256) = q::delete_orphan_attachment(&conn, orphan.id)? else {
+                return Ok(false);
+            };
+            if q::count_rows_for_sha(&conn, &sha256)? == 0 {
+                store.delete_unlocked(&sha256)?;
+            }
+            Ok(true)
+        })?;
+        if removed {
+            collected += 1;
         }
-        // Remove the blob only if no other row still references those bytes.
-        let remaining = {
-            let conn = pool.read()?;
-            q::count_rows_for_sha(&conn, &orphan.sha256)?
-        };
-        if remaining == 0 {
-            store.delete(&orphan.sha256)?;
-        }
-        collected += 1;
     }
     Ok(collected)
 }
@@ -669,6 +767,23 @@ mod tests {
         assert_eq!(count, 1);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn attachment_storage_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (store, _tmp) = tmp_store();
+        let sha = store.write(b"private attachment").unwrap();
+        let dir_mode = std::fs::metadata(store.dir()).unwrap().permissions().mode() & 0o777;
+        let file_mode = std::fs::metadata(store.dir().join(sha))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dir_mode, 0o700);
+        assert_eq!(file_mode, 0o600);
+    }
+
     #[test]
     fn delete_is_idempotent() {
         let (store, _tmp) = tmp_store();
@@ -746,6 +861,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn path_rejects_traversal_and_noncanonical_hashes() {
+        let (store, dir) = tmp_store();
+        for value in ["../lific.toml", &"A".repeat(64)] {
+            assert!(store.read(value).is_err());
+            assert!(store.delete(value).is_err());
+        }
+        let valid = "a".repeat(64);
+        assert!(store.read(&valid).is_err());
+        assert!(store.delete(&valid).is_ok());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     // ── MIME sniffing ────────────────────────────────────────
 
     #[test]
@@ -804,18 +932,12 @@ mod tests {
         );
     }
 
-    /// Inline-safe covers rasters *and* media containers, which is wider than
-    /// the raster set. The two predicates are not interchangeable: anything
-    /// asking "can a model look at this?" wants `is_raster_mime`.
     #[test]
-    fn inline_safe_covers_rasters_and_media_but_not_documents() {
-        for mime in RASTER_MIMES {
-            assert!(is_inline_safe_mime(mime), "{mime} should be inline-safe");
-        }
-        for mime in ["video/mp4", "video/webm", "audio/webm", "audio/ogg", "audio/mpeg"] {
-            assert!(is_inline_safe_mime(mime), "{mime} should be inline-safe");
-            assert!(!is_raster_mime(mime), "{mime} is not a raster image");
-        }
+    fn only_raster_images_are_inline_safe() {
+        assert!(is_inline_safe_mime("image/png"));
+        assert!(is_inline_safe_mime("image/jpeg"));
+        assert!(is_inline_safe_mime("image/gif"));
+        assert!(is_inline_safe_mime("image/webp"));
         assert!(!is_inline_safe_mime("application/pdf"));
         assert!(!is_inline_safe_mime("text/plain"));
     }
@@ -994,7 +1116,11 @@ mod tests {
         assert!(!expects_thumbnail("image/png", Some(480), Some(480)));
         assert!(!expects_thumbnail("image/png", None, None));
         assert!(!expects_thumbnail("video/mp4", Some(1920), Some(1080)));
-        assert!(!expects_thumbnail("application/pdf", Some(1920), Some(1080)));
+        assert!(!expects_thumbnail(
+            "application/pdf",
+            Some(1920),
+            Some(1080)
+        ));
     }
 
     #[test]
@@ -1006,7 +1132,7 @@ mod tests {
         store.write_thumb(&sha, b"pretend webp").unwrap();
         assert_eq!(store.read_thumb(&sha).unwrap().unwrap(), b"pretend webp");
         assert_eq!(
-            store.thumb_path_for(&sha).parent().unwrap(),
+            store.thumb_path_for(&sha).unwrap().parent().unwrap(),
             store.dir().join("thumbs")
         );
 


### PR DESCRIPTION
## Summary

Harden local persistence and restore paths so unsafe filesystem state, interrupted writes, and attachment lifecycle races fail closed without leaving partial or inconsistent data.

The branch:

- Secures configuration creation, updates, and reads with private staging, no-follow access where supported, atomic publication, symlink and dangling-link rejection, secret-aware permissions, and correct systemd escaping for paths and command arguments.
- Rejects unsafe database parents and database links, secures SQLite sidecars, and preserves owner-only permissions for database files and related state.
- Validates dump destinations and attachment names, uses private staging files, synchronizes data before publication, and protects long-running dump staging with an inter-process lock so cleanup cannot remove active work.
- Validates restore archives before installation, stages the complete restored tree, installs the database, attachments, and manifest together, and restores the previous state if installation fails.
- Keeps attachment CPU work outside the storage write lock, uses private no-follow temporary files, cleans up only files created by a failed upload, and makes orphan deletion safe against concurrent changes.
- Prevents audio and video attachments from being presented as inline images by MCP while retaining inline rendering for raster images.

The branch-added regression coverage exercises symlink and hard-link rejection, dangling configuration links, no-follow and private temporary-file creation, atomic configuration publication, service quoting, database sidecar and file permissions, dump destination and entry validation, archive staging-lock behavior, restore rollback and manifest installation, attachment transaction cleanup, orphan-cleanup races, and MCP media rendering. The full suite passes with 1,827 tests.