### PR TITLE
chore: enforce Rust formatting in CI and pre-commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Repository-wide rustfmt pass from PR #44.
+c3723aff8b6b690b6888634ecc5776bbe6b48c28

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
 
       - name: Ensure web/dist exists for rust-embed
         run: mkdir -p web/dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 repos:
   - repo: local
     hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
       - id: cargo-clippy
         name: cargo clippy
         entry: cargo clippy --all-targets -- -D warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,14 +48,23 @@ The whole suite runs in seconds. Every new MCP tool and REST endpoint ships with
 
 ## What CI runs (run it before pushing)
 
-CI lints with warnings-as-errors, so `cargo test` passing is not enough. Reproduce CI locally with both commands:
+CI checks formatting and lints with warnings-as-errors, so `cargo test` passing is not enough. Reproduce the Rust checks locally with:
 
 ```bash
+cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
 cargo test --all-targets
 ```
 
 If clippy complains, fix it. Don't `#[allow]` a lint without a comment explaining why.
+
+To run the same formatting check before each commit, install the repository's `pre-commit` hook once:
+
+```bash
+pre-commit install
+```
+
+Use `cargo fmt --all` to apply formatting fixes.
 
 ## Commit message style
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -125,7 +125,11 @@ mod tests {
             user_id: Some(2),
             transport: Transport::Mcp,
         };
-        let seen = scope(outer, async move { scope(inner, async { current() }).await }).await;
+        let seen = scope(
+            outer,
+            async move { scope(inner, async { current() }).await },
+        )
+        .await;
         assert_eq!(seen.user_id, Some(2));
         assert_eq!(seen.transport, Transport::Mcp);
     }

--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -206,55 +206,57 @@ pub(super) async fn upload_attachment(
     // is inserted.
     // Non-blocking: a REST handler must not park a Tokio worker for the
     // length of a dump. Busy means "retry", not "failed".
-    let (attachment, event) = store.try_with_lock(|store| {
-        // Same definition of "already there" the writer uses, so a path that
-        // is present but not a usable regular file fails here rather than
-        // being read as "this upload created it" during cleanup.
-        let blob_existed = store.blob_exists(&sha)?;
-        let thumb_existed = match thumbnail.as_ref() {
-            Some(_) => store.thumb_exists(&sha)?,
-            None => false,
-        };
-        let result = db.transaction(|conn| {
-            let mut att = q::create_attachment(conn, &sha, &filename, &mime, size, Some(user.id))?;
-            store.write_unlocked(&bytes)?;
-            if let Some(thumb) = thumbnail.as_deref()
-                && let Err(e) = store.write_thumb(&sha, thumb)
-            {
-                tracing::warn!(error = %e, "failed to cache attachment thumbnail");
-            }
-            if let Some((w, h)) = dimensions {
-                q::set_dimensions(conn, att.id, i64::from(w), i64::from(h))?;
-                att = q::get_attachment(conn, att.id)?;
-            }
-            if q::is_extractable(&mime, size)
-                && let Ok(text) = std::str::from_utf8(&bytes)
-            {
-                q::set_extracted_text(conn, att.id, text)?;
-            }
-            let event = match link {
-                Some((entity, eid)) => {
-                    authorize_link_conn(conn, &identity, entity, eid)?;
-                    q::link_attachment(conn, att.id, entity, eid)?;
-                    linked_entity_event(conn, entity, eid)?
-                }
-                None => None,
+    let (attachment, event) = store
+        .try_with_lock(|store| {
+            // Same definition of "already there" the writer uses, so a path that
+            // is present but not a usable regular file fails here rather than
+            // being read as "this upload created it" during cleanup.
+            let blob_existed = store.blob_exists(&sha)?;
+            let thumb_existed = match thumbnail.as_ref() {
+                Some(_) => store.thumb_exists(&sha)?,
+                None => false,
             };
-            Ok((att, event))
-        });
-        if result.is_err() {
-            discard_failed_upload(
-                &db,
-                store,
-                &sha,
-                blob_existed,
-                thumb_existed,
-                thumbnail.is_some(),
-            );
-        }
-        result
-    })?
-    .ok_or_else(AttachmentStore::busy_error)?;
+            let result = db.transaction(|conn| {
+                let mut att =
+                    q::create_attachment(conn, &sha, &filename, &mime, size, Some(user.id))?;
+                store.write_unlocked(&bytes)?;
+                if let Some(thumb) = thumbnail.as_deref()
+                    && let Err(e) = store.write_thumb(&sha, thumb)
+                {
+                    tracing::warn!(error = %e, "failed to cache attachment thumbnail");
+                }
+                if let Some((w, h)) = dimensions {
+                    q::set_dimensions(conn, att.id, i64::from(w), i64::from(h))?;
+                    att = q::get_attachment(conn, att.id)?;
+                }
+                if q::is_extractable(&mime, size)
+                    && let Ok(text) = std::str::from_utf8(&bytes)
+                {
+                    q::set_extracted_text(conn, att.id, text)?;
+                }
+                let event = match link {
+                    Some((entity, eid)) => {
+                        authorize_link_conn(conn, &identity, entity, eid)?;
+                        q::link_attachment(conn, att.id, entity, eid)?;
+                        linked_entity_event(conn, entity, eid)?
+                    }
+                    None => None,
+                };
+                Ok((att, event))
+            });
+            if result.is_err() {
+                discard_failed_upload(
+                    &db,
+                    store,
+                    &sha,
+                    blob_existed,
+                    thumb_existed,
+                    thumbnail.is_some(),
+                );
+            }
+            result
+        })?
+        .ok_or_else(AttachmentStore::busy_error)?;
     if let Some(event) = event {
         realtime.send(event);
     }
@@ -760,21 +762,22 @@ pub(super) async fn delete_attachment(
 
     authorize_delete(&db, &identity, &user, &attachment)?;
 
-    let events = store.try_with_lock(|store| {
-        let events = with_write(&db, |conn| {
-            let events = linked_attachment_events(conn, id)?;
-            q::delete_attachment(conn, id)?;
-            Ok(events)
-        })?;
+    let events = store
+        .try_with_lock(|store| {
+            let events = with_write(&db, |conn| {
+                let events = linked_attachment_events(conn, id)?;
+                q::delete_attachment(conn, id)?;
+                Ok(events)
+            })?;
 
-        // GC the sidecar only when no remaining row references the same bytes.
-        let remaining = with_read(&db, |conn| q::count_rows_for_sha(conn, &attachment.sha256))?;
-        if remaining == 0 {
-            store.delete_unlocked(&attachment.sha256)?;
-        }
-        Ok(events)
-    })?
-    .ok_or_else(AttachmentStore::busy_error)?;
+            // GC the sidecar only when no remaining row references the same bytes.
+            let remaining = with_read(&db, |conn| q::count_rows_for_sha(conn, &attachment.sha256))?;
+            if remaining == 0 {
+                store.delete_unlocked(&attachment.sha256)?;
+            }
+            Ok(events)
+        })?
+        .ok_or_else(AttachmentStore::busy_error)?;
     for event in events {
         realtime.send(event);
     }
@@ -899,34 +902,39 @@ fn describe_entity(
     entity_id: i64,
 ) -> Result<Option<LinkedEntity>, LificError> {
     with_read(db, |conn| {
-        let described = match entity {
-            AttachmentEntity::Issue => queries::get_issue(conn, entity_id).ok().map(|issue| {
-                LinkedEntity {
-                    entity_type: "issue".into(),
-                    entity_id,
-                    identifier: Some(issue.identifier),
-                    title: issue.title,
+        let described =
+            match entity {
+                AttachmentEntity::Issue => {
+                    queries::get_issue(conn, entity_id)
+                        .ok()
+                        .map(|issue| LinkedEntity {
+                            entity_type: "issue".into(),
+                            entity_id,
+                            identifier: Some(issue.identifier),
+                            title: issue.title,
+                        })
                 }
-            }),
-            AttachmentEntity::Page => {
-                queries::get_page(conn, entity_id).ok().map(|page| LinkedEntity {
-                    entity_type: "page".into(),
-                    entity_id,
-                    identifier: Some(page.identifier),
-                    title: page.title,
-                })
-            }
-            AttachmentEntity::Comment => queries::comments::get_comment(conn, entity_id)
-                .ok()
-                .map(|comment| LinkedEntity {
-                    entity_type: "comment".into(),
-                    entity_id,
-                    // A comment is not addressable by identifier; the client
-                    // navigates to it through its parent issue or page.
-                    identifier: None,
-                    title: comment_title(&comment.content),
-                }),
-        };
+                AttachmentEntity::Page => {
+                    queries::get_page(conn, entity_id)
+                        .ok()
+                        .map(|page| LinkedEntity {
+                            entity_type: "page".into(),
+                            entity_id,
+                            identifier: Some(page.identifier),
+                            title: page.title,
+                        })
+                }
+                AttachmentEntity::Comment => queries::comments::get_comment(conn, entity_id)
+                    .ok()
+                    .map(|comment| LinkedEntity {
+                        entity_type: "comment".into(),
+                        entity_id,
+                        // A comment is not addressable by identifier; the client
+                        // navigates to it through its parent issue or page.
+                        identifier: None,
+                        title: comment_title(&comment.content),
+                    }),
+            };
         Ok(described)
     })
 }
@@ -1288,7 +1296,11 @@ mod tests {
         assert!(matches!(error, LificError::Unavailable(_)), "got {error:?}");
         let response = error.into_response();
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-        assert!(response.headers().contains_key(axum::http::header::RETRY_AFTER));
+        assert!(
+            response
+                .headers()
+                .contains_key(axum::http::header::RETRY_AFTER)
+        );
 
         release_tx.send(()).unwrap();
         worker.join().unwrap().unwrap();
@@ -1429,12 +1441,18 @@ mod tests {
 
     #[test]
     fn ranges_outside_the_resource_are_unsatisfiable() {
-        assert_eq!(parse_range("bytes=1000-", 1000), RangeRequest::Unsatisfiable);
+        assert_eq!(
+            parse_range("bytes=1000-", 1000),
+            RangeRequest::Unsatisfiable
+        );
         assert_eq!(
             parse_range("bytes=1500-1600", 1000),
             RangeRequest::Unsatisfiable
         );
-        assert_eq!(parse_range("bytes=50-10", 1000), RangeRequest::Unsatisfiable);
+        assert_eq!(
+            parse_range("bytes=50-10", 1000),
+            RangeRequest::Unsatisfiable
+        );
         assert_eq!(parse_range("bytes=-0", 1000), RangeRequest::Unsatisfiable);
         assert_eq!(parse_range("bytes=0-0", 0), RangeRequest::Unsatisfiable);
     }
@@ -1728,7 +1746,11 @@ mod api_tests {
 
         for (name, mime, bytes) in [
             ("shot.png", "image/png", png_bytes()),
-            ("logo.svg", "image/svg+xml", b"<svg xmlns=\"x\"></svg>".to_vec()),
+            (
+                "logo.svg",
+                "image/svg+xml",
+                b"<svg xmlns=\"x\"></svg>".to_vec(),
+            ),
             ("notes.txt", "text/plain", b"hello\n".to_vec()),
         ] {
             let resp = upload(&app, name, mime, &bytes, None).await;
@@ -1860,15 +1882,17 @@ mod api_tests {
                 display_name: lead.display_name.clone(),
                 is_admin: false,
             })))
-            .layer(axum::Extension(Some(crate::resolve_caller::ResolvedIdentity {
-                user: AuthUser {
-                    id: lead.id,
-                    username: lead.username.clone(),
-                    display_name: lead.display_name.clone(),
-                    is_admin: false,
+            .layer(axum::Extension(Some(
+                crate::resolve_caller::ResolvedIdentity {
+                    user: AuthUser {
+                        id: lead.id,
+                        username: lead.username.clone(),
+                        display_name: lead.display_name.clone(),
+                        is_admin: false,
+                    },
+                    transport: crate::actor::Transport::Web,
                 },
-                transport: crate::actor::Transport::Web,
-            })));
+            )));
 
         let issue = parse_json(
             json_post(
@@ -2240,15 +2264,17 @@ mod api_tests {
                 display_name: "GC".into(),
                 is_admin: true,
             })))
-            .layer(axum::Extension(Some(crate::resolve_caller::ResolvedIdentity {
-                user: AuthUser {
-                    id: admin_id,
-                    username: "gc".into(),
-                    display_name: "GC".into(),
-                    is_admin: true,
+            .layer(axum::Extension(Some(
+                crate::resolve_caller::ResolvedIdentity {
+                    user: AuthUser {
+                        id: admin_id,
+                        username: "gc".into(),
+                        display_name: "GC".into(),
+                        is_admin: true,
+                    },
+                    transport: crate::actor::Transport::Web,
                 },
-                transport: crate::actor::Transport::Web,
-            })));
+            )));
         let (project_id2, _) = seed_project(&app).await;
 
         // Upload two: one linked to an issue, one left dangling.
@@ -2349,8 +2375,9 @@ mod api_tests {
         // Unlinked: belongs to no project, so it stays out of the listing.
         upload(&app, "stray.txt", "text/plain", b"nowhere\n", None).await;
 
-        let body = parse_json(json_get(&app, &format!("/api/projects/{project_id}/attachments")).await)
-            .await;
+        let body =
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/attachments")).await)
+                .await;
         assert_eq!(body["total_count"], 2);
         assert_eq!(body["has_more"], false);
         let items = body["items"].as_array().unwrap();
@@ -2454,7 +2481,14 @@ mod api_tests {
             Some(("issue", issue_id)),
         )
         .await;
-        upload(&app, "abandoned.txt", "text/plain", b"draft that never landed\n", None).await;
+        upload(
+            &app,
+            "abandoned.txt",
+            "text/plain",
+            b"draft that never landed\n",
+            None,
+        )
+        .await;
 
         let body = parse_json(
             json_get(
@@ -2622,7 +2656,12 @@ mod media_tests {
     }
 
     async fn body_bytes(resp: axum::response::Response) -> Vec<u8> {
-        resp.into_body().collect().await.unwrap().to_bytes().to_vec()
+        resp.into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .to_vec()
     }
 
     fn header(resp: &axum::response::Response, name: &str) -> Option<String> {
@@ -2816,8 +2855,9 @@ mod media_tests {
     #[tokio::test]
     async fn upload_records_raster_dimensions() {
         let app = test_app();
-        let data = parse_json(upload(&app, "big.png", "image/png", &png_image(800, 200), None).await)
-            .await;
+        let data =
+            parse_json(upload(&app, "big.png", "image/png", &png_image(800, 200), None).await)
+                .await;
         assert_eq!(data["width"], 800);
         assert_eq!(data["height"], 200);
         assert_eq!(data["has_thumbnail"], true);
@@ -2833,10 +2873,11 @@ mod media_tests {
     #[tokio::test]
     async fn thumbnail_endpoint_serves_a_downscaled_webp() {
         let app = test_app();
-        let id = parse_json(upload(&app, "big.png", "image/png", &png_image(1200, 600), None).await)
-            .await["id"]
-            .as_i64()
-            .unwrap();
+        let id =
+            parse_json(upload(&app, "big.png", "image/png", &png_image(1200, 600), None).await)
+                .await["id"]
+                .as_i64()
+                .unwrap();
 
         let resp = json_get(&app, &format!("/api/attachments/{id}/thumbnail")).await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -2871,10 +2912,10 @@ mod media_tests {
         );
 
         // Not a raster image at all.
-        let text = parse_json(upload(&app, "n.txt", "text/plain", b"hello\n", None).await).await
-            ["id"]
-            .as_i64()
-            .unwrap();
+        let text =
+            parse_json(upload(&app, "n.txt", "text/plain", b"hello\n", None).await).await["id"]
+                .as_i64()
+                .unwrap();
         assert_eq!(
             json_get(&app, &format!("/api/attachments/{text}/thumbnail"))
                 .await
@@ -2908,11 +2949,9 @@ mod media_tests {
             .unwrap();
         let sha: String = {
             let conn = db.read().unwrap();
-            conn.query_row(
-                "SELECT sha256 FROM attachments WHERE id = ?1",
-                [id],
-                |r| r.get(0),
-            )
+            conn.query_row("SELECT sha256 FROM attachments WHERE id = ?1", [id], |r| {
+                r.get(0)
+            })
             .unwrap()
         };
 
@@ -3067,7 +3106,12 @@ mod media_tests {
         assert_eq!(data["alt_text"], serde_json::Value::Null);
 
         // An empty patch is a no-op rather than a 400.
-        let resp = json_patch(&app, &format!("/api/attachments/{id}"), serde_json::json!({})).await;
+        let resp = json_patch(
+            &app,
+            &format!("/api/attachments/{id}"),
+            serde_json::json!({}),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
@@ -3184,7 +3228,14 @@ mod media_tests {
 
         let bytes = png_image(20, 20);
         let id = parse_json(
-            upload(&app, "shot.png", "image/png", &bytes, Some(("issue", issue_id))).await,
+            upload(
+                &app,
+                "shot.png",
+                "image/png",
+                &bytes,
+                Some(("issue", issue_id)),
+            )
+            .await,
         )
         .await["id"]
             .as_i64()
@@ -3218,7 +3269,10 @@ mod media_tests {
         assert_eq!(issue["title"], "Broken export");
         assert!(issue["identifier"].as_str().unwrap().contains('-'));
 
-        let page = entities.iter().find(|e| e["entity_type"] == "page").unwrap();
+        let page = entities
+            .iter()
+            .find(|e| e["entity_type"] == "page")
+            .unwrap();
         assert_eq!(page["title"], "Runbook");
         assert!(page["identifier"].as_str().unwrap().contains("-DOC-"));
 
@@ -3256,7 +3310,14 @@ mod media_tests {
 
         let bytes = png_image(24, 24);
         let first = parse_json(
-            upload(&app, "a.png", "image/png", &bytes, Some(("issue", issue_id))).await,
+            upload(
+                &app,
+                "a.png",
+                "image/png",
+                &bytes,
+                Some(("issue", issue_id)),
+            )
+            .await,
         )
         .await["id"]
             .as_i64()
@@ -3319,10 +3380,9 @@ mod media_tests {
             .as_i64()
             .unwrap();
 
-        let links = parse_json(
-            json_get(&outsider_app, &format!("/api/attachments/{mine}/links")).await,
-        )
-        .await;
+        let links =
+            parse_json(json_get(&outsider_app, &format!("/api/attachments/{mine}/links")).await)
+                .await;
         let dupes = links["duplicates"].as_array().unwrap();
         assert_eq!(dupes.len(), 1);
         assert_eq!(dupes[0]["attachment_id"], hidden);

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -21,11 +21,10 @@ use super::{require_admin, require_user, with_read, with_write};
 fn session_cookie(token: &str, expires_at: &str, secure: bool) -> String {
     use chrono::DateTime;
     // Parse expiry for Max-Age calculation; fall back to 30 days
-    let max_age = DateTime::parse_from_rfc3339(expires_at)
-        .map_or(30 * 24 * 3600, |exp| {
-            let exp_utc: DateTime<chrono::Utc> = exp.into();
-            (exp_utc - chrono::Utc::now()).num_seconds().max(0)
-        });
+    let max_age = DateTime::parse_from_rfc3339(expires_at).map_or(30 * 24 * 3600, |exp| {
+        let exp_utc: DateTime<chrono::Utc> = exp.into();
+        (exp_utc - chrono::Utc::now()).num_seconds().max(0)
+    });
 
     let secure_attr = if secure { "; Secure" } else { "" };
     format!("lific_token={token}; Path=/; Max-Age={max_age}; HttpOnly{secure_attr}; SameSite=Lax")
@@ -224,7 +223,9 @@ async fn authenticate_off_writer(
 
     // The read connection is released with this binding, before the verify.
     let challenge = with_read(db, |conn| {
-        Ok(crate::db::queries::users::password_challenge(conn, identity))
+        Ok(crate::db::queries::users::password_challenge(
+            conn, identity,
+        ))
     })?;
 
     let password = password.to_string();
@@ -367,12 +368,11 @@ pub(super) async fn auth_auto_login(
     // LIFIC-8: the "no credential → first admin" fallback is consolidated in
     // `resolve_caller`. Auto-login has no credential (it is the thing that
     // *produces* a session), so the passwordless fallback applies.
-    let admin = crate::resolve_caller::resolve_caller_conn(
-        &conn,
-        None,
-        crate::actor::Transport::Web,
-    )?
-    .ok_or_else(|| LificError::BadRequest("no admin account exists to sign in as".into()))?;
+    let admin =
+        crate::resolve_caller::resolve_caller_conn(&conn, None, crate::actor::Transport::Web)?
+            .ok_or_else(|| {
+                LificError::BadRequest("no admin account exists to sign in as".into())
+            })?;
     let admin = admin.user;
 
     let session = crate::db::queries::users::create_session(
@@ -718,9 +718,7 @@ pub(super) async fn refresh_session(
                 Err(rejected) => {
                     let retry = match rejected {
                         crate::ratelimit::ReservationRejection::First => rl.retry_after(&ip_key),
-                        crate::ratelimit::ReservationRejection::Second => {
-                            rl.retry_after(&user_key)
-                        }
+                        crate::ratelimit::ReservationRejection::Second => rl.retry_after(&user_key),
                     };
                     return Err(LificError::BadRequest(
                         crate::ratelimit::retry_after_message(
@@ -892,9 +890,7 @@ pub(super) async fn change_password(
                 Err(rejected) => {
                     let retry = match rejected {
                         crate::ratelimit::ReservationRejection::First => rl.retry_after(&ip_key),
-                        crate::ratelimit::ReservationRejection::Second => {
-                            rl.retry_after(&user_key)
-                        }
+                        crate::ratelimit::ReservationRejection::Second => rl.retry_after(&user_key),
                     };
                     return Err(LificError::BadRequest(
                         crate::ratelimit::retry_after_message(
@@ -2946,9 +2942,9 @@ mod tests {
     /// This exercises the handler directly with a resolved identity of None.
     #[tokio::test]
     async fn user_roster_handler_refuses_without_an_identity() {
-        let app = zero_user_app(crate::db::open_memory().expect("test db")).layer(
-            axum::Extension(None::<crate::resolve_caller::ResolvedIdentity>),
-        );
+        let app = zero_user_app(crate::db::open_memory().expect("test db")).layer(axum::Extension(
+            None::<crate::resolve_caller::ResolvedIdentity>,
+        ));
         let resp = json_get(&app, "/api/users").await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
@@ -3198,7 +3194,7 @@ mod tests {
             "/api/instance/settings",
             serde_json::json!({ "authz_enforced": true }),
         )
-            .await;
+        .await;
         assert_eq!(patch.status(), StatusCode::OK);
         assert_eq!(parse_json(patch).await["authz_enforced"], true);
 
@@ -3280,8 +3276,8 @@ mod tests {
                 "/api/instance/settings",
                 serde_json::json!({ "allow_signup": true })
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
     }
@@ -3558,16 +3554,20 @@ mod tests {
     // ── LIF-412: login verifies off the database writer ──────
 
     fn login_app(db: crate::db::DbPool) -> axum::Router {
-        with_client_ip_test_layers(crate::api::router(db, &[]), test_peer()).layer(
-            axum::Extension(crate::config::AuthConfig {
+        with_client_ip_test_layers(crate::api::router(db, &[]), test_peer()).layer(axum::Extension(
+            crate::config::AuthConfig {
                 allow_signup: true,
                 required: true,
                 secure_cookies: false,
-            }),
-        )
+            },
+        ))
     }
 
-    async fn login(app: &axum::Router, identity: &str, password: &str) -> (StatusCode, serde_json::Value) {
+    async fn login(
+        app: &axum::Router,
+        identity: &str,
+        password: &str,
+    ) -> (StatusCode, serde_json::Value) {
         let resp = json_post(
             app,
             "/api/auth/login",
@@ -4632,7 +4632,12 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::FORBIDDEN, "create is admin-only");
 
         for action in ["promote", "demote", "deactivate", "reactivate"] {
-            let resp = json_post(&app, &format!("/api/users/{}/{action}", admin.id), json!({})).await;
+            let resp = json_post(
+                &app,
+                &format!("/api/users/{}/{action}", admin.id),
+                json!({}),
+            )
+            .await;
             assert_eq!(
                 resp.status(),
                 StatusCode::FORBIDDEN,
@@ -4668,8 +4673,12 @@ mod tests {
         );
 
         for action in ["demote", "deactivate"] {
-            let resp =
-                json_post(&app, &format!("/api/users/{}/{action}", admin.id), json!({})).await;
+            let resp = json_post(
+                &app,
+                &format!("/api/users/{}/{action}", admin.id),
+                json!({}),
+            )
+            .await;
             assert_eq!(
                 resp.status(),
                 StatusCode::CONFLICT,
@@ -4677,7 +4686,10 @@ mod tests {
             );
             let data = parse_json(resp).await;
             assert!(
-                data["error"].as_str().unwrap().contains("last instance admin"),
+                data["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("last instance admin"),
                 "{action}: {data}"
             );
         }

--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -662,8 +662,8 @@ mod tests {
         .await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-        let listing = parse_json(json_get(&app, &format!("/api/issues/{issue_id}/comments")).await)
-            .await;
+        let listing =
+            parse_json(json_get(&app, &format!("/api/issues/{issue_id}/comments")).await).await;
         let comments = listing.as_array().unwrap();
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0]["content"], "Original");

--- a/src/api/export.rs
+++ b/src/api/export.rs
@@ -1,15 +1,15 @@
+use axum::Extension;
 use axum::body::{Body, Bytes};
 use axum::extract::{Path, Query, State};
-use axum::http::{header, HeaderMap, HeaderValue};
+use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::IntoResponse;
-use axum::Extension;
 use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::sync::OwnedSemaphorePermit;
 
 use crate::authz;
-use crate::db::models::Role;
 use crate::db::DbPool;
+use crate::db::models::Role;
 use crate::error::LificError;
 
 use super::with_read;
@@ -369,7 +369,7 @@ mod tests {
     use tower::ServiceExt;
 
     use super::{
-        blocking_export, stream_response, ExportTestGate, PreparedExport, EXPORT_TEST_GATE,
+        EXPORT_TEST_GATE, ExportTestGate, PreparedExport, blocking_export, stream_response,
     };
     use crate::api::test_helpers::{
         json_post, parse_json, seed_project, setup_membership_test, test_app,
@@ -457,10 +457,12 @@ mod tests {
         let bundle = parse_json(resp).await;
         assert_eq!(bundle["root"], "TST");
         assert_eq!(bundle["files"][0]["path"], "TST/issues/tst-1-export-me.md");
-        assert!(bundle["files"][0]["content"]
-            .as_str()
-            .unwrap()
-            .contains("# Export me"));
+        assert!(
+            bundle["files"][0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("# Export me")
+        );
     }
 
     #[tokio::test]
@@ -560,10 +562,11 @@ mod tests {
             resp.headers()[axum::http::header::CONTENT_TYPE],
             "application/zip"
         );
-        assert!(resp
-            .headers()
-            .get(axum::http::header::CONTENT_LENGTH)
-            .is_none());
+        assert!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_LENGTH)
+                .is_none()
+        );
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         assert!(!body.is_empty());
         assert_eq!(&body[..2], b"PK");

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -579,7 +579,9 @@ mod tests {
         let id = created["id"].as_i64().unwrap();
 
         assert_eq!(
-            json_delete(&app, &format!("/api/issues/{id}")).await.status(),
+            json_delete(&app, &format!("/api/issues/{id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
 
@@ -597,7 +599,8 @@ mod tests {
         .unwrap();
         assert!(list.is_empty(), "the list drops it too");
 
-        let board = body_of(json_get(&app, &format!("/api/projects/{project_id}/board")).await).await;
+        let board =
+            body_of(json_get(&app, &format!("/api/projects/{project_id}/board")).await).await;
         assert_eq!(
             board.as_object().map(|columns| columns.len()),
             Some(0),
@@ -614,7 +617,9 @@ mod tests {
 
         // Deleting it again is a 404, not a second tombstone.
         assert_eq!(
-            json_delete(&app, &format!("/api/issues/{id}")).await.status(),
+            json_delete(&app, &format!("/api/issues/{id}"))
+                .await
+                .status(),
             StatusCode::NOT_FOUND
         );
     }
@@ -872,7 +877,11 @@ mod tests {
             );
         }
         // Numeric ids come along for O(1) node lookup client-side.
-        assert!(edges.iter().all(|e| e["source_id"].is_i64() && e["target_id"].is_i64()));
+        assert!(
+            edges
+                .iter()
+                .all(|e| e["source_id"].is_i64() && e["target_id"].is_i64())
+        );
 
         let resp = json_get(&app, &format!("/api/projects/{other_id}/relations")).await;
         let edges: serde_json::Value = parse_json(resp).await;
@@ -924,7 +933,8 @@ mod tests {
         assert_eq!(body["reversed"], true);
 
         let edges: serde_json::Value =
-            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await).await;
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await)
+                .await;
         let edges = edges.as_array().unwrap();
         assert_eq!(edges.len(), 1, "reversal must not duplicate the edge");
         assert_eq!(edges[0]["source_identifier"], "TST-2");
@@ -965,10 +975,9 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-        let edges: serde_json::Value = parse_json(
-            json_get(&lead_app, &format!("/api/projects/{project_id}/relations")).await,
-        )
-        .await;
+        let edges: serde_json::Value =
+            parse_json(json_get(&lead_app, &format!("/api/projects/{project_id}/relations")).await)
+                .await;
         let edges = edges.as_array().unwrap();
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0]["source_identifier"], "MEM-1");
@@ -1000,7 +1009,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
         let edges: serde_json::Value =
-            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await).await;
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await)
+                .await;
         assert_eq!(edges.as_array().unwrap().len(), 0);
 
         // An edge running the other way is not a match either: reversing
@@ -1021,7 +1031,8 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         let edges: serde_json::Value =
-            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await).await;
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await)
+                .await;
         let edges = edges.as_array().unwrap();
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0]["source_identifier"], "TST-2");
@@ -1059,7 +1070,9 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/issues?project_id={project_id}&status=shipped"))
+                    .uri(format!(
+                        "/api/issues?project_id={project_id}&status=shipped"
+                    ))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -363,16 +363,16 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
         .route("/api/health", get(health))
         .layer(
             cors.allow_methods([
-                    axum::http::Method::GET,
-                    axum::http::Method::POST,
+                axum::http::Method::GET,
+                axum::http::Method::POST,
                 axum::http::Method::PATCH,
-                    axum::http::Method::PUT,
-                    axum::http::Method::DELETE,
-                ])
-                .allow_headers([
-                    axum::http::header::CONTENT_TYPE,
-                    axum::http::header::AUTHORIZATION,
-                ]),
+                axum::http::Method::PUT,
+                axum::http::Method::DELETE,
+            ])
+            .allow_headers([
+                axum::http::header::CONTENT_TYPE,
+                axum::http::header::AUTHORIZATION,
+            ]),
         )
         .with_state(db)
         .layer(Extension(cors_origins.to_vec()))
@@ -463,7 +463,7 @@ fn websocket_origin_allowed(headers: &HeaderMap, allowed_origins: &[String]) -> 
         Some(Ok(origin)) => {
             allowed_origins.iter().any(|allowed| allowed == origin)
                 || headers
-                .get(header::HOST)
+                    .get(header::HOST)
                     .and_then(|value| value.to_str().ok())
                     .is_some_and(|host| {
                         websocket_same_origin(origin, host, websocket_request_scheme(headers))
@@ -1148,7 +1148,7 @@ pub(crate) mod test_helpers {
             maintainer.id,
             Role::Maintainer,
         )
-            .unwrap();
+        .unwrap();
         crate::db::queries::members::upsert_member(&conn, project.id, viewer.id, Role::Viewer)
             .unwrap();
 
@@ -1657,8 +1657,8 @@ mod authz_gating_tests {
                 &format!("/api/issues/{issue_id}"),
                 serde_json::json!({"title": "hijack"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
         let non_member_app = app_as_user(db.clone(), &non_member);
@@ -1668,8 +1668,8 @@ mod authz_gating_tests {
                 &format!("/api/issues/{issue_id}"),
                 serde_json::json!({"title": "hijack"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 
@@ -1680,8 +1680,8 @@ mod authz_gating_tests {
                 &format!("/api/issues/{issue_id}"),
                 serde_json::json!({"title": "renamed"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
 
@@ -1789,8 +1789,8 @@ mod authz_gating_tests {
                 "/api/modules",
                 serde_json::json!({"project_id": project_id, "name": "Nope"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
         let non_member_app = app_as_user(db.clone(), &non_member);
@@ -1800,8 +1800,8 @@ mod authz_gating_tests {
                 "/api/labels",
                 serde_json::json!({"project_id": project_id, "name": "nope"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 
@@ -1812,8 +1812,8 @@ mod authz_gating_tests {
                 "/api/modules",
                 serde_json::json!({"project_id": project_id, "name": "Backend"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK,
             "maintainer should manage structure once enforcement loosens the gate"
         );
@@ -1823,8 +1823,8 @@ mod authz_gating_tests {
                 "/api/folders",
                 serde_json::json!({"project_id": project_id, "name": "Docs"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
     }
@@ -1843,8 +1843,8 @@ mod authz_gating_tests {
                 &format!("/api/projects/{project_id}"),
                 serde_json::json!({"name": "Nope"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 
@@ -1855,8 +1855,8 @@ mod authz_gating_tests {
                 &format!("/api/projects/{project_id}"),
                 serde_json::json!({"name": "Renamed"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
     }
@@ -1945,7 +1945,7 @@ mod authz_gating_tests {
                 maintainer.id,
                 Role::Maintainer,
             )
-                .unwrap();
+            .unwrap();
         }
         assert_eq!(
             json_post(&maintainer_app, "/api/issues/link", link_body)
@@ -1970,8 +1970,8 @@ mod authz_gating_tests {
                 "/api/pages",
                 serde_json::json!({"title": "Workspace doc"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 
@@ -2034,8 +2034,8 @@ mod authz_gating_tests {
                 "/api/issues",
                 serde_json::json!({ "project_id": project_id, "title": "by admin" })
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
         assert_eq!(
@@ -2044,8 +2044,8 @@ mod authz_gating_tests {
                 &format!("/api/issues/{issue_id}"),
                 serde_json::json!({"title": "renamed by admin"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
 
@@ -2268,8 +2268,8 @@ mod authz_gating_tests {
                 "/api/modules",
                 serde_json::json!({"project_id": project_id, "name": "Nope"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
         let lead_app = app_as_user(db.clone(), &lead);
@@ -2279,8 +2279,8 @@ mod authz_gating_tests {
                 "/api/modules",
                 serde_json::json!({"project_id": project_id, "name": "Yes"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
 
@@ -2321,7 +2321,7 @@ mod authz_gating_tests {
             "/api/instance/settings",
             serde_json::json!({"authz_enforced": true}),
         )
-            .await;
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(parse_json(resp).await["authz_enforced"], true);
 

--- a/src/api/pages.rs
+++ b/src/api/pages.rs
@@ -431,7 +431,9 @@ mod tests {
         let id = created["id"].as_i64().unwrap();
 
         assert_eq!(
-            json_delete(&app, &format!("/api/pages/{id}")).await.status(),
+            json_delete(&app, &format!("/api/pages/{id}"))
+                .await
+                .status(),
             StatusCode::OK
         );
         assert_eq!(
@@ -439,7 +441,9 @@ mod tests {
             StatusCode::NOT_FOUND
         );
         assert_eq!(
-            json_get(&app, "/api/pages/resolve/TST-DOC-1").await.status(),
+            json_get(&app, "/api/pages/resolve/TST-DOC-1")
+                .await
+                .status(),
             StatusCode::NOT_FOUND
         );
         let listed: Vec<serde_json::Value> = serde_json::from_value(
@@ -448,7 +452,12 @@ mod tests {
         .unwrap();
         assert!(listed.is_empty());
 
-        let resp = json_post(&app, &format!("/api/pages/{id}/restore"), serde_json::json!({})).await;
+        let resp = json_post(
+            &app,
+            &format!("/api/pages/{id}/restore"),
+            serde_json::json!({}),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let restored = parse_json(resp).await;
         assert_eq!(restored["identifier"], "TST-DOC-1");
@@ -476,9 +485,13 @@ mod tests {
         .await;
         let id = created["id"].as_i64().unwrap();
         assert_eq!(
-            json_post(&app, &format!("/api/pages/{id}/restore"), serde_json::json!({}))
-                .await
-                .status(),
+            json_post(
+                &app,
+                &format!("/api/pages/{id}/restore"),
+                serde_json::json!({})
+            )
+            .await
+            .status(),
             StatusCode::NOT_FOUND
         );
     }

--- a/src/api/plans.rs
+++ b/src/api/plans.rs
@@ -22,7 +22,8 @@ fn require_issue_project_role(
     identity: &Option<crate::resolve_caller::ResolvedIdentity>,
     issue_id: i64,
 ) -> Result<(), LificError> {
-    let project_id = with_read(db, |conn| crate::db::queries::get_issue(conn, issue_id))?.project_id;
+    let project_id =
+        with_read(db, |conn| crate::db::queries::get_issue(conn, issue_id))?.project_id;
     authz::require_role(db, identity, project_id, Role::Maintainer)
 }
 
@@ -96,7 +97,9 @@ pub(super) async fn create_plan(
     authz::require_role(&db, &identity, input.project_id, Role::Maintainer)?;
     require_create_plan_issue_roles(&db, &identity, &input)?;
     let plan = with_write(&db, |conn| plans::create_plan(conn, &input))?;
-    realtime.send(RealtimeEvent::ProjectUpdated { project_id: plan.project_id });
+    realtime.send(RealtimeEvent::ProjectUpdated {
+        project_id: plan.project_id,
+    });
     Ok(Json(plan))
 }
 
@@ -396,7 +399,14 @@ mod tests {
             assert_eq!(response.status(), StatusCode::OK);
         }
 
-        let first = body_json(json_get(&app, &format!("/api/plans?project_id={project_id}&order_by=id&limit=2")).await).await;
+        let first = body_json(
+            json_get(
+                &app,
+                &format!("/api/plans?project_id={project_id}&order_by=id&limit=2"),
+            )
+            .await,
+        )
+        .await;
         let first = first.as_array().unwrap();
         assert_eq!(first.len(), 2);
         let cursor_id = first[1]["id"].as_i64().unwrap();

--- a/src/api/project_groups.rs
+++ b/src/api/project_groups.rs
@@ -313,7 +313,11 @@ mod tests {
 
         let resp = json_get(&app, "/api/project-groups").await;
         let groups = parse_json(resp).await;
-        assert_eq!(groups.as_array().unwrap().len(), 1, "the group itself stays");
+        assert_eq!(
+            groups.as_array().unwrap().len(),
+            1,
+            "the group itself stays"
+        );
         assert!(
             groups[0]["project_ids"].as_array().unwrap().is_empty(),
             "a project the caller can no longer see must not be listed"

--- a/src/api/projects.rs
+++ b/src/api/projects.rs
@@ -805,8 +805,7 @@ mod tests {
     /// filter_visible), not just the authz unit.
     #[tokio::test]
     async fn enforced_admin_sees_all_projects_non_member_sees_none() {
-        let (db, admin, _lead, _maint, _viewer, non_member, project_id) =
-            setup_membership_test();
+        let (db, admin, _lead, _maint, _viewer, non_member, project_id) = setup_membership_test();
 
         let resp = json_get(&app_as_user(db.clone(), &admin), "/api/projects").await;
         assert_eq!(resp.status(), StatusCode::OK);

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -44,8 +44,7 @@ pub(super) trait Structure: 'static {
 
     fn list(conn: &Connection, project_id: i64) -> Result<Vec<Self::Model>, LificError>;
     fn create(conn: &Connection, input: &Self::Create) -> Result<Self::Model, LificError>;
-    fn update(conn: &Connection, id: i64, input: &Self::Update)
-    -> Result<Self::Model, LificError>;
+    fn update(conn: &Connection, id: i64, input: &Self::Update) -> Result<Self::Model, LificError>;
     fn delete(conn: &Connection, id: i64) -> Result<(), LificError>;
 }
 
@@ -250,7 +249,9 @@ pub(super) async fn merge_label_handler(
     let label = with_write(&db, |conn| {
         crate::db::queries::merge_label(conn, id, input.into)
     })?;
-    realtime.send(RealtimeEvent::ProjectUpdated { project_id: source_project });
+    realtime.send(RealtimeEvent::ProjectUpdated {
+        project_id: source_project,
+    });
     Ok(Json(label))
 }
 

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -87,7 +87,11 @@ mod tests {
             serde_json::json!({ "project_id": project_id, "title": "Design" }),
         )
         .await;
-        json_delete(&app, &format!("/api/issues/{}", doomed["id"].as_i64().unwrap())).await;
+        json_delete(
+            &app,
+            &format!("/api/issues/{}", doomed["id"].as_i64().unwrap()),
+        )
+        .await;
 
         let resp = json_get(&app, &format!("/api/projects/{project_id}/index")).await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -137,7 +141,11 @@ mod tests {
             serde_json::json!({ "title": "edited twice" }),
         )
         .await;
-        json_delete(&app, &format!("/api/issues/{}", doomed["id"].as_i64().unwrap())).await;
+        json_delete(
+            &app,
+            &format!("/api/issues/{}", doomed["id"].as_i64().unwrap()),
+        )
+        .await;
 
         let body = parse_json(
             json_get(
@@ -151,10 +159,7 @@ mod tests {
         assert_eq!(changes.len(), 2, "only the two touched rows");
         assert!(!body["has_more"].as_bool().unwrap());
 
-        let seqs: Vec<i64> = changes
-            .iter()
-            .map(|c| c["seq"].as_i64().unwrap())
-            .collect();
+        let seqs: Vec<i64> = changes.iter().map(|c| c["seq"].as_i64().unwrap()).collect();
         let mut sorted = seqs.clone();
         sorted.sort_unstable();
         assert_eq!(seqs, sorted, "ascending by seq");
@@ -194,10 +199,8 @@ mod tests {
         )
         .await;
 
-        let body = parse_json(
-            json_get(&app, &format!("/api/projects/{project_id}/changes")).await,
-        )
-        .await;
+        let body =
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/changes")).await).await;
         let comments: Vec<&serde_json::Value> = body["changes"]
             .as_array()
             .unwrap()
@@ -292,7 +295,11 @@ mod tests {
 
         // `limit=-1` must floor at 1 rather than becoming SQLite's "no limit".
         let clamped = parse_json(
-            json_get(&app, &format!("/api/projects/{project_id}/changes?limit=-1")).await,
+            json_get(
+                &app,
+                &format!("/api/projects/{project_id}/changes?limit=-1"),
+            )
+            .await,
         )
         .await;
         assert_eq!(clamped["changes"].as_array().unwrap().len(), 1);
@@ -362,10 +369,9 @@ mod authz_gating_tests {
         }
 
         let viewer_app = app_as_user(db, &viewer);
-        let changes = parse_json(
-            json_get(&viewer_app, &format!("/api/projects/{project_id}/changes")).await,
-        )
-        .await;
+        let changes =
+            parse_json(json_get(&viewer_app, &format!("/api/projects/{project_id}/changes")).await)
+                .await;
         assert_eq!(changes["changes"].as_array().unwrap().len(), 1);
 
         let index =

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -443,8 +443,8 @@ mod tests {
                 &non_member_app,
                 &format!("/api/projects/{project_id}/views/{view_id}")
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -618,7 +618,9 @@ fn oauth_blocked_reason(method: &Method, path: &str) -> Option<&'static str> {
     // nothing reaches here; the rule is here so moving them behind auth later
     // cannot hand a token authority over the flow that issued it.
     if path == "/oauth" || path.starts_with("/oauth/") {
-        return Some("OAuth client and token administration is not available to OAuth-token callers");
+        return Some(
+            "OAuth client and token administration is not available to OAuth-token callers",
+        );
     }
 
     None
@@ -964,21 +966,33 @@ pub async fn require_api_key(
         Ok(user) => user,
         Err(ApiKeyReject::BadChecksum) => {
             warn!("rejected API key with invalid checksum");
-            return (StatusCode::UNAUTHORIZED,
-                    [("WWW-Authenticate", www_auth.as_str())], "Invalid API key").into_response();
+            return (
+                StatusCode::UNAUTHORIZED,
+                [("WWW-Authenticate", www_auth.as_str())],
+                "Invalid API key",
+            )
+                .into_response();
         }
         Err(ApiKeyReject::Db) => {
             return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
         }
         Err(ApiKeyReject::NotFound) => {
             warn!("rejected invalid API key");
-            return (StatusCode::UNAUTHORIZED,
-                    [("WWW-Authenticate", www_auth.as_str())], "Invalid API key").into_response();
+            return (
+                StatusCode::UNAUTHORIZED,
+                [("WWW-Authenticate", www_auth.as_str())],
+                "Invalid API key",
+            )
+                .into_response();
         }
         Err(ApiKeyReject::HashMismatch) => {
             warn!("API key hash verification failed");
-            return (StatusCode::UNAUTHORIZED,
-                    [("WWW-Authenticate", www_auth.as_str())], "Invalid API key").into_response();
+            return (
+                StatusCode::UNAUTHORIZED,
+                [("WWW-Authenticate", www_auth.as_str())],
+                "Invalid API key",
+            )
+                .into_response();
         }
         Err(ApiKeyReject::Inactive) => {
             warn!("rejected API key: deactivated account, or a bot with a deactivated owner");
@@ -1249,22 +1263,12 @@ mod tests {
         let pool = test_db();
         let manager = create_key_manager().unwrap();
 
-        let live = create_api_key_with_expiry(
-            &pool,
-            &manager,
-            "live",
-            Some(&rfc3339_from_now(1)),
-            None,
-        )
-        .unwrap();
-        let dead = create_api_key_with_expiry(
-            &pool,
-            &manager,
-            "dead",
-            Some(&rfc3339_from_now(-1)),
-            None,
-        )
-        .unwrap();
+        let live =
+            create_api_key_with_expiry(&pool, &manager, "live", Some(&rfc3339_from_now(1)), None)
+                .unwrap();
+        let dead =
+            create_api_key_with_expiry(&pool, &manager, "dead", Some(&rfc3339_from_now(-1)), None)
+                .unwrap();
 
         assert!(
             validate_api_key(&pool, &manager, &live).is_ok(),
@@ -2567,7 +2571,12 @@ mod tests {
         state.required = false;
 
         let resp = operator_probe_app(state, pool.clone())
-            .oneshot(Request::builder().uri("/probe").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -2582,10 +2591,11 @@ mod tests {
     #[tokio::test]
     async fn auth_required_default_credentialless_request_still_401s() {
         let pool = test_db();
-        let resp = echo_app(test_auth_state(&pool)) // required: true
-            .oneshot(Request::builder().uri("/echo").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+        let resp =
+            echo_app(test_auth_state(&pool)) // required: true
+                .oneshot(Request::builder().uri("/echo").body(Body::empty()).unwrap())
+                .await
+                .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
@@ -2600,9 +2610,9 @@ mod tests {
         state.required = false;
 
         for bad in [
-            "lific_sk-garbage",          // malformed API key
-            "lific_sess_expiredorfake",  // unknown session
-            "lific_at_neverissued",      // unknown OAuth token
+            "lific_sk-garbage",         // malformed API key
+            "lific_sess_expiredorfake", // unknown session
+            "lific_at_neverissued",     // unknown OAuth token
         ] {
             let resp = echo_app(state.clone())
                 .oneshot(
@@ -2661,7 +2671,10 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        assert_eq!(bytes.as_ref(), format!("user:{user_id}:optionaluser:false").as_bytes());
+        assert_eq!(
+            bytes.as_ref(),
+            format!("user:{user_id}:optionaluser:false").as_bytes()
+        );
     }
 
     #[tokio::test]
@@ -2978,10 +2991,7 @@ mod tests {
 
     #[test]
     fn is_attachment_download_matches_numeric_id_get() {
-        assert!(is_attachment_download(
-            &Method::GET,
-            "/api/attachments/5"
-        ));
+        assert!(is_attachment_download(&Method::GET, "/api/attachments/5"));
         assert!(is_attachment_download(
             &Method::GET,
             "/api/attachments/12345"
@@ -2990,10 +3000,7 @@ mod tests {
 
     #[test]
     fn is_attachment_download_tolerates_trailing_slash() {
-        assert!(is_attachment_download(
-            &Method::GET,
-            "/api/attachments/7/"
-        ));
+        assert!(is_attachment_download(&Method::GET, "/api/attachments/7/"));
     }
 
     #[test]
@@ -3013,10 +3020,7 @@ mod tests {
             &Method::GET,
             "/api/attachments/5/extra"
         ));
-        assert!(!is_attachment_download(
-            &Method::GET,
-            "/api/attachments/5x"
-        ));
+        assert!(!is_attachment_download(&Method::GET, "/api/attachments/5x"));
     }
 
     /// LIF-418: a thumbnail is loaded by an `<img>` exactly like the full
@@ -3056,10 +3060,7 @@ mod tests {
             &Method::DELETE,
             "/api/attachments/5"
         ));
-        assert!(!is_attachment_download(
-            &Method::POST,
-            "/api/attachments/5"
-        ));
+        assert!(!is_attachment_download(&Method::POST, "/api/attachments/5"));
     }
 
     #[test]
@@ -3067,7 +3068,9 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(
             "cookie",
-            "foo=bar; lific_token=lific_sess_abc123; baz=qux".parse().unwrap(),
+            "foo=bar; lific_token=lific_sess_abc123; baz=qux"
+                .parse()
+                .unwrap(),
         );
         assert_eq!(
             session_cookie_token(&headers).as_deref(),
@@ -3519,11 +3522,7 @@ mod tests {
             ("POST", "/api/auth/bots", Some(serde_json::json!({}))),
             ("POST", "/api/auth/bots/1/disconnect", None),
             ("DELETE", "/api/auth/bots/1", None),
-            (
-                "POST",
-                "/api/auth/me/password",
-                Some(serde_json::json!({})),
-            ),
+            ("POST", "/api/auth/me/password", Some(serde_json::json!({}))),
             ("DELETE", "/api/auth/me/sessions", None),
             ("POST", "/api/users/1/promote", None),
         ];

--- a/src/authz_coverage_tests.rs
+++ b/src/authz_coverage_tests.rs
@@ -298,9 +298,7 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
         ),
         (
             ("PUT", "/api/projects/reorder"),
-            Exempt(
-                "require_user only; instance-wide sidebar chrome, not a project edit — LIF-233",
-            ),
+            Exempt("require_user only; instance-wide sidebar chrome, not a project edit — LIF-233"),
         ),
         (("GET", "/api/projects/{id}"), Gated(Viewer)),
         (("PUT", "/api/projects/{id}"), Gated(Lead)),

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -166,8 +166,7 @@ fn run_backup(
 
     match dump::write_dump(pool, db_path, &backup_path) {
         Ok(manifest) => {
-            let size = std::fs::metadata(&backup_path)
-                .map_or(0, |m| m.len());
+            let size = std::fs::metadata(&backup_path).map_or(0, |m| m.len());
             info!(
                 path = %backup_path.display(),
                 size_kb = size / 1024,
@@ -262,7 +261,11 @@ fn prune_audit_log(pool: &DbPool, audit_retention_days: Option<u32>) {
         rusqlite::params![cutoff],
     ) {
         Ok(0) => {}
-        Ok(deleted) => info!(deleted, retention_days = days, "pruned old audit log entries"),
+        Ok(deleted) => info!(
+            deleted,
+            retention_days = days,
+            "pruned old audit log entries"
+        ),
         Err(e) => warn!(error = %e, "audit log pruning failed"),
     }
 }
@@ -359,8 +362,7 @@ fn rotate_backups(backup_dir: &Path, db_stem: &str, retain: usize) {
                     return false;
                 }
                 // New archives (`.tar.gz`) or legacy snapshots (`.db`).
-                name.ends_with(".tar.gz")
-                    || p.extension().and_then(|e| e.to_str()) == Some("db")
+                name.ends_with(".tar.gz") || p.extension().and_then(|e| e.to_str()) == Some("db")
             })
             .collect(),
         Err(e) => {
@@ -581,7 +583,13 @@ mod tests {
         let other_stem = dir.join("other_20260101_120000.tar.archive.tmp");
         let real_backup = dir.join("lific_20260101_120000.tar.gz");
         let stale_dir = dir.join(".lific-dump-stale");
-        for p in [&stale_snap, &stale_arch, &fresh_arch, &other_stem, &real_backup] {
+        for p in [
+            &stale_snap,
+            &stale_arch,
+            &fresh_arch,
+            &other_stem,
+            &real_backup,
+        ] {
             fs::write(p, "x").unwrap();
         }
         fs::create_dir(&stale_dir).unwrap();
@@ -590,10 +598,7 @@ mod tests {
         backdate(&stale_arch, old);
         backdate(&other_stem, old);
         backdate(&real_backup, old);
-        backdate(
-            &stale_dir.join("activity"),
-            old,
-        );
+        backdate(&stale_dir.join("activity"), old);
 
         sweep_stale_tmps(dir, "lific");
 
@@ -601,8 +606,14 @@ mod tests {
         assert!(!stale_arch.exists(), "stale archive tmp must be swept");
         assert!(fresh_arch.exists(), "fresh staging tmp must survive");
         assert!(other_stem.exists(), "other stems are not ours to sweep");
-        assert!(real_backup.exists(), "real archives are rotation's job, not the sweep's");
-        assert!(!stale_dir.exists(), "stale dump staging directory must be swept");
+        assert!(
+            real_backup.exists(),
+            "real archives are rotation's job, not the sweep's"
+        );
+        assert!(
+            !stale_dir.exists(),
+            "stale dump staging directory must be swept"
+        );
     }
 
     #[test]
@@ -708,8 +719,16 @@ mod tests {
             .map(|e| e.unwrap().path().unwrap().to_string_lossy().to_string())
             .collect();
         assert!(names.iter().any(|n| n == crate::dump::ARCHIVE_DB_NAME));
-        assert!(names.iter().any(|n| n == crate::dump::ARCHIVE_MANIFEST_NAME));
-        assert!(names.iter().any(|n| n == &format!("attachments/{blob_name}")));
+        assert!(
+            names
+                .iter()
+                .any(|n| n == crate::dump::ARCHIVE_MANIFEST_NAME)
+        );
+        assert!(
+            names
+                .iter()
+                .any(|n| n == &format!("attachments/{blob_name}"))
+        );
         assert!(
             !names.iter().any(|n| n.ends_with(".tmp")),
             "in-progress .tmp writes must not be archived: {names:?}"

--- a/src/cli/agents_md.rs
+++ b/src/cli/agents_md.rs
@@ -100,7 +100,8 @@ pub fn write(path: &Path, project: Option<&str>) -> Result<AgentsAction, String>
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
     }
-    std::fs::write(path, contents).map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    std::fs::write(path, contents)
+        .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
     Ok(action)
 }
 
@@ -224,7 +225,10 @@ mod tests {
         std::fs::write(&path, "Top.\n").unwrap();
         write(&path, Some("OLD")).unwrap();
         // Append trailing content after the block to prove it's preserved.
-        let with_trailer = format!("{}\n\nTrailing note.\n", std::fs::read_to_string(&path).unwrap().trim_end());
+        let with_trailer = format!(
+            "{}\n\nTrailing note.\n",
+            std::fs::read_to_string(&path).unwrap().trim_end()
+        );
         std::fs::write(&path, with_trailer).unwrap();
 
         let action = write(&path, Some("NEW")).unwrap();

--- a/src/cli/connect/clients.rs
+++ b/src/cli/connect/clients.rs
@@ -251,8 +251,12 @@ impl ClientSpec {
         // token into the client's env field as LIFIC_TOKEN so the spawned
         // server resolves the caller as the bound agent. Clients that can't
         // carry an env map get the token silently dropped (i.e. write nothing).
-        if let (Transport::Stdio { token: Some(tok), .. }, Some(env_key)) =
-            (&cfg.transport, self.stdio_env_key)
+        if let (
+            Transport::Stdio {
+                token: Some(tok), ..
+            },
+            Some(env_key),
+        ) = (&cfg.transport, self.stdio_env_key)
         {
             entry.value[env_key] = serde_json::json!({ "LIFIC_TOKEN": tok });
         }
@@ -455,9 +459,7 @@ pub fn all_clients() -> Vec<ClientSpec> {
                             "claude_desktop_config.json",
                         ],
                     ),
-                    Os::Windows => {
-                        config_dir(b, &["Claude", "claude_desktop_config.json"])
-                    }
+                    Os::Windows => config_dir(b, &["Claude", "claude_desktop_config.json"]),
                     Os::Linux => config_dir(b, &["Claude", "claude_desktop_config.json"]),
                 })
             },
@@ -1037,7 +1039,10 @@ mod tests {
         assert_eq!(e.top_key, "mcp");
         assert_eq!(e.value["type"], "remote");
         assert_eq!(e.value["url"], "http://127.0.0.1:3456/mcp");
-        assert_eq!(e.value["headers"]["Authorization"], "Bearer lific_sk-live-KEY");
+        assert_eq!(
+            e.value["headers"]["Authorization"],
+            "Bearer lific_sk-live-KEY"
+        );
         assert_eq!(e.value["enabled"], true);
     }
 
@@ -1055,9 +1060,7 @@ mod tests {
 
     #[test]
     fn opencode_stdio_token_writes_into_environment_field() {
-        let e = find_client("opencode")
-            .unwrap()
-            .compile(&stdio_token_cfg());
+        let e = find_client("opencode").unwrap().compile(&stdio_token_cfg());
         assert_eq!(e.value["type"], "local");
         // Command stays unchanged.
         assert_eq!(
@@ -1065,7 +1068,10 @@ mod tests {
             serde_json::json!(["lific", "--db", "/abs/lific.db", "mcp"])
         );
         // opencode names its env field `environment`.
-        assert_eq!(e.value["environment"]["LIFIC_TOKEN"], "lific_sk-live-AGENTTOKEN");
+        assert_eq!(
+            e.value["environment"]["LIFIC_TOKEN"],
+            "lific_sk-live-AGENTTOKEN"
+        );
     }
 
     #[test]
@@ -1147,7 +1153,9 @@ mod tests {
 
     #[test]
     fn claude_desktop_remote_uses_mcp_remote_shim() {
-        let e = find_client("claude-desktop").unwrap().compile(&remote_cfg());
+        let e = find_client("claude-desktop")
+            .unwrap()
+            .compile(&remote_cfg());
         assert_eq!(e.value["command"], "npx");
         let args = e.value["args"].as_array().unwrap();
         assert!(args.iter().any(|a| a == "mcp-remote"));
@@ -1201,9 +1209,7 @@ mod tests {
                 .unwrap()
                 .path_for(&base, Scope::Global)
                 .unwrap(),
-            PathBuf::from(
-                "C:\\Users\\tester\\AppData\\Roaming/Claude/claude_desktop_config.json"
-            )
+            PathBuf::from("C:\\Users\\tester\\AppData\\Roaming/Claude/claude_desktop_config.json")
         );
     }
 

--- a/src/cli/connect/mod.rs
+++ b/src/cli/connect/mod.rs
@@ -329,9 +329,7 @@ fn interactive_picker(detected: &[DetectedClient], target: &str) -> Result<Vec<S
     let mut prompt = cliclack::multiselect(if any_installed {
         format!("Which clients should connect to {target}?")
     } else {
-        format!(
-            "No installed clients detected in this scope — pick any to configure for {target}:"
-        )
+        format!("No installed clients detected in this scope — pick any to configure for {target}:")
     })
     .required(true);
     for c in &ordered {
@@ -741,7 +739,10 @@ fn write_all_clients(
                 id: id.clone(),
                 display: spec.display.to_string(),
                 format: spec.format.as_str().to_string(),
-                error: Some(format!("{} does not support --oauth; skipped", spec.display)),
+                error: Some(format!(
+                    "{} does not support --oauth; skipped",
+                    spec.display
+                )),
                 notes: vec![reason.to_string()],
                 ..Default::default()
             });
@@ -879,8 +880,7 @@ fn maybe_write_agents_md(
         return Ok(None);
     }
 
-    let looks_like_project =
-        args.scope == Scope::Project || base.project.join(".git").exists();
+    let looks_like_project = args.scope == Scope::Project || base.project.join(".git").exists();
     if !looks_like_project {
         return Ok(None);
     }
@@ -1170,14 +1170,8 @@ mod tests {
         let guard = tmp();
         let dir = guard.path();
         let b = base(dir);
-        let err = resolve_clients_inner(
-            &["nope".into()],
-            true,
-            &b,
-            Scope::Global,
-            no_picker,
-        )
-        .unwrap_err();
+        let err = resolve_clients_inner(&["nope".into()], true, &b, Scope::Global, no_picker)
+            .unwrap_err();
         assert!(err.contains("unknown client"));
     }
 
@@ -1196,10 +1190,9 @@ mod tests {
         let guard = tmp();
         let dir = guard.path();
         let b = base(dir);
-        let got = resolve_clients_inner(&[], true, &b, Scope::Global, |_| {
-            Ok(vec!["cursor".into()])
-        })
-        .unwrap();
+        let got =
+            resolve_clients_inner(&[], true, &b, Scope::Global, |_| Ok(vec!["cursor".into()]))
+                .unwrap();
         assert_eq!(got, vec!["cursor".to_string()]);
     }
 
@@ -1240,14 +1233,12 @@ mod tests {
 
     #[test]
     fn transport_tty_no_flag_calls_picker() {
-        let got =
-            resolve_transport_inner(false, false, true, || Ok(TransportMode::Stdio)).unwrap();
+        let got = resolve_transport_inner(false, false, true, || Ok(TransportMode::Stdio)).unwrap();
         assert_eq!(got, TransportMode::Stdio);
         let got =
             resolve_transport_inner(false, false, true, || Ok(TransportMode::Remote)).unwrap();
         assert_eq!(got, TransportMode::Remote);
-        let got =
-            resolve_transport_inner(false, false, true, || Ok(TransportMode::Oauth)).unwrap();
+        let got = resolve_transport_inner(false, false, true, || Ok(TransportMode::Oauth)).unwrap();
         assert_eq!(got, TransportMode::Oauth);
     }
 
@@ -1382,8 +1373,7 @@ mod tests {
             "stdio needs no key"
         );
 
-        let written =
-            std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
+        let written = std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(v["mcp"]["lific"]["type"], "local");
         let cmd = v["mcp"]["lific"]["command"].as_array().unwrap();
@@ -1416,8 +1406,7 @@ mod tests {
         // config MUST carry the minted agent token in the env field.
         assert!(result.outcomes.iter().all(|o| o.key.is_none()));
 
-        let written =
-            std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
+        let written = std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(v["mcp"]["lific"]["type"], "local");
         let token = v["mcp"]["lific"]["environment"]["LIFIC_TOKEN"]
@@ -1460,8 +1449,7 @@ mod tests {
         let result = run(&a, &cfg, &pool, &b).unwrap();
         assert_eq!(result.outcomes[0].action.as_deref(), Some("updated"));
 
-        let written =
-            std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
+        let written = std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
         // Unrelated entries survive.
         assert_eq!(v["mcp"]["other"]["url"], "http://other");
@@ -1505,14 +1493,20 @@ mod tests {
         let result = run(&a, &cfg, &pool, &b).unwrap();
         assert_eq!(result.outcomes[0].action.as_deref(), Some("updated"));
 
-        let v: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(b.project.join("opencode.json")).unwrap())
-                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(b.project.join("opencode.json")).unwrap(),
+        )
+        .unwrap();
         // Lific entry healed: command kept, token env added.
         assert_eq!(v["mcp"]["lific"]["type"], "local");
         assert_eq!(
             v["mcp"]["lific"]["command"],
-            serde_json::json!(["lific", "--db", dir.join("mydb.db").display().to_string(), "mcp"])
+            serde_json::json!([
+                "lific",
+                "--db",
+                dir.join("mydb.db").display().to_string(),
+                "mcp"
+            ])
         );
         let token = v["mcp"]["lific"]["environment"]["LIFIC_TOKEN"]
             .as_str()
@@ -1554,7 +1548,11 @@ mod tests {
         let _ = run(&a, &cfg, &pool, &b).unwrap();
         let conn = pool.read().unwrap();
         let bots: i64 = conn
-            .query_row("SELECT COUNT(*) FROM users WHERE username = 'opencode-solo'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM users WHERE username = 'opencode-solo'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         let keys: i64 = conn
             .query_row(
@@ -1568,9 +1566,10 @@ mod tests {
 
         // The config remains well-formed and carries a live token after run #2
         // (a re-connect may rotate the key — that is a valid fresh plaintext).
-        let second_v: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(b.project.join("opencode.json")).unwrap())
-                .unwrap();
+        let second_v: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(b.project.join("opencode.json")).unwrap(),
+        )
+        .unwrap();
         let second_token = second_v["mcp"]["lific"]["environment"]["LIFIC_TOKEN"]
             .as_str()
             .expect("token must be present after rerun");
@@ -1600,8 +1599,7 @@ mod tests {
             outcome.error
         );
 
-        let written =
-            std::fs::read_to_string(b.project.join(".codex/config.toml")).unwrap();
+        let written = std::fs::read_to_string(b.project.join(".codex/config.toml")).unwrap();
         // The stdio command and the env table with LIFIC_TOKEN both land.
         assert!(
             written.contains("command = \"lific\""),
@@ -1646,8 +1644,7 @@ mod tests {
         let result = run(&a, &cfg, &pool, &b).unwrap();
         assert_eq!(result.outcomes[0].action.as_deref(), Some("updated"));
 
-        let written =
-            std::fs::read_to_string(b.project.join(".codex/config.toml")).unwrap();
+        let written = std::fs::read_to_string(b.project.join(".codex/config.toml")).unwrap();
         // Unrelated config survives.
         assert!(
             written.contains("model = \"gpt-5\""),
@@ -1768,10 +1765,8 @@ mod tests {
             assert_eq!(uid, None, "{name} key must be unassigned");
         }
         // Each config file contains its own key.
-        let oc_body = std::fs::read_to_string(
-            b.home.join(".config/opencode/opencode.json"),
-        )
-        .unwrap();
+        let oc_body =
+            std::fs::read_to_string(b.home.join(".config/opencode/opencode.json")).unwrap();
         assert!(oc_body.contains(&ock));
         let cur_body = std::fs::read_to_string(b.home.join(".cursor/mcp.json")).unwrap();
         assert!(cur_body.contains(&curk));
@@ -2027,13 +2022,17 @@ mod tests {
 
         // Plain stdio config: command present, but NO token (no env field,
         // because no owner resolved → no LIFIC_TOKEN to bind).
-        let written =
-            std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
+        let written = std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(v["mcp"]["lific"]["type"], "local");
         assert_eq!(
             v["mcp"]["lific"]["command"],
-            serde_json::json!(["lific", "--db", dir.join("mydb.db").display().to_string(), "mcp"])
+            serde_json::json!([
+                "lific",
+                "--db",
+                dir.join("mydb.db").display().to_string(),
+                "mcp"
+            ])
         );
         assert!(
             v["mcp"]["lific"].get("environment").is_none(),
@@ -2064,8 +2063,7 @@ mod tests {
         assert_eq!(oc.auth_hint.as_deref(), Some("opencode mcp auth lific"));
 
         // The written config has a url and NO headers key at all.
-        let body =
-            std::fs::read_to_string(b.home.join(".config/opencode/opencode.json")).unwrap();
+        let body = std::fs::read_to_string(b.home.join(".config/opencode/opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["mcp"]["lific"]["url"], "http://127.0.0.1:3456/mcp");
         assert!(
@@ -2079,7 +2077,9 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM api_keys", [], |r| r.get(0))
             .unwrap();
         let bots: i64 = conn
-            .query_row("SELECT COUNT(*) FROM users WHERE is_bot = 1", [], |r| r.get(0))
+            .query_row("SELECT COUNT(*) FROM users WHERE is_bot = 1", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(keys, 0, "oauth mints no keys");
         assert_eq!(bots, 0, "oauth creates no bots");
@@ -2104,7 +2104,9 @@ mod tests {
             Some("http://127.0.0.1:3456/mcp")
         );
         assert!(
-            doc["mcp_servers"]["lific"].get("bearer_token_env_var").is_none(),
+            doc["mcp_servers"]["lific"]
+                .get("bearer_token_env_var")
+                .is_none(),
             "oauth codex must not set bearer_token_env_var: {body}"
         );
     }
@@ -2125,7 +2127,10 @@ mod tests {
             let oc = result.outcomes.iter().find(|o| o.id == id).unwrap();
             assert!(oc.action.is_none(), "{id} must be skipped, not written");
             assert!(
-                oc.error.as_ref().unwrap().contains("does not support --oauth"),
+                oc.error
+                    .as_ref()
+                    .unwrap()
+                    .contains("does not support --oauth"),
                 "{id} skip must explain why"
             );
             assert!(!oc.notes.is_empty(), "{id} must carry an explanatory note");

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -179,20 +179,24 @@ pub fn write(path: &Path, format: Format, entry: &CompiledEntry) -> Result<Actio
 /// `connect` cannot leave the config missing even though the write reported
 /// success. Unix only: Windows exposes no directory handle to sync, and
 /// `fsync` on a directory has no meaning there.
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn sync_parent_dir(_dir: &Path) -> Result<(), WriteError> {
     #[cfg(unix)]
     {
         std::fs::File::open(_dir)
             .and_then(|dir| dir.sync_all())
-            .map_err(|e| {
-                WriteError::new(format!("failed to sync {}: {e}", _dir.display()))
-            })?;
+            .map_err(|e| WriteError::new(format!("failed to sync {}: {e}", _dir.display())))?;
     }
     Ok(())
 }
 
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn set_private_file(_file: &std::fs::File) -> Result<(), WriteError> {
     #[cfg(unix)]
     {
@@ -204,7 +208,10 @@ fn set_private_file(_file: &std::fs::File) -> Result<(), WriteError> {
     Ok(())
 }
 
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn set_private_dir(_path: &Path) -> Result<(), WriteError> {
     #[cfg(unix)]
     {

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -359,8 +359,7 @@ pub fn load_with_source(base_url: &str) -> Option<(String, TokenSource)> {
 pub fn delete(base_url: &str) -> bool {
     let key = normalize_base_url(base_url);
     let kr = keyring_delete(&key);
-    let file = default_file_path()
-        .is_some_and(|p| FileStore::new(p).delete(&key).unwrap_or(false));
+    let file = default_file_path().is_some_and(|p| FileStore::new(p).delete(&key).unwrap_or(false));
     kr || file
 }
 
@@ -512,7 +511,11 @@ mod tests {
     fn file_store_creates_missing_parent_dir() {
         let tmp = tempfile::tempdir().unwrap();
         // Path two levels deep, neither of which exists yet.
-        let path = tmp.path().join("deep").join("nested").join("credentials.json");
+        let path = tmp
+            .path()
+            .join("deep")
+            .join("nested")
+            .join("credentials.json");
         let store = FileStore::new(path.clone());
         store.store("http://a", "tok").unwrap();
         assert!(path.exists());
@@ -528,7 +531,10 @@ mod tests {
 
     #[test]
     fn origin_of_makes_default_ports_explicit() {
-        assert_eq!(origin_of("https://h.example").unwrap(), "https://h.example:443");
+        assert_eq!(
+            origin_of("https://h.example").unwrap(),
+            "https://h.example:443"
+        );
         assert_eq!(
             origin_of("https://h.example:443").unwrap(),
             origin_of("https://h.example").unwrap()
@@ -548,7 +554,10 @@ mod tests {
     fn origin_of_ignores_case_path_and_trailing_slash() {
         let base = origin_of("https://Lific.Example:3998").unwrap();
         assert_eq!(origin_of("https://lific.example:3998/").unwrap(), base);
-        assert_eq!(origin_of("HTTPS://LIFIC.EXAMPLE:3998/a/b?q=1#f").unwrap(), base);
+        assert_eq!(
+            origin_of("HTTPS://LIFIC.EXAMPLE:3998/a/b?q=1#f").unwrap(),
+            base
+        );
         assert_eq!(origin_of("  https://lific.example:3998  ").unwrap(), base);
     }
 
@@ -563,7 +572,11 @@ mod tests {
     #[test]
     fn env_token_attaches_when_target_origin_matches_env_url() {
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("https://ci.example"), "https://ci.example"),
+            env_token_for(
+                Some("env-tok"),
+                Some("https://ci.example"),
+                "https://ci.example"
+            ),
             EnvToken::Bound("env-tok".into())
         );
         // Same origin spelled differently on either side still binds.
@@ -576,7 +589,11 @@ mod tests {
             EnvToken::Bound("env-tok".into())
         );
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("http://127.0.0.1:3998"), "http://127.0.0.1:3998/"),
+            env_token_for(
+                Some("env-tok"),
+                Some("http://127.0.0.1:3998"),
+                "http://127.0.0.1:3998/"
+            ),
             EnvToken::Bound("env-tok".into())
         );
     }
@@ -585,22 +602,38 @@ mod tests {
     fn env_token_is_dropped_when_target_origin_differs() {
         // The attack: a cwd config (or --url) points somewhere else.
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("https://ci.example"), "https://hostile.example"),
+            env_token_for(
+                Some("env-tok"),
+                Some("https://ci.example"),
+                "https://hostile.example"
+            ),
             EnvToken::Unbound
         );
         // Different port, same host.
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("http://127.0.0.1:3998"), "http://127.0.0.1:4000"),
+            env_token_for(
+                Some("env-tok"),
+                Some("http://127.0.0.1:3998"),
+                "http://127.0.0.1:4000"
+            ),
             EnvToken::Unbound
         );
         // Different scheme, same host: an http downgrade must not carry it.
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("https://ci.example"), "http://ci.example"),
+            env_token_for(
+                Some("env-tok"),
+                Some("https://ci.example"),
+                "http://ci.example"
+            ),
             EnvToken::Unbound
         );
         // Subdomain is a different origin.
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("https://ci.example"), "https://evil.ci.example"),
+            env_token_for(
+                Some("env-tok"),
+                Some("https://ci.example"),
+                "https://evil.ci.example"
+            ),
             EnvToken::Unbound
         );
         // Unparseable/non-http on either side never binds.
@@ -635,11 +668,18 @@ mod tests {
             EnvToken::Absent
         );
         assert_eq!(
-            env_token_for(Some("   "), Some("https://ci.example"), "https://ci.example"),
+            env_token_for(
+                Some("   "),
+                Some("https://ci.example"),
+                "https://ci.example"
+            ),
             EnvToken::Absent
         );
         // Absent, not Unbound, even with no LIFIC_URL: nothing to warn about.
-        assert_eq!(env_token_for(None, None, "https://ci.example"), EnvToken::Absent);
+        assert_eq!(
+            env_token_for(None, None, "https://ci.example"),
+            EnvToken::Absent
+        );
     }
 
     // The remaining tests mutate the process env, so they serialize on the

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -161,10 +161,7 @@ pub async fn run(
     let report = build_report_with_config_path(cfg, explicit_config, key.as_deref()).await;
     print_report(&report, json);
     if report.fail_count() > 0 {
-        Err(format!(
-            "doctor: {} check(s) failed",
-            report.fail_count()
-        ))
+        Err(format!("doctor: {} check(s) failed", report.fail_count()))
     } else {
         Ok(())
     }
@@ -201,14 +198,16 @@ pub async fn build_report_with_config_path(
     // credential store keyed by the server's public_url when set, else the
     // loopback base, since that's how `lific login` would have keyed it.
     let cred_base = cfg.server.public_url.as_deref().unwrap_or(&base);
-    let (effective_key, key_source): (Option<String>, Option<crate::cli::credentials::TokenSource>) =
-        match key {
-            Some(k) => (Some(k.to_string()), None),
-            None => match crate::cli::credentials::load_with_source(cred_base) {
-                Some((tok, src)) => (Some(tok), Some(src)),
-                None => (None, None),
-            },
-        };
+    let (effective_key, key_source): (
+        Option<String>,
+        Option<crate::cli::credentials::TokenSource>,
+    ) = match key {
+        Some(k) => (Some(k.to_string()), None),
+        None => match crate::cli::credentials::load_with_source(cred_base) {
+            Some((tok, src)) => (Some(tok), Some(src)),
+            None => (None, None),
+        },
+    };
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(3))
@@ -382,10 +381,7 @@ fn check_database(cfg: &Config) -> Check {
             Some(v) => Check::new(
                 "database",
                 Status::Pass,
-                format!(
-                    "{} opens; migrations applied (schema v{v})",
-                    path.display()
-                ),
+                format!("{} opens; migrations applied (schema v{v})", path.display()),
             ),
             None => Check::new(
                 "database",
@@ -653,7 +649,9 @@ pub async fn check_mcp(client: &reqwest::Client, base: &str, key: Option<&str>) 
     };
 
     let status = resp.status();
-    let has_www_auth = resp.headers().contains_key(reqwest::header::WWW_AUTHENTICATE);
+    let has_www_auth = resp
+        .headers()
+        .contains_key(reqwest::header::WWW_AUTHENTICATE);
 
     match key {
         None => {
@@ -721,11 +719,7 @@ pub async fn check_mcp(client: &reqwest::Client, base: &str, key: Option<&str>) 
                             format!("initialize returned a JSON-RPC error: {}", body["error"]),
                         )
                     } else {
-                        Check::new(
-                            "mcp",
-                            Status::Fail,
-                            "200 but result had no serverInfo",
-                        )
+                        Check::new("mcp", Status::Fail, "200 but result had no serverInfo")
                     }
                 }
                 Err(e) => Check::new(
@@ -974,8 +968,7 @@ mod tests {
     fn database_check_fails_when_parent_unwritable() {
         let mut cfg = Config::default();
         // A path under a directory that does not exist → parent not writable.
-        cfg.database.path =
-            std::path::PathBuf::from("/nonexistent-lific-doctor-xyz/deep/lific.db");
+        cfg.database.path = std::path::PathBuf::from("/nonexistent-lific-doctor-xyz/deep/lific.db");
         let c = check_database(&cfg);
         assert_eq!(c.status, Status::Fail, "detail: {}", c.detail);
     }
@@ -1167,9 +1160,7 @@ mod tests {
         let app = build_test_app(pool, "http://127.0.0.1");
         let base = serve_ephemeral(app).await;
 
-        let probe = http_server_reachable(&test_client(), &base)
-            .await
-            .unwrap();
+        let probe = http_server_reachable(&test_client(), &base).await.unwrap();
         assert!(probe.reachable);
         assert_eq!(probe.status, Some(200));
     }
@@ -1195,11 +1186,7 @@ mod tests {
 
         let c = check_mcp(&test_client(), &base, None).await;
         assert_eq!(c.status, Status::Pass, "detail: {}", c.detail);
-        assert!(
-            c.detail.contains("auth enforced"),
-            "detail: {}",
-            c.detail
-        );
+        assert!(c.detail.contains("auth enforced"), "detail: {}", c.detail);
     }
 
     #[tokio::test]
@@ -1251,13 +1238,7 @@ mod tests {
         assert!(report.ok);
 
         // server = warn, oauth_discovery + mcp = skipped
-        let by = |n: &str| {
-            report
-                .checks
-                .iter()
-                .find(|c| c.name == n)
-                .map(|c| c.status)
-        };
+        let by = |n: &str| report.checks.iter().find(|c| c.name == n).map(|c| c.status);
         assert_eq!(by("server"), Some(Status::Warn));
         assert_eq!(by("oauth_discovery"), Some(Status::Skipped));
         assert_eq!(by("mcp"), Some(Status::Skipped));

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1161,7 +1161,10 @@ mod tests {
             .unwrap();
             conn.execute(
                 "UPDATE comments SET created_at = ?1 WHERE id = ?2",
-                rusqlite::params![format!("2026-01-01 00:{:02}:{:02}", i / 60, i % 60), comment.id],
+                rusqlite::params![
+                    format!("2026-01-01 00:{:02}:{:02}", i / 60, i % 60),
+                    comment.id
+                ],
             )
             .unwrap();
         }

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -100,7 +100,11 @@ impl HttpBackend {
                 parsed.host_str().unwrap_or_default()
             );
         }
-        if parsed.scheme() == "http" && parsed.host_str().is_some_and(|host| !is_loopback_host(host)) {
+        if parsed.scheme() == "http"
+            && parsed
+                .host_str()
+                .is_some_and(|host| !is_loopback_host(host))
+        {
             eprintln!(
                 "warning: connecting over unencrypted http to {}",
                 parsed.host_str().unwrap_or_default()
@@ -1478,24 +1482,24 @@ mod tests {
             display_name: "Test Admin".into(),
             is_admin: true,
         })))
-            .layer(Extension(Some(crate::resolve_caller::ResolvedIdentity {
-                user: AuthUser {
-                    id: admin_id,
-                    username: "test-admin".into(),
-                    display_name: "Test Admin".into(),
-                    is_admin: true,
-                },
-                transport: crate::actor::Transport::Web,
-            })))
-            .layer(Extension(Some(crate::resolve_caller::ResolvedIdentity {
-                user: AuthUser {
-                    id: admin_id,
-                    username: "test-admin".into(),
-                    display_name: "Test Admin".into(),
-                    is_admin: true,
-                },
-                transport: crate::actor::Transport::Web,
-            })));
+        .layer(Extension(Some(crate::resolve_caller::ResolvedIdentity {
+            user: AuthUser {
+                id: admin_id,
+                username: "test-admin".into(),
+                display_name: "Test Admin".into(),
+                is_admin: true,
+            },
+            transport: crate::actor::Transport::Web,
+        })))
+        .layer(Extension(Some(crate::resolve_caller::ResolvedIdentity {
+            user: AuthUser {
+                id: admin_id,
+                username: "test-admin".into(),
+                display_name: "Test Admin".into(),
+                is_admin: true,
+            },
+            transport: crate::actor::Transport::Web,
+        })));
         let (project_id, _) = seed_project(&app).await;
         let project_page = parse_json(
             json_post(
@@ -3198,7 +3202,10 @@ mod tests {
             .await
             .unwrap();
 
-        let value = backend.execute(&command, IssueLinkOutput::Url).await.unwrap();
+        let value = backend
+            .execute(&command, IssueLinkOutput::Url)
+            .await
+            .unwrap();
         let remote = backend.human(&command, &value).await;
 
         let pool = crate::db::open_memory().expect("test db");

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -7,10 +7,10 @@
 
 use crate::config::Config;
 use crate::db::{self, DbPool};
-use crate::import::{self, ImportSummary};
 use crate::import::github::{self, StateFilter};
 use crate::import::jira::{self, JiraStatusMap};
 use crate::import::linear::{self, LinearStatusMap};
+use crate::import::{self, ImportSummary};
 
 /// Dispatch an `ImportAction` to the right source runner.
 pub fn run(
@@ -35,8 +35,15 @@ pub fn run(
             user,
             dry_run,
         } => run_github(
-            &pool, repo, project, state, token.as_deref(), map_open, map_closed,
-            user.as_deref(), *dry_run,
+            &pool,
+            repo,
+            project,
+            state,
+            token.as_deref(),
+            map_open,
+            map_closed,
+            user.as_deref(),
+            *dry_run,
         )?,
         ImportAction::Linear {
             team,
@@ -44,7 +51,14 @@ pub fn run(
             token,
             user,
             dry_run,
-        } => run_linear(&pool, team, project, token.as_deref(), user.as_deref(), *dry_run)?,
+        } => run_linear(
+            &pool,
+            team,
+            project,
+            token.as_deref(),
+            user.as_deref(),
+            *dry_run,
+        )?,
         ImportAction::Jira {
             site,
             jira_project,
@@ -54,8 +68,14 @@ pub fn run(
             user,
             dry_run,
         } => run_jira(
-            &pool, site, jira_project, project, email.as_deref(), token.as_deref(),
-            user.as_deref(), *dry_run,
+            &pool,
+            site,
+            jira_project,
+            project,
+            email.as_deref(),
+            token.as_deref(),
+            user.as_deref(),
+            *dry_run,
         )?,
     };
 
@@ -80,7 +100,12 @@ fn resolve_bot(
     user: Option<&str>,
 ) -> Result<Option<i64>, Box<dyn std::error::Error>> {
     match import::resolve_owner(pool, user)? {
-        Some(owner) => Ok(Some(import::ensure_import_bot(pool, owner, source_slug, display)?)),
+        Some(owner) => Ok(Some(import::ensure_import_bot(
+            pool,
+            owner,
+            source_slug,
+            display,
+        )?)),
         None => Ok(None),
     }
 }
@@ -208,11 +233,7 @@ pub fn print_summary(summary: &ImportSummary, json: bool) {
         }
     }
     // What didn't come across.
-    if summary.skipped_non_issues
-        + summary.skipped_assignees
-        + summary.skipped_other
-        > 0
-    {
+    if summary.skipped_non_issues + summary.skipped_assignees + summary.skipped_other > 0 {
         println!();
         println!("  Not imported (by design):");
         if summary.skipped_non_issues > 0 {

--- a/src/cli/instance.rs
+++ b/src/cli/instance.rs
@@ -91,15 +91,31 @@ pub fn run(
         println!("{}", serde_json::to_string_pretty(&out)?);
     } else {
         println!("Instance");
-        println!("  name:          {}", settings.instance_name.as_deref().unwrap_or("(unnamed)"));
+        println!(
+            "  name:          {}",
+            settings.instance_name.as_deref().unwrap_or("(unnamed)")
+        );
         println!("  version:       {version}");
         println!("  database:      {}", cfg.database.path.display());
         println!("  bind:          {}:{}", cfg.server.host, cfg.server.port);
-        println!("  public url:    {}", cfg.server.public_url.as_deref().unwrap_or("(not set)"));
-        println!("  signups:       {}", if settings.allow_signup { "open" } else { "closed" });
+        println!(
+            "  public url:    {}",
+            cfg.server.public_url.as_deref().unwrap_or("(not set)")
+        );
+        println!(
+            "  signups:       {}",
+            if settings.allow_signup {
+                "open"
+            } else {
+                "closed"
+            }
+        );
         println!("  signup domains:{domains}");
         println!("  session days:  {}", settings.session_lifetime_days);
-        println!("  login message: {}", settings.login_message.as_deref().unwrap_or("(none)"));
+        println!(
+            "  login message: {}",
+            settings.login_message.as_deref().unwrap_or("(none)")
+        );
         println!("  users:         {total} ({admins} admin)");
     }
     Ok(())

--- a/src/cli/key.rs
+++ b/src/cli/key.rs
@@ -12,7 +12,8 @@ pub fn run(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let json = term::wants_json(json_flag);
     let pool = db::open(&cfg.database.path)?;
-    let manager = auth::create_key_manager().map_err(|e| format!("key manager init failed: {e}"))?;
+    let manager =
+        auth::create_key_manager().map_err(|e| format!("key manager init failed: {e}"))?;
 
     match action {
         KeyAction::Create {
@@ -46,7 +47,9 @@ pub fn run(
                 println!("{}", serde_json::to_string_pretty(&out)?);
             } else {
                 let title = if let Some(ref username) = assigned {
-                    format!("API key '{name}' created (assigned to {username}) — save it now, it will not be shown again")
+                    format!(
+                        "API key '{name}' created (assigned to {username}) — save it now, it will not be shown again"
+                    )
                 } else {
                     format!("API key '{name}' created — save it now, it will not be shown again")
                 };

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -269,15 +269,13 @@ impl DeviceFlow for HttpDeviceFlow {
             if let Some(label) = label {
                 form.push(("client_name", label));
             }
-            return self
-                .device_authorization(&form)
-                .map_err(|e| match e {
-                    DeviceAuthFailure::UnknownClient => "device authorization failed: the server \
+            return self.device_authorization(&form).map_err(|e| match e {
+                DeviceAuthFailure::UnknownClient => "device authorization failed: the server \
                                                          requires a registered client but \
                                                          refused to register one"
-                        .to_string(),
-                    DeviceAuthFailure::Other(e) => e,
-                });
+                    .to_string(),
+                DeviceAuthFailure::Other(e) => e,
+            });
         };
         crate::cli::credentials::store_client_id(&self.base, &client_id);
 
@@ -311,7 +309,9 @@ impl DeviceFlow for HttpDeviceFlow {
                 .get("access_token")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| "token response missing access_token".to_string())?;
-            return Ok(PollSignal::Terminal(PollOutcome::Approved(token.to_string())));
+            return Ok(PollSignal::Terminal(PollOutcome::Approved(
+                token.to_string(),
+            )));
         }
         let err = body.get("error").and_then(|v| v.as_str()).unwrap_or("");
         Ok(classify_poll_error(err))
@@ -386,7 +386,10 @@ pub fn run_login_with_flow<F: DeviceFlow>(
     // polling — a second `--complete` call finishes the login.
     if args.non_interactive || !stdin_tty {
         let payload = non_interactive_json(&resp, base);
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload).unwrap_or_default()
+        );
         return Ok(());
     }
 
@@ -513,7 +516,10 @@ mod tests {
 
     #[test]
     fn classify_maps_rfc8628_errors() {
-        assert_eq!(classify_poll_error("authorization_pending"), PollSignal::Pending);
+        assert_eq!(
+            classify_poll_error("authorization_pending"),
+            PollSignal::Pending
+        );
         assert_eq!(classify_poll_error("slow_down"), PollSignal::SlowDown);
         assert_eq!(
             classify_poll_error("access_denied"),
@@ -535,10 +541,7 @@ mod tests {
         let mut cfg = Config::default();
         cfg.server.port = 3999;
         // Explicit --url wins, trailing slash trimmed.
-        assert_eq!(
-            resolve_base_url(Some("http://h:1/"), &cfg),
-            "http://h:1"
-        );
+        assert_eq!(resolve_base_url(Some("http://h:1/"), &cfg), "http://h:1");
         // Else public_url.
         cfg.server.public_url = Some("https://lific.example/".into());
         assert_eq!(resolve_base_url(None, &cfg), "https://lific.example");
@@ -590,7 +593,9 @@ mod tests {
                     device_code: "DEV".into(),
                     user_code: "BCDF-GHJK".into(),
                     verification_uri: "http://h/oauth/device".into(),
-                    verification_uri_complete: Some("http://h/oauth/device?user_code=BCDF-GHJK".into()),
+                    verification_uri_complete: Some(
+                        "http://h/oauth/device?user_code=BCDF-GHJK".into(),
+                    ),
                     expires_in: 900,
                     interval: 5,
                 },
@@ -681,7 +686,11 @@ mod tests {
         };
         // stdin_tty=true but --non-interactive set → still non-interactive.
         run_login_with_flow(&args, "http://h", &flow, true, true).unwrap();
-        assert_eq!(*flow.polls.borrow(), 0, "must not poll in non-interactive mode");
+        assert_eq!(
+            *flow.polls.borrow(),
+            0,
+            "must not poll in non-interactive mode"
+        );
     }
 
     #[test]

--- a/src/cli/member.rs
+++ b/src/cli/member.rs
@@ -86,7 +86,11 @@ pub fn run(
                         if skipped.is_empty() {
                             String::new()
                         } else {
-                            format!(" ({} already a member: {})", skipped.len(), skipped.join(", "))
+                            format!(
+                                " ({} already a member: {})",
+                                skipped.len(),
+                                skipped.join(", ")
+                            )
                         }
                     ));
                 }
@@ -106,8 +110,7 @@ pub fn run(
                 } else {
                     ui::step(format!(
                         "Added '{}' to {ident} as {}",
-                        u.username,
-                        member.role
+                        u.username, member.role
                     ));
                 }
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1277,7 +1277,10 @@ mod tests {
             resolve_http_credential(None, || Some(" stored ".into())),
             Ok(Some("stored".into()))
         );
-        assert_eq!(resolve_http_credential(None, || Some("  ".into())), Ok(None));
+        assert_eq!(
+            resolve_http_credential(None, || Some("  ".into())),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -1342,22 +1345,13 @@ mod tests {
 
     #[test]
     fn rejects_unknown_backend_values() {
-        assert!(
-            Cli::try_parse_from(["lific", "--backend", "remote", "project", "list"]).is_err()
-        );
+        assert!(Cli::try_parse_from(["lific", "--backend", "remote", "project", "list"]).is_err());
     }
 
     #[test]
     fn parses_json_output_alongside_http_backend() {
-        let cli = Cli::try_parse_from([
-            "lific",
-            "--backend",
-            "http",
-            "--json",
-            "project",
-            "list",
-        ])
-        .expect("JSON output should be transport independent");
+        let cli = Cli::try_parse_from(["lific", "--backend", "http", "--json", "project", "list"])
+            .expect("JSON output should be transport independent");
 
         assert_eq!(cli.backend, BackendKind::Http);
         assert!(cli.json);
@@ -1512,8 +1506,7 @@ mod tests {
 
     #[test]
     fn parse_restore_force() {
-        let cli =
-            Cli::try_parse_from(["lific", "restore", "/tmp/b.tar.gz", "--force"]).unwrap();
+        let cli = Cli::try_parse_from(["lific", "restore", "/tmp/b.tar.gz", "--force"]).unwrap();
         match cli.command {
             Command::Restore {
                 archive,
@@ -1530,8 +1523,8 @@ mod tests {
 
     #[test]
     fn parse_restore_allow_large() {
-        let cli = Cli::try_parse_from(["lific", "restore", "/tmp/b.tar.gz", "--allow-large"])
-            .unwrap();
+        let cli =
+            Cli::try_parse_from(["lific", "restore", "/tmp/b.tar.gz", "--allow-large"]).unwrap();
         match cli.command {
             Command::Restore {
                 force, allow_large, ..
@@ -1617,13 +1610,16 @@ mod tests {
     #[test]
     fn parse_login_complete() {
         let cli = Cli::try_parse_from([
-            "lific", "login", "--complete", "abc123def", "--url", "http://h:1",
+            "lific",
+            "login",
+            "--complete",
+            "abc123def",
+            "--url",
+            "http://h:1",
         ])
         .unwrap();
         match cli.command {
-            Command::Login {
-                complete, url, ..
-            } => {
+            Command::Login { complete, url, .. } => {
                 assert_eq!(complete, Some("abc123def".into()));
                 assert_eq!(url, Some("http://h:1".into()));
             }
@@ -1642,7 +1638,8 @@ mod tests {
 
     #[test]
     fn parse_logout_with_url() {
-        let cli = Cli::try_parse_from(["lific", "logout", "--url", "https://lific.example"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["lific", "logout", "--url", "https://lific.example"]).unwrap();
         match cli.command {
             Command::Logout { url } => assert_eq!(url, Some("https://lific.example".into())),
             _ => panic!("expected Logout"),
@@ -1717,14 +1714,21 @@ mod tests {
     #[test]
     fn parse_connect_repeatable_client_and_flags() {
         let cli = Cli::try_parse_from([
-            "lific", "connect",
-            "--client", "opencode",
-            "--client", "codex",
-            "--scope", "project",
+            "lific",
+            "connect",
+            "--client",
+            "opencode",
+            "--client",
+            "codex",
+            "--scope",
+            "project",
             "--stdio",
-            "--url", "http://127.0.0.1:9000/mcp",
-            "--key", "lific_sk-live-K",
-            "--user", "blake",
+            "--url",
+            "http://127.0.0.1:9000/mcp",
+            "--key",
+            "lific_sk-live-K",
+            "--user",
+            "blake",
             "--yes",
             "--dry-run",
             "--skip-agents",
@@ -1773,7 +1777,12 @@ mod tests {
     #[test]
     fn parse_agents_md_with_path_and_project() {
         let cli = Cli::try_parse_from([
-            "lific", "agents-md", "--path", "docs/AGENTS.md", "--project", "LIF",
+            "lific",
+            "agents-md",
+            "--path",
+            "docs/AGENTS.md",
+            "--project",
+            "LIF",
         ])
         .unwrap();
         match cli.command {
@@ -1826,14 +1835,23 @@ mod tests {
     #[test]
     fn parse_instance_set() {
         let cli = Cli::try_parse_from([
-            "lific", "instance", "set",
-            "--name", "Acme Eng",
-            "--signups", "false",
-            "--signup-domains", "acme.com,sub.acme.com",
-            "--session-days", "14",
-            "--login-message", "Ask #it for access",
-            "--auto-login", "true",
-            "--authz-enforced", "true",
+            "lific",
+            "instance",
+            "set",
+            "--name",
+            "Acme Eng",
+            "--signups",
+            "false",
+            "--signup-domains",
+            "acme.com,sub.acme.com",
+            "--session-days",
+            "14",
+            "--login-message",
+            "Ask #it for access",
+            "--auto-login",
+            "true",
+            "--authz-enforced",
+            "true",
         ])
         .unwrap();
         match cli.command {
@@ -1866,11 +1884,12 @@ mod tests {
         let cli = Cli::try_parse_from(["lific", "key", "create", "--name", "test-key"]).unwrap();
         match cli.command {
             Command::Key {
-                action: KeyAction::Create {
-                    name,
-                    user,
-                    expires,
-                },
+                action:
+                    KeyAction::Create {
+                        name,
+                        user,
+                        expires,
+                    },
             } => {
                 assert_eq!(name, "test-key");
                 assert!(user.is_none());
@@ -1888,11 +1907,12 @@ mod tests {
         .unwrap();
         match cli.command {
             Command::Key {
-                action: KeyAction::Create {
-                    name,
-                    user,
-                    expires,
-                },
+                action:
+                    KeyAction::Create {
+                        name,
+                        user,
+                        expires,
+                    },
             } => {
                 assert_eq!(name, "my-key");
                 assert_eq!(user, Some("blake".into()));
@@ -1916,11 +1936,12 @@ mod tests {
         .unwrap();
         match cli.command {
             Command::Key {
-                action: KeyAction::Create {
-                    name,
-                    user,
-                    expires,
-                },
+                action:
+                    KeyAction::Create {
+                        name,
+                        user,
+                        expires,
+                    },
             } => {
                 assert_eq!(name, "temp-key");
                 assert!(user.is_none());
@@ -2009,10 +2030,8 @@ mod tests {
 
     #[test]
     fn parse_user_set_password() {
-        let cli = Cli::try_parse_from([
-            "lific", "user", "set-password", "--username", "blake",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["lific", "user", "set-password", "--username", "blake"]).unwrap();
         match cli.command {
             Command::User {
                 action: UserAction::SetPassword { username, password },
@@ -2027,7 +2046,13 @@ mod tests {
     #[test]
     fn parse_user_set_password_with_password_flag() {
         let cli = Cli::try_parse_from([
-            "lific", "user", "set-password", "-u", "blake", "-p", "newpass123",
+            "lific",
+            "user",
+            "set-password",
+            "-u",
+            "blake",
+            "-p",
+            "newpass123",
         ])
         .unwrap();
         match cli.command {
@@ -2046,12 +2071,24 @@ mod tests {
     #[test]
     fn parse_member_add_defaults_to_viewer() {
         let cli = Cli::try_parse_from([
-            "lific", "member", "add", "--project", "LIF", "--user", "bob",
+            "lific",
+            "member",
+            "add",
+            "--project",
+            "LIF",
+            "--user",
+            "bob",
         ])
         .unwrap();
         match cli.command {
             Command::Member {
-                action: MemberAction::Add { project, user, role, all },
+                action:
+                    MemberAction::Add {
+                        project,
+                        user,
+                        role,
+                        all,
+                    },
             } => {
                 assert_eq!(project, Some("LIF".into()));
                 assert_eq!(user, "bob");
@@ -2065,12 +2102,25 @@ mod tests {
     #[test]
     fn parse_member_add_all_projects() {
         let cli = Cli::try_parse_from([
-            "lific", "member", "add", "--all", "--user", "bob", "--role", "maintainer",
+            "lific",
+            "member",
+            "add",
+            "--all",
+            "--user",
+            "bob",
+            "--role",
+            "maintainer",
         ])
         .unwrap();
         match cli.command {
             Command::Member {
-                action: MemberAction::Add { project, user, role, all },
+                action:
+                    MemberAction::Add {
+                        project,
+                        user,
+                        role,
+                        all,
+                    },
             } => {
                 assert!(project.is_none());
                 assert_eq!(user, "bob");
@@ -2089,7 +2139,14 @@ mod tests {
         );
         assert!(
             Cli::try_parse_from([
-                "lific", "member", "add", "--project", "LIF", "--all", "--user", "bob",
+                "lific",
+                "member",
+                "add",
+                "--project",
+                "LIF",
+                "--all",
+                "--user",
+                "bob",
             ])
             .is_err(),
             "--project conflicts with --all"
@@ -2102,7 +2159,9 @@ mod tests {
             Cli::try_parse_from(["lific", "member", "list", "--project", "LIF"])
                 .unwrap()
                 .command,
-            Command::Member { action: MemberAction::List { .. } }
+            Command::Member {
+                action: MemberAction::List { .. }
+            }
         ));
         match Cli::try_parse_from([
             "lific", "member", "role", "-p", "LIF", "-u", "bob", "-r", "lead",
@@ -2111,9 +2170,17 @@ mod tests {
         .command
         {
             Command::Member {
-                action: MemberAction::Role { project, user, role },
+                action:
+                    MemberAction::Role {
+                        project,
+                        user,
+                        role,
+                    },
             } => {
-                assert_eq!((project.as_str(), user.as_str(), role.as_str()), ("LIF", "bob", "lead"));
+                assert_eq!(
+                    (project.as_str(), user.as_str(), role.as_str()),
+                    ("LIF", "bob", "lead")
+                );
             }
             _ => panic!("expected Member Role"),
         }
@@ -2121,7 +2188,9 @@ mod tests {
             Cli::try_parse_from(["lific", "member", "remove", "-p", "LIF", "-u", "bob"])
                 .unwrap()
                 .command,
-            Command::Member { action: MemberAction::Remove { .. } }
+            Command::Member {
+                action: MemberAction::Remove { .. }
+            }
         ));
     }
 

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -392,7 +392,12 @@ pub fn comment_list(
 
 pub fn comment_added(comment: &Comment, identifier: &str) -> String {
     let mut out = String::new();
-    w!(out, "Added comment to {} by {}:", identifier, comment.author);
+    w!(
+        out,
+        "Added comment to {} by {}:",
+        identifier,
+        comment.author
+    );
     w!(out, "  {}", comment.content);
     out
 }
@@ -498,7 +503,12 @@ pub fn folder_created(folder: &Folder) -> String {
 
 pub fn folder_updated(previous_name: &str, folder: &Folder) -> String {
     let mut out = String::new();
-    w!(out, "Renamed folder '{}' -> '{}'", previous_name, folder.name);
+    w!(
+        out,
+        "Renamed folder '{}' -> '{}'",
+        previous_name,
+        folder.name
+    );
     out
 }
 
@@ -596,7 +606,10 @@ mod tests {
             ),
             "got: {unknown}"
         );
-        assert!(!unknown.contains("More comments available"), "got: {unknown}");
+        assert!(
+            !unknown.contains("More comments available"),
+            "got: {unknown}"
+        );
     }
 
     #[test]

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -157,7 +157,10 @@ mod tests {
             err.contains("--yes"),
             "error should name the bypass flag, got: {err}"
         );
-        assert!(err.contains("interactive"), "error should explain why: {err}");
+        assert!(
+            err.contains("interactive"),
+            "error should explain why: {err}"
+        );
     }
 
     #[test]
@@ -188,30 +191,49 @@ mod tests {
     #[test]
     fn prompt_text_refuses_without_tty_and_names_bypass_flag() {
         let mut input: &[u8] = b"";
-        let err = prompt_text_inner("What's your name?", "--name", false, &mut input, &mut Vec::new())
-            .expect_err("must refuse when stdin is not a TTY");
+        let err = prompt_text_inner(
+            "What's your name?",
+            "--name",
+            false,
+            &mut input,
+            &mut Vec::new(),
+        )
+        .expect_err("must refuse when stdin is not a TTY");
         assert!(
             err.contains("--name"),
             "error should name the bypass flag, got: {err}"
         );
-        assert!(err.contains("interactive"), "error should explain why: {err}");
+        assert!(
+            err.contains("interactive"),
+            "error should explain why: {err}"
+        );
     }
 
     #[test]
     fn prompt_text_trims_response_on_tty() {
         let mut input: &[u8] = b"  Blake Alston  \n";
-        let value =
-            prompt_text_inner("What's your name?", "--name", true, &mut input, &mut Vec::new())
-                .unwrap();
+        let value = prompt_text_inner(
+            "What's your name?",
+            "--name",
+            true,
+            &mut input,
+            &mut Vec::new(),
+        )
+        .unwrap();
         assert_eq!(value, "Blake Alston");
     }
 
     #[test]
     fn prompt_text_rejects_empty_input() {
         let mut input: &[u8] = b"\n";
-        let err =
-            prompt_text_inner("What's your name?", "--name", true, &mut input, &mut Vec::new())
-                .expect_err("empty input must fail");
+        let err = prompt_text_inner(
+            "What's your name?",
+            "--name",
+            true,
+            &mut input,
+            &mut Vec::new(),
+        )
+        .expect_err("empty input must fail");
         assert!(err.contains("empty"), "error should explain why: {err}");
     }
 }

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -18,7 +18,12 @@
 
 /// Begin a command session: prints the `┌ <title>` header.
 pub fn intro(title: &str) {
-    let _ = cliclack::intro(console::style(format!(" {title} ")).on_cyan().black().to_string());
+    let _ = cliclack::intro(
+        console::style(format!(" {title} "))
+            .on_cyan()
+            .black()
+            .to_string(),
+    );
 }
 
 /// A completed step: `◇ <msg>`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,10 @@ struct ConfigFile {
 /// was read from. Fails closed on symlinks: [`read_config_file`] opens with
 /// `O_NOFOLLOW`, so a symlinked config never produces a [`ConfigFile`] to
 /// tighten in the first place.
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn tighten_config_permissions(_config: &ConfigFile) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -369,7 +372,7 @@ impl Default for BackupConfig {
             enabled: true,
             dir: PathBuf::from("backups"),
             interval_minutes: 60,
-            retain: 24, // keep 24 hourly backups = 1 day of history
+            retain: 24,                 // keep 24 hourly backups = 1 day of history
             audit_retention_days: None, // keep audit history forever
         }
     }
@@ -598,10 +601,7 @@ mod tests {
         let config = Config::default();
         assert_eq!(config.server.host, "0.0.0.0");
         assert_eq!(config.server.port, 3456);
-        assert_eq!(
-            config.server.trusted_proxies,
-            Vec::<String>::new()
-        );
+        assert_eq!(config.server.trusted_proxies, Vec::<String>::new());
         assert_eq!(config.database.path, PathBuf::from("lific.db"));
         assert!(config.backup.enabled);
         assert_eq!(config.backup.retain, 24);
@@ -650,7 +650,10 @@ enabled = false
 
         Config::load(Some(&path)).unwrap();
 
-        assert_eq!(std::fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 
     #[cfg(unix)]
@@ -783,7 +786,11 @@ enabled = false
     fn absolute_db_path_is_untouched_by_anchoring() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("lific.toml");
-        std::fs::write(&path, format!("[database]\npath = \"{ABSOLUTE_DB_PATH}\"\n")).unwrap();
+        std::fs::write(
+            &path,
+            format!("[database]\npath = \"{ABSOLUTE_DB_PATH}\"\n"),
+        )
+        .unwrap();
 
         let config = Config::load(Some(&path)).unwrap();
         assert_eq!(config.database.path, PathBuf::from(ABSOLUTE_DB_PATH));
@@ -1076,17 +1083,14 @@ enabled = false
     // LIFIC-24: the startup guard's bind-host check.
     #[test]
     fn is_localhost_host_accepts_only_loopback() {
-        for host in [
-            "127.0.0.1",
-            "127.5.5.5",
-            "::1",
-            "localhost",
-            "LOCALHOST",
-        ] {
+        for host in ["127.0.0.1", "127.5.5.5", "::1", "localhost", "LOCALHOST"] {
             assert!(is_localhost_host(host), "{host} should count as loopback");
         }
         for host in ["0.0.0.0", "::", "[::]", "192.168.1.10", "lific.example", ""] {
-            assert!(!is_localhost_host(host), "{host} must NOT count as loopback");
+            assert!(
+                !is_localhost_host(host),
+                "{host} must NOT count as loopback"
+            );
         }
     }
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -689,7 +689,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(has_column, 0, "fixture must start on the pre-checksum shape");
+        assert_eq!(
+            has_column, 0,
+            "fixture must start on the pre-checksum shape"
+        );
 
         run(&conn).expect("a legacy database must upgrade cleanly");
 
@@ -1008,7 +1011,9 @@ mod tests {
             .unwrap();
         assert_eq!(counts, (3, 2), "no rows may be lost or deduplicated");
         assert!(index_names(&conn, "oauth_codes").contains(&"idx_oauth_codes_client".to_string()));
-        assert!(index_names(&conn, "oauth_tokens").contains(&"idx_oauth_tokens_client".to_string()));
+        assert!(
+            index_names(&conn, "oauth_tokens").contains(&"idx_oauth_tokens_client".to_string())
+        );
 
         // Non-unique: another code for a client that already has two.
         conn.execute(
@@ -1256,7 +1261,10 @@ mod tests {
 
         let id = new_issue(&conn, project_id, "One", Status::Todo);
         assert_eq!(
-            count(&conn, "SELECT count(*) FROM audit_log WHERE entity_type = 'issue'"),
+            count(
+                &conn,
+                "SELECT count(*) FROM audit_log WHERE entity_type = 'issue'"
+            ),
             1,
             "creating an issue is one audit row; the stamp must add none"
         );
@@ -1451,7 +1459,11 @@ mod tests {
         .unwrap();
 
         let recorded = transitions(&conn);
-        assert_eq!(recorded.len(), 1, "one status change, one row: {recorded:?}");
+        assert_eq!(
+            recorded.len(),
+            1,
+            "one status change, one row: {recorded:?}"
+        );
         let (issue_id, from, to, actor_user_id, transport, seq) =
             recorded.into_iter().next().unwrap();
         assert_eq!(issue_id, id);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -283,9 +283,8 @@ fn ensure_private_file(path: &Path) -> Result<(), LificError> {
     match options.open(path) {
         Ok(_) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            let metadata = std::fs::symlink_metadata(path).map_err(|error| {
-                LificError::Internal(format!("inspect database file: {error}"))
-            })?;
+            let metadata = std::fs::symlink_metadata(path)
+                .map_err(|error| LificError::Internal(format!("inspect database file: {error}")))?;
             if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
                 return Err(LificError::Internal(
                     "database path must be a regular file, not a link".into(),
@@ -316,10 +315,9 @@ fn secure_parent(path: &Path) -> Result<(), LificError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        let metadata = parent
-            .symlink_metadata()
-            .map_err(|error| LificError::Internal(format!("inspect database directory: {error}")))?
-            ;
+        let metadata = parent.symlink_metadata().map_err(|error| {
+            LificError::Internal(format!("inspect database directory: {error}"))
+        })?;
         if metadata.file_type().is_symlink() {
             return Err(LificError::Internal(
                 "database directory must not be a symlink".into(),
@@ -341,7 +339,10 @@ fn secure_parent(path: &Path) -> Result<(), LificError> {
     Ok(())
 }
 
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn secure_file(_path: &Path) -> Result<(), LificError> {
     #[cfg(unix)]
     {

--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -645,7 +645,8 @@ mod tests {
             },
         );
         let issue = queries::create_issue(&conn, &new_issue(pid, "Orphan")).unwrap();
-        conn.execute("DELETE FROM users WHERE id = ?1", [uid]).unwrap();
+        conn.execute("DELETE FROM users WHERE id = ?1", [uid])
+            .unwrap();
         drop(conn);
 
         let feed = issue_feed(&pool, issue.id);
@@ -732,14 +733,20 @@ mod tests {
 
         crate::actor::stamp(
             &conn,
-            &ActorCtx { user_id: Some(alice), transport: Transport::Web },
+            &ActorCtx {
+                user_id: Some(alice),
+                transport: Transport::Web,
+            },
         );
         queries::create_issue(&conn, &new_issue(pid, "a1")).unwrap();
         queries::create_issue(&conn, &new_issue(pid, "a2")).unwrap();
 
         crate::actor::stamp(
             &conn,
-            &ActorCtx { user_id: Some(bot), transport: Transport::Mcp },
+            &ActorCtx {
+                user_id: Some(bot),
+                transport: Transport::Mcp,
+            },
         );
         queries::create_issue(&conn, &new_issue(pid, "b1")).unwrap();
         queries::create_issue(&conn, &new_issue(pid, "b2")).unwrap();

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -118,7 +118,11 @@ pub fn update_alt_text(
 /// screenshot into two projects produces two rows over one blob, and this is
 /// how `GET /api/attachments/{id}/links` finds the twin so a caller can see
 /// the file is already in the tracker before uploading a third copy.
-pub fn duplicates_of(conn: &Connection, id: i64, sha256: &str) -> Result<Vec<Attachment>, LificError> {
+pub fn duplicates_of(
+    conn: &Connection,
+    id: i64,
+    sha256: &str,
+) -> Result<Vec<Attachment>, LificError> {
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT {ATTACHMENT_COLUMNS} FROM attachments
          WHERE sha256 = ?1 AND id != ?2 ORDER BY id"
@@ -151,10 +155,7 @@ pub fn delete_attachment(conn: &Connection, id: i64) -> Result<bool, LificError>
 /// Delete an unlinked attachment only if it is still unlinked on this writer
 /// connection. The returned hash is safe for the caller to garbage-collect
 /// after checking whether another row still shares it.
-pub fn delete_orphan_attachment(
-    conn: &Connection,
-    id: i64,
-) -> Result<Option<String>, LificError> {
+pub fn delete_orphan_attachment(conn: &Connection, id: i64) -> Result<Option<String>, LificError> {
     conn.query_row(
         "DELETE FROM attachments
          WHERE id = ?1
@@ -470,9 +471,7 @@ pub fn find_orphans(
         format!("+{} seconds", -grace_seconds)
     };
     let rows = stmt.query_map(params![modifier], |row| {
-        Ok(OrphanAttachment {
-            id: row.get(0)?,
-        })
+        Ok(OrphanAttachment { id: row.get(0)? })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
@@ -658,11 +657,10 @@ pub fn list_project_attachments(
          WHERE {where_clause}"
     );
     let totals_params = base_params();
-    let (total_count, total_bytes): (i64, i64) = conn.query_row(
-        &totals_sql,
-        bind(&totals_params).as_slice(),
-        |row| Ok((row.get(0)?, row.get(1)?)),
-    )?;
+    let (total_count, total_bytes): (i64, i64) =
+        conn.query_row(&totals_sql, bind(&totals_params).as_slice(), |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?;
 
     let ids: Vec<i64> = items.iter().map(|item| item.id).collect();
     let mut entities = linked_entities_in_project(conn, project_id, &ids)?;
@@ -1607,7 +1605,10 @@ mod tests {
             create_attachment(&conn, &test_sha("race"), "a.png", "image/png", 1, None).unwrap();
         link_attachment(&conn, attachment.id, AttachmentEntity::Issue, issue).unwrap();
 
-        assert_eq!(delete_orphan_attachment(&conn, attachment.id).unwrap(), None);
+        assert_eq!(
+            delete_orphan_attachment(&conn, attachment.id).unwrap(),
+            None
+        );
         assert!(get_attachment(&conn, attachment.id).is_ok());
     }
 

--- a/src/db/queries/changes.rs
+++ b/src/db/queries/changes.rs
@@ -691,7 +691,12 @@ mod tests {
                 .iter()
                 .all(|issue| issue.seq <= snapshot.cursor)
         );
-        assert!(snapshot.pages.iter().all(|page| page.seq <= snapshot.cursor));
+        assert!(
+            snapshot
+                .pages
+                .iter()
+                .all(|page| page.seq <= snapshot.cursor)
+        );
     }
 
     /// LIF-439's race rule, exercised against the real composition

--- a/src/db/queries/comments.rs
+++ b/src/db/queries/comments.rs
@@ -1315,7 +1315,10 @@ mod tests {
         let (deleted_at, seq) = raw_comment(&conn, c.id);
         assert!(deleted_at.is_some());
         assert!(seq > before);
-        assert_eq!(count_comments(&conn, CommentParent::Issue(issue_id), None).unwrap(), 0);
+        assert_eq!(
+            count_comments(&conn, CommentParent::Issue(issue_id), None).unwrap(),
+            0
+        );
         assert!(
             list_comments(&conn, CommentParent::Issue(issue_id), None, None)
                 .unwrap()
@@ -1328,10 +1331,8 @@ mod tests {
     fn deleting_an_issue_tombstones_its_comments_with_their_own_seqs() {
         let (pool, issue_id, _, user_id) = setup();
         let conn = pool.write().unwrap();
-        let first =
-            create_comment(&conn, CommentParent::Issue(issue_id), user_id, "One").unwrap();
-        let second =
-            create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Two").unwrap();
+        let first = create_comment(&conn, CommentParent::Issue(issue_id), user_id, "One").unwrap();
+        let second = create_comment(&conn, CommentParent::Issue(issue_id), user_id, "Two").unwrap();
         let (_, first_seq) = raw_comment(&conn, first.id);
         let (_, second_seq) = raw_comment(&conn, second.id);
 

--- a/src/db/queries/insights.rs
+++ b/src/db/queries/insights.rs
@@ -91,7 +91,10 @@ fn bucket_weekly(
         .map(|d| {
             let key = d.format("%Y-%m-%d").to_string();
             let count = counts.get(&key).copied().unwrap_or(0);
-            WeekPoint { week_start: key, count }
+            WeekPoint {
+                week_start: key,
+                count,
+            }
         })
         .collect())
 }
@@ -226,7 +229,8 @@ fn top_actors(
             top_transport: row.get(6)?,
         })
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(LificError::Database)
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(LificError::Database)
 }
 
 /// Compute the full Insights payload for a project. `weeks` should already
@@ -332,7 +336,11 @@ mod tests {
         let conn = pool.read().unwrap();
         let payload = get_insights(&conn, pid, 4).unwrap();
         assert_eq!(payload.weeks, 4);
-        assert_eq!(payload.created_per_week.len(), 4, "dense — one point per week");
+        assert_eq!(
+            payload.created_per_week.len(),
+            4,
+            "dense — one point per week"
+        );
         // Every bucket is Monday-aligned.
         for pt in &payload.created_per_week {
             let d = NaiveDate::parse_from_str(&pt.week_start, "%Y-%m-%d").unwrap();
@@ -356,7 +364,10 @@ mod tests {
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Done), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
         )
         .unwrap();
         drop(conn);
@@ -375,14 +386,20 @@ mod tests {
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Done), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
         )
         .unwrap();
         // Reopen: latest status transition is no longer terminal.
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Todo), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Todo),
+                ..Default::default()
+            },
         )
         .unwrap();
         drop(conn);
@@ -390,7 +407,10 @@ mod tests {
         let conn = pool.read().unwrap();
         let payload = get_insights(&conn, pid, 4).unwrap();
         let total: i64 = payload.closed_per_week.iter().map(|p| p.count).sum();
-        assert_eq!(total, 0, "currently-open issue must not appear in closed_per_week");
+        assert_eq!(
+            total, 0,
+            "currently-open issue must not appear in closed_per_week"
+        );
     }
 
     #[test]
@@ -401,19 +421,28 @@ mod tests {
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Done), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
         )
         .unwrap();
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Todo), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Todo),
+                ..Default::default()
+            },
         )
         .unwrap();
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Cancelled), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Cancelled),
+                ..Default::default()
+            },
         )
         .unwrap();
         drop(conn);
@@ -439,7 +468,10 @@ mod tests {
         queries::update_issue(
             &conn,
             c.id,
-            &UpdateIssue { status: Some(Status::Done), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
         )
         .unwrap();
         drop(conn);
@@ -474,7 +506,10 @@ mod tests {
         queries::update_issue(
             &conn,
             a.id,
-            &UpdateIssue { module_id: Some(Some(module.id)), ..Default::default() },
+            &UpdateIssue {
+                module_id: Some(Some(module.id)),
+                ..Default::default()
+            },
         )
         .unwrap();
         quick_issue(&conn, pid, "B", Priority::None);
@@ -490,7 +525,11 @@ mod tests {
             .unwrap();
         assert_eq!(backend.name, "Backend");
         assert_eq!(backend.count, 1);
-        let unassigned = payload.module_counts.iter().find(|m| m.module_id.is_none()).unwrap();
+        let unassigned = payload
+            .module_counts
+            .iter()
+            .find(|m| m.module_id.is_none())
+            .unwrap();
         assert_eq!(unassigned.name, "No module");
         assert_eq!(unassigned.count, 1);
     }
@@ -512,7 +551,10 @@ mod tests {
         };
         crate::actor::stamp(
             &conn,
-            &crate::actor::ActorCtx { user_id: Some(alice), transport: crate::actor::Transport::Web },
+            &crate::actor::ActorCtx {
+                user_id: Some(alice),
+                transport: crate::actor::Transport::Web,
+            },
         );
         quick_issue(&conn, pid, "A1", Priority::None);
         quick_issue(&conn, pid, "A2", Priority::None);

--- a/src/db/queries/issues.rs
+++ b/src/db/queries/issues.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -742,13 +742,15 @@ pub fn deleted_issue_project_id(conn: &Connection, id: i64) -> Result<i64, Lific
 /// tombstone, not of the last edit, or a resuming client would be handed a
 /// cursor that predates the deletion it just applied. Read after the write.
 pub fn issue_seq(conn: &Connection, id: i64) -> Result<i64, LificError> {
-    conn.query_row("SELECT seq FROM issues WHERE id = ?1", [id], |row| row.get(0))
-        .map_err(|error| match error {
-            rusqlite::Error::QueryReturnedNoRows => {
-                LificError::NotFound(format!("issue {id} not found"))
-            }
-            other => other.into(),
-        })
+    conn.query_row("SELECT seq FROM issues WHERE id = ?1", [id], |row| {
+        row.get(0)
+    })
+    .map_err(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => {
+            LificError::NotFound(format!("issue {id} not found"))
+        }
+        other => other.into(),
+    })
 }
 
 pub fn link_issues(
@@ -1028,15 +1030,17 @@ mod tests {
                     "module {module_id} does not belong to project {issue_project_id}"
                 )
         ));
-        assert!(list_issues(
-            &conn,
-            &ListIssuesQuery {
-                project_id: Some(issue_project_id),
-                ..Default::default()
-            }
-        )
-        .unwrap()
-        .is_empty());
+        assert!(
+            list_issues(
+                &conn,
+                &ListIssuesQuery {
+                    project_id: Some(issue_project_id),
+                    ..Default::default()
+                }
+            )
+            .unwrap()
+            .is_empty()
+        );
     }
 
     // LIF-130: the issue INSERT and its label attaches are one atomic unit.

--- a/src/db/queries/members.rs
+++ b/src/db/queries/members.rs
@@ -7,7 +7,7 @@
 //! paths that set it (`queries::projects::create_project` /
 //! `update_project`) call [`upsert_member`] to keep both in sync.
 
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::{MemberWithUser, ProjectMember, Role};
 use crate::error::LificError;
@@ -64,12 +64,10 @@ pub fn get_member_role(
     project_id: i64,
     user_id: i64,
 ) -> Result<Option<Role>, LificError> {
-    conn.prepare_cached(
-        "SELECT role FROM project_members WHERE project_id = ?1 AND user_id = ?2",
-    )?
-    .query_row(params![project_id, user_id], |row| row.get(0))
-    .optional()
-    .map_err(Into::into)
+    conn.prepare_cached("SELECT role FROM project_members WHERE project_id = ?1 AND user_id = ?2")?
+        .query_row(params![project_id, user_id], |row| row.get(0))
+        .optional()
+        .map_err(Into::into)
 }
 
 /// Insert or update a member's role. Idempotent — re-running with the same
@@ -124,9 +122,8 @@ pub fn remove_member(conn: &Connection, project_id: i64, user_id: i64) -> Result
 /// Powers `authz::visible_project_ids` (LIF-196) — the cross-project read
 /// filter for search / project listing once enforcement is wired in.
 pub fn list_project_ids_for_user(conn: &Connection, user_id: i64) -> Result<Vec<i64>, LificError> {
-    let mut stmt = conn.prepare_cached(
-        "SELECT project_id FROM project_members WHERE user_id = ?1",
-    )?;
+    let mut stmt =
+        conn.prepare_cached("SELECT project_id FROM project_members WHERE user_id = ?1")?;
     let rows = stmt.query_map(params![user_id], |row| row.get(0))?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
@@ -215,7 +212,9 @@ pub fn change_role(
     let new_role: Role = new_role.parse().map_err(LificError::BadRequest)?;
 
     let current = get_member_role(conn, project_id, user_id)?.ok_or_else(|| {
-        LificError::NotFound(format!("user {user_id} is not a member of project {project_id}"))
+        LificError::NotFound(format!(
+            "user {user_id} is not a member of project {project_id}"
+        ))
     })?;
 
     if current == Role::Lead && new_role != Role::Lead && count_leads(conn, project_id)? <= 1 {
@@ -245,7 +244,9 @@ pub fn remove_member_guarded(
     user_id: i64,
 ) -> Result<(), LificError> {
     let current = get_member_role(conn, project_id, user_id)?.ok_or_else(|| {
-        LificError::NotFound(format!("user {user_id} is not a member of project {project_id}"))
+        LificError::NotFound(format!(
+            "user {user_id} is not a member of project {project_id}"
+        ))
     })?;
 
     if current == Role::Lead && count_leads(conn, project_id)? <= 1 {
@@ -275,8 +276,8 @@ pub fn remove_member_guarded(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{self, queries::projects};
     use crate::db::models::{CreateProject, UpdateProject};
+    use crate::db::{self, queries::projects};
 
     fn test_db() -> db::DbPool {
         db::open_memory().expect("test db")
@@ -622,7 +623,10 @@ mod tests {
         let err = add_member(&conn, project_id, alice, "maintainer").unwrap_err();
         assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
         // The conflicting call must not have overwritten the role.
-        assert_eq!(get_member_role(&conn, project_id, alice).unwrap(), Some(Role::Viewer));
+        assert_eq!(
+            get_member_role(&conn, project_id, alice).unwrap(),
+            Some(Role::Viewer)
+        );
     }
 
     #[test]
@@ -680,7 +684,10 @@ mod tests {
 
         let err = change_role(&conn, project_id, alice, "maintainer").unwrap_err();
         assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
-        assert_eq!(get_member_role(&conn, project_id, alice).unwrap(), Some(Role::Lead));
+        assert_eq!(
+            get_member_role(&conn, project_id, alice).unwrap(),
+            Some(Role::Lead)
+        );
 
         // Re-affirming the same role is not a demotion — always fine.
         assert!(change_role(&conn, project_id, alice, "lead").is_ok());
@@ -697,7 +704,10 @@ mod tests {
         upsert_member(&conn, project_id, bob, Role::Lead).unwrap();
 
         change_role(&conn, project_id, alice, "maintainer").unwrap();
-        assert_eq!(get_member_role(&conn, project_id, alice).unwrap(), Some(Role::Maintainer));
+        assert_eq!(
+            get_member_role(&conn, project_id, alice).unwrap(),
+            Some(Role::Maintainer)
+        );
     }
 
     #[test]
@@ -710,7 +720,10 @@ mod tests {
 
         let err = remove_member_guarded(&conn, project_id, alice).unwrap_err();
         assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
-        assert_eq!(get_member_role(&conn, project_id, alice).unwrap(), Some(Role::Lead));
+        assert_eq!(
+            get_member_role(&conn, project_id, alice).unwrap(),
+            Some(Role::Lead)
+        );
     }
 
     #[test]
@@ -811,6 +824,10 @@ mod tests {
         remove_member_guarded(&conn, project.id, bob).unwrap();
 
         let updated = projects::get_project(&conn, project.id).unwrap();
-        assert_eq!(updated.lead_user_id, Some(alice), "unrelated removal must not touch the pointer");
+        assert_eq!(
+            updated.lead_user_id,
+            Some(alice),
+            "unrelated removal must not touch the pointer"
+        );
     }
 }

--- a/src/db/queries/pages.rs
+++ b/src/db/queries/pages.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -318,7 +318,9 @@ fn validate_page_folder(
         Some(folder_project_id) => Err(LificError::BadRequest(format!(
             "folder {folder_id} belongs to project {folder_project_id}, not page project {project_id}"
         ))),
-        None => Err(LificError::BadRequest(format!("folder {folder_id} not found"))),
+        None => Err(LificError::BadRequest(format!(
+            "folder {folder_id} not found"
+        ))),
     }
 }
 
@@ -472,13 +474,15 @@ pub fn delete_page(conn: &Connection, id: i64) -> Result<(), LificError> {
 /// counterpart of [`super::issues::issue_seq`]; see that function for why the
 /// caller's pre-delete copy of the row is the wrong seq to publish.
 pub fn page_seq(conn: &Connection, id: i64) -> Result<i64, LificError> {
-    conn.query_row("SELECT seq FROM pages WHERE id = ?1", [id], |row| row.get(0))
-        .map_err(|error| match error {
-            rusqlite::Error::QueryReturnedNoRows => {
-                LificError::NotFound(format!("page {id} not found"))
-            }
-            other => other.into(),
-        })
+    conn.query_row("SELECT seq FROM pages WHERE id = ?1", [id], |row| {
+        row.get(0)
+    })
+    .map_err(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => {
+            LificError::NotFound(format!("page {id} not found"))
+        }
+        other => other.into(),
+    })
 }
 
 /// Bring a tombstoned page back, together with the comments that went down
@@ -1383,18 +1387,20 @@ mod tests {
             .is_err(),
             "unknown order_by must error, not be interpolated"
         );
-        assert!(list_pages(
-            &conn,
-            Some(pid),
-            None,
-            None,
-            None,
-            None,
-            Some("up"),
-            None,
-            None
-        )
-        .is_err());
+        assert!(
+            list_pages(
+                &conn,
+                Some(pid),
+                None,
+                None,
+                None,
+                None,
+                Some("up"),
+                None,
+                None
+            )
+            .is_err()
+        );
     }
 
     // ── LIF-183: page pinning ────────────────────────────────

--- a/src/db/queries/plans.rs
+++ b/src/db/queries/plans.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -21,9 +21,9 @@ pub struct StepDoneEffect {
 
 /// Resolve "PROJ-PLAN-7" to a plan id.
 pub fn resolve_plan_identifier(conn: &Connection, identifier: &str) -> Result<i64, LificError> {
-    let idx = identifier.rfind("-PLAN-").ok_or_else(|| {
-        LificError::BadRequest(format!("invalid plan identifier: {identifier}"))
-    })?;
+    let idx = identifier
+        .rfind("-PLAN-")
+        .ok_or_else(|| LificError::BadRequest(format!("invalid plan identifier: {identifier}")))?;
     let project_ident = &identifier[..idx];
     let sequence: i64 = identifier[idx + 6..]
         .parse()
@@ -79,7 +79,9 @@ fn read_plan_row(conn: &Connection, id: i64) -> Result<Plan, LificError> {
         },
     )
     .map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => LificError::NotFound(format!("plan {id} not found")),
+        rusqlite::Error::QueryReturnedNoRows => {
+            LificError::NotFound(format!("plan {id} not found"))
+        }
         _ => e.into(),
     })
 }
@@ -134,7 +136,10 @@ fn assemble_tree(flat: Vec<PlanStepNode>) -> Vec<PlanStepNode> {
     use std::collections::HashMap;
     let mut children_of: HashMap<Option<i64>, Vec<PlanStepNode>> = HashMap::new();
     for node in flat {
-        children_of.entry(node.parent_step_id).or_default().push(node);
+        children_of
+            .entry(node.parent_step_id)
+            .or_default()
+            .push(node);
     }
     fn build(
         parent: Option<i64>,
@@ -206,7 +211,11 @@ pub fn list_plans(conn: &Connection, q: &ListPlansQuery) -> Result<Vec<Plan>, Li
         inner.push_str(&format!(" LIMIT ?{}", pv.len() + 1));
         pv.push(Box::new(limit));
     } else {
-        inner.push_str(&format!(" LIMIT ?{} OFFSET ?{}", pv.len() + 1, pv.len() + 2));
+        inner.push_str(&format!(
+            " LIMIT ?{} OFFSET ?{}",
+            pv.len() + 1,
+            pv.len() + 2
+        ));
         pv.push(Box::new(limit));
         pv.push(Box::new(offset));
     }
@@ -307,7 +316,10 @@ pub fn update_plan(conn: &Connection, id: i64, input: &UpdatePlan) -> Result<Pla
     read_plan_row(conn, id)?;
     savepoint(conn, "update_plan", || {
         if let Some(ref title) = input.title {
-            conn.execute("UPDATE plans SET title = ?1 WHERE id = ?2", params![title, id])?;
+            conn.execute(
+                "UPDATE plans SET title = ?1 WHERE id = ?2",
+                params![title, id],
+            )?;
         }
         if let Some(ref status) = input.status {
             if !["active", "done", "archived"].contains(&status.as_str()) {
@@ -374,7 +386,9 @@ pub fn set_step_title(conn: &Connection, step_id: i64, title: &str) -> Result<()
         params![title, step_id],
     )?;
     if changed == 0 {
-        return Err(LificError::NotFound(format!("plan step {step_id} not found")));
+        return Err(LificError::NotFound(format!(
+            "plan step {step_id} not found"
+        )));
     }
     Ok(())
 }
@@ -390,7 +404,9 @@ pub fn set_step_description(
         params![unescape_text(description), step_id],
     )?;
     if changed == 0 {
-        return Err(LificError::NotFound(format!("plan step {step_id} not found")));
+        return Err(LificError::NotFound(format!(
+            "plan step {step_id} not found"
+        )));
     }
     Ok(())
 }
@@ -461,7 +477,7 @@ pub fn edit_step_text(
         other => {
             return Err(LificError::BadRequest(format!(
                 "invalid field '{other}'. Use title or description."
-            )))
+            )));
         }
     };
     let current: String = conn
@@ -602,7 +618,9 @@ pub fn set_step_issue(
         params![issue_id, step_id],
     )?;
     if changed == 0 {
-        return Err(LificError::NotFound(format!("plan step {step_id} not found")));
+        return Err(LificError::NotFound(format!(
+            "plan step {step_id} not found"
+        )));
     }
     Ok(())
 }
@@ -619,7 +637,9 @@ pub fn move_step(
 
     if let Some(parent) = new_parent {
         if parent == step_id {
-            return Err(LificError::BadRequest("a step cannot be its own parent".into()));
+            return Err(LificError::BadRequest(
+                "a step cannot be its own parent".into(),
+            ));
         }
         // Walk up from the proposed parent; if we reach step_id, the parent is
         // a descendant of the step → cycle.
@@ -672,7 +692,9 @@ pub fn move_step(
 pub fn delete_step(conn: &Connection, step_id: i64) -> Result<(), LificError> {
     let changed = conn.execute("DELETE FROM plan_steps WHERE id = ?1", params![step_id])?;
     if changed == 0 {
-        return Err(LificError::NotFound(format!("plan step {step_id} not found")));
+        return Err(LificError::NotFound(format!(
+            "plan step {step_id} not found"
+        )));
     }
     Ok(())
 }
@@ -765,8 +787,26 @@ mod tests {
         let conn = pool.write().unwrap();
         let a = seed_project(&conn, "AAA");
         let b = seed_project(&conn, "BBB");
-        let p1 = create_plan(&conn, &CreatePlan { project_id: a, title: "a".into(), issue_id: None, steps: vec![] }).unwrap();
-        let p2 = create_plan(&conn, &CreatePlan { project_id: b, title: "b".into(), issue_id: None, steps: vec![] }).unwrap();
+        let p1 = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: a,
+                title: "a".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        let p2 = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: b,
+                title: "b".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
         assert_eq!(p1.identifier, "AAA-PLAN-1");
         assert_eq!(p2.identifier, "BBB-PLAN-1");
         assert_eq!(resolve_plan_identifier(&conn, "AAA-PLAN-1").unwrap(), p1.id);
@@ -826,7 +866,10 @@ mod tests {
         .unwrap();
 
         let refreshed = get_plan(&conn, plan.id).unwrap();
-        assert!(refreshed.steps[0].done, "issue close should complete the step");
+        assert!(
+            refreshed.steps[0].done,
+            "issue close should complete the step"
+        );
         let _ = step_id;
     }
 
@@ -865,7 +908,10 @@ mod tests {
         .unwrap();
 
         let refreshed = get_plan(&conn, plan.id).unwrap();
-        assert!(!refreshed.steps[0].done, "reopen should un-complete the step");
+        assert!(
+            !refreshed.steps[0].done,
+            "reopen should un-complete the step"
+        );
         assert!(
             refreshed.steps[0].reopened_via_issue_at.is_some(),
             "reopen should stamp the reason"
@@ -889,7 +935,15 @@ mod tests {
         )
         .unwrap();
         // Archive the plan → frozen.
-        update_plan(&conn, plan.id, &UpdatePlan { status: Some("archived".into()), ..Default::default() }).unwrap();
+        update_plan(
+            &conn,
+            plan.id,
+            &UpdatePlan {
+                status: Some("archived".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         issues::update_issue(
             &conn,
@@ -902,7 +956,10 @@ mod tests {
         .unwrap();
 
         let refreshed = get_plan(&conn, plan.id).unwrap();
-        assert!(!refreshed.steps[0].done, "archived plan steps must not cascade");
+        assert!(
+            !refreshed.steps[0].done,
+            "archived plan steps must not cascade"
+        );
     }
 
     #[test]
@@ -943,12 +1000,33 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         let anchor = seed_issue(&conn, pid, "Epic", Status::Active);
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: Some(anchor.id), steps: vec![] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: Some(anchor.id),
+                steps: vec![],
+            },
+        )
+        .unwrap();
 
-        update_plan(&conn, plan.id, &UpdatePlan { status: Some("done".into()), ..Default::default() }).unwrap();
+        update_plan(
+            &conn,
+            plan.id,
+            &UpdatePlan {
+                status: Some("done".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let got = issues::get_issue(&conn, anchor.id).unwrap();
-        assert_eq!(got.status, Status::Active, "plan completion must not close the anchor issue");
+        assert_eq!(
+            got.status,
+            Status::Active,
+            "plan completion must not close the anchor issue"
+        );
     }
 
     #[test]
@@ -956,7 +1034,16 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("root", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("root", None)],
+            },
+        )
+        .unwrap();
         let root_id = plan.steps[0].id;
 
         let child = add_step(&conn, plan.id, Some(root_id), "child", "desc", None).unwrap();
@@ -979,10 +1066,25 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("s", None)],
+            },
+        )
+        .unwrap();
         delete_plan(&conn, plan.id).unwrap();
         assert!(get_plan(&conn, plan.id).is_err());
-        let count: i64 = conn.query_row("SELECT COUNT(*) FROM plan_steps WHERE plan_id = ?1", params![plan.id], |r| r.get(0)).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM plan_steps WHERE plan_id = ?1",
+                params![plan.id],
+                |r| r.get(0),
+            )
+            .unwrap();
         assert_eq!(count, 0);
     }
 
@@ -991,12 +1093,46 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let p = create_plan(&conn, &CreatePlan { project_id: pid, title: "Active".into(), issue_id: None, steps: vec![simple_step("a", None), simple_step("b", None)] }).unwrap();
+        let p = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Active".into(),
+                issue_id: None,
+                steps: vec![simple_step("a", None), simple_step("b", None)],
+            },
+        )
+        .unwrap();
         set_step_done(&conn, p.steps[0].id, true).unwrap();
-        let archived = create_plan(&conn, &CreatePlan { project_id: pid, title: "Old".into(), issue_id: None, steps: vec![] }).unwrap();
-        update_plan(&conn, archived.id, &UpdatePlan { status: Some("archived".into()), ..Default::default() }).unwrap();
+        let archived = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Old".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        update_plan(
+            &conn,
+            archived.id,
+            &UpdatePlan {
+                status: Some("archived".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
-        let active = list_plans(&conn, &ListPlansQuery { project_id: Some(pid), status: Some("active".into()), ..Default::default() }).unwrap();
+        let active = list_plans(
+            &conn,
+            &ListPlansQuery {
+                project_id: Some(pid),
+                status: Some("active".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].title, "Active");
         assert_eq!(active[0].step_count, 2);
@@ -1012,9 +1148,25 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        create_plan(&conn, &CreatePlan { project_id: pid, title: "Empty".into(), issue_id: None, steps: vec![] }).unwrap();
+        create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Empty".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
 
-        let plans = list_plans(&conn, &ListPlansQuery { project_id: Some(pid), ..Default::default() }).unwrap();
+        let plans = list_plans(
+            &conn,
+            &ListPlansQuery {
+                project_id: Some(pid),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].step_count, 0, "stepless plan must count 0, not 1");
         assert_eq!(plans[0].done_count, 0);
@@ -1028,16 +1180,45 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         for i in 0..5 {
-            create_plan(&conn, &CreatePlan { project_id: pid, title: format!("Plan {i}"), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+            create_plan(
+                &conn,
+                &CreatePlan {
+                    project_id: pid,
+                    title: format!("Plan {i}"),
+                    issue_id: None,
+                    steps: vec![simple_step("s", None)],
+                },
+            )
+            .unwrap();
         }
-        let page = list_plans(&conn, &ListPlansQuery { project_id: Some(pid), status: None, limit: Some(2), offset: Some(0), ..Default::default() }).unwrap();
+        let page = list_plans(
+            &conn,
+            &ListPlansQuery {
+                project_id: Some(pid),
+                status: None,
+                limit: Some(2),
+                offset: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(page.len(), 2);
         // Newest (highest id / latest updated_at) first.
         assert_eq!(page[0].title, "Plan 4");
         assert_eq!(page[1].title, "Plan 3");
         assert_eq!(page[0].step_count, 1);
 
-        let next = list_plans(&conn, &ListPlansQuery { project_id: Some(pid), status: None, limit: Some(2), offset: Some(2), ..Default::default() }).unwrap();
+        let next = list_plans(
+            &conn,
+            &ListPlansQuery {
+                project_id: Some(pid),
+                status: None,
+                limit: Some(2),
+                offset: Some(2),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(next.len(), 2);
         assert_eq!(next[0].title, "Plan 2");
     }
@@ -1047,10 +1228,46 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let first_created = create_plan(&conn, &CreatePlan { project_id: pid, title: "First".into(), issue_id: None, steps: vec![] }).unwrap();
-        let second_created = create_plan(&conn, &CreatePlan { project_id: pid, title: "Second".into(), issue_id: None, steps: vec![] }).unwrap();
-        let third_created = create_plan(&conn, &CreatePlan { project_id: pid, title: "Third".into(), issue_id: None, steps: vec![] }).unwrap();
-        let fourth_created = create_plan(&conn, &CreatePlan { project_id: pid, title: "Fourth".into(), issue_id: None, steps: vec![] }).unwrap();
+        let first_created = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "First".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        let second_created = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Second".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        let third_created = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Third".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        let fourth_created = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Fourth".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
         conn.execute("DROP TRIGGER plans_updated", []).unwrap();
         conn.execute(
             "UPDATE plans SET updated_at = '2020-01-01 00:00:00' WHERE project_id = ?1",
@@ -1068,7 +1285,10 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(first.iter().map(|plan| plan.id).collect::<Vec<_>>(), vec![fourth_created.id, third_created.id]);
+        assert_eq!(
+            first.iter().map(|plan| plan.id).collect::<Vec<_>>(),
+            vec![fourth_created.id, third_created.id]
+        );
 
         // An unseen row can move in updated-at order between requests without
         // crossing an immutable id cursor boundary.
@@ -1090,14 +1310,23 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(second.iter().map(|plan| plan.id).collect::<Vec<_>>(), vec![second_created.id, first_created.id]);
+        assert_eq!(
+            second.iter().map(|plan| plan.id).collect::<Vec<_>>(),
+            vec![second_created.id, first_created.id]
+        );
 
         let default_order = list_plans(
             &conn,
-            &ListPlansQuery { project_id: Some(pid), ..Default::default() },
+            &ListPlansQuery {
+                project_id: Some(pid),
+                ..Default::default()
+            },
         )
         .unwrap();
-        assert_eq!(default_order[0].id, second_created.id, "default ordering remains updated_at DESC, id DESC");
+        assert_eq!(
+            default_order[0].id, second_created.id,
+            "default ordering remains updated_at DESC, id DESC"
+        );
     }
 
     #[test]
@@ -1142,12 +1371,21 @@ mod tests {
 
     // ── Audit coverage (LIF-176) ──
 
-    fn audit_rows(conn: &Connection, entity_type: &str) -> Vec<(String, Option<String>, Option<String>)> {
+    fn audit_rows(
+        conn: &Connection,
+        entity_type: &str,
+    ) -> Vec<(String, Option<String>, Option<String>)> {
         let mut stmt = conn
-            .prepare("SELECT action, field, new_value FROM audit_log WHERE entity_type = ?1 ORDER BY id")
+            .prepare(
+                "SELECT action, field, new_value FROM audit_log WHERE entity_type = ?1 ORDER BY id",
+            )
             .unwrap();
         stmt.query_map(params![entity_type], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, Option<String>>(1)?, r.get::<_, Option<String>>(2)?))
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, Option<String>>(1)?,
+                r.get::<_, Option<String>>(2)?,
+            ))
         })
         .unwrap()
         .collect::<Result<Vec<_>, _>>()
@@ -1159,17 +1397,35 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("s", None)],
+            },
+        )
+        .unwrap();
         let step_id = plan.steps[0].id;
         set_step_done(&conn, step_id, true).unwrap();
 
-        let plan_actions: Vec<String> = audit_rows(&conn, "plan").into_iter().map(|r| r.0).collect();
-        assert!(plan_actions.contains(&"create".to_string()), "plan create must be audited: {plan_actions:?}");
+        let plan_actions: Vec<String> =
+            audit_rows(&conn, "plan").into_iter().map(|r| r.0).collect();
+        assert!(
+            plan_actions.contains(&"create".to_string()),
+            "plan create must be audited: {plan_actions:?}"
+        );
 
         let step_audit = audit_rows(&conn, "plan_step");
-        assert!(step_audit.iter().any(|(a, _, _)| a == "create"), "step create audited");
         assert!(
-            step_audit.iter().any(|(a, f, _)| a == "update" && f.as_deref() == Some("done")),
+            step_audit.iter().any(|(a, _, _)| a == "create"),
+            "step create audited"
+        );
+        assert!(
+            step_audit
+                .iter()
+                .any(|(a, f, _)| a == "update" && f.as_deref() == Some("done")),
             "step done audited: {step_audit:?}"
         );
     }
@@ -1180,12 +1436,26 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         let issue = seed_issue(&conn, pid, "Work", Status::Todo);
-        create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("mirror", Some(issue.id))] }).unwrap();
+        create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("mirror", Some(issue.id))],
+            },
+        )
+        .unwrap();
 
-        issues::update_issue(&conn, issue.id, &UpdateIssue {
-            status: Some(Status::Done),
-            ..Default::default()
-        }).unwrap();
+        issues::update_issue(
+            &conn,
+            issue.id,
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let step_audit = audit_rows(&conn, "plan_step");
         assert!(
@@ -1204,15 +1474,36 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan_a = create_plan(&conn, &CreatePlan { project_id: pid, title: "A".into(), issue_id: None, steps: vec![simple_step("a-step", None)] }).unwrap();
-        let plan_b = create_plan(&conn, &CreatePlan { project_id: pid, title: "B".into(), issue_id: None, steps: vec![simple_step("b-step", None)] }).unwrap();
+        let plan_a = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "A".into(),
+                issue_id: None,
+                steps: vec![simple_step("a-step", None)],
+            },
+        )
+        .unwrap();
+        let plan_b = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "B".into(),
+                issue_id: None,
+                steps: vec![simple_step("b-step", None)],
+            },
+        )
+        .unwrap();
         let a_step = plan_a.steps[0].id;
         let b_step = plan_b.steps[0].id;
 
         assert!(assert_step_in_plan(&conn, plan_a.id, a_step).is_ok());
         // a_step belongs to plan_a, not plan_b → BadRequest.
         let err = assert_step_in_plan(&conn, plan_b.id, a_step).unwrap_err();
-        assert!(matches!(err, LificError::BadRequest(_)), "foreign step must be rejected, got {err:?}");
+        assert!(
+            matches!(err, LificError::BadRequest(_)),
+            "foreign step must be rejected, got {err:?}"
+        );
         assert!(assert_step_in_plan(&conn, plan_b.id, b_step).is_ok());
     }
 
@@ -1221,7 +1512,16 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("old title", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("old title", None)],
+            },
+        )
+        .unwrap();
         let step_id = plan.steps[0].id;
 
         set_step_title(&conn, step_id, "new title").unwrap();
@@ -1229,7 +1529,10 @@ mod tests {
         assert_eq!(reread.steps[0].title, "new title");
 
         let err = set_step_title(&conn, 999_999, "ghost").unwrap_err();
-        assert!(matches!(err, LificError::NotFound(_)), "missing step must 404, got {err:?}");
+        assert!(
+            matches!(err, LificError::NotFound(_)),
+            "missing step must 404, got {err:?}"
+        );
     }
 
     // set_step_description runs unescape_text (LIF-177): literal \n from JSON
@@ -1239,12 +1542,24 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("s", None)],
+            },
+        )
+        .unwrap();
         let step_id = plan.steps[0].id;
 
         set_step_description(&conn, step_id, "line one\\nline two").unwrap();
         let reread = get_plan(&conn, plan.id).unwrap();
-        assert_eq!(reread.steps[0].description, "line one\nline two", "\\n must be unescaped to a newline");
+        assert_eq!(
+            reread.steps[0].description, "line one\nline two",
+            "\\n must be unescaped to a newline"
+        );
 
         let err = set_step_description(&conn, 999_999, "x").unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)));
@@ -1256,11 +1571,23 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         let issue = seed_issue(&conn, pid, "Linkable", Status::Todo);
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("s", None)],
+            },
+        )
+        .unwrap();
         let step_id = plan.steps[0].id;
 
         set_step_issue(&conn, step_id, Some(issue.id)).unwrap();
-        assert_eq!(get_plan(&conn, plan.id).unwrap().steps[0].issue_id, Some(issue.id));
+        assert_eq!(
+            get_plan(&conn, plan.id).unwrap().steps[0].issue_id,
+            Some(issue.id)
+        );
 
         // Passing None must clear the link back to NULL.
         set_step_issue(&conn, step_id, None).unwrap();
@@ -1294,7 +1621,11 @@ mod tests {
         let parent_id = plan.steps[0].id;
         let child_id = plan.steps[0].children[0].id;
 
-        assert_eq!(step_parent(&conn, parent_id).unwrap(), None, "root step has no parent");
+        assert_eq!(
+            step_parent(&conn, parent_id).unwrap(),
+            None,
+            "root step has no parent"
+        );
         assert_eq!(step_parent(&conn, child_id).unwrap(), Some(parent_id));
 
         let err = step_parent(&conn, 999_999).unwrap_err();

--- a/src/db/queries/project_groups.rs
+++ b/src/db/queries/project_groups.rs
@@ -214,8 +214,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
 
-        let created =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let created = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
         assert_eq!(created.name, "Work");
         assert!(created.project_ids.is_empty());
 
@@ -231,14 +237,33 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
 
-        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
-        let err =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap_err();
+        let err = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap_err();
         assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
 
-        create_group(&conn, bob, &CreateProjectGroup { name: "Work".into() })
-            .expect("a different user may reuse the name");
+        create_group(
+            &conn,
+            bob,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .expect("a different user may reuse the name");
     }
 
     #[test]
@@ -248,7 +273,14 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
 
-        create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+        create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Personal".into(),
+            },
+        )
+        .unwrap();
 
         assert!(list_groups(&conn, bob).unwrap().is_empty());
     }
@@ -272,10 +304,22 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
-        let personal =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
+        let personal = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Personal".into(),
+            },
+        )
+        .unwrap();
 
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
         assign_project(&conn, alice, project, Some(personal.id)).unwrap();
@@ -296,8 +340,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
         assign_project(&conn, alice, project, None).unwrap();
@@ -313,10 +363,22 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
         let project = seed_project(&conn, "APP");
-        let alice_work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
-        let bob_side =
-            create_group(&conn, bob, &CreateProjectGroup { name: "Side".into() }).unwrap();
+        let alice_work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
+        let bob_side = create_group(
+            &conn,
+            bob,
+            &CreateProjectGroup {
+                name: "Side".into(),
+            },
+        )
+        .unwrap();
 
         assign_project(&conn, alice, project, Some(alice_work.id)).unwrap();
         assign_project(&conn, bob, project, Some(bob_side.id)).unwrap();
@@ -338,8 +400,14 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
         let project = seed_project(&conn, "APP");
-        let alice_work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let alice_work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
         let err = assign_project(&conn, bob, project, Some(alice_work.id)).unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
@@ -353,8 +421,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
 
         assert!(delete_group(&conn, work.id, alice).unwrap());
@@ -369,8 +443,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
         let err = delete_group(&conn, work.id, bob).unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
@@ -382,8 +462,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
 
         queries::delete_project(&conn, project).unwrap();
@@ -396,7 +482,14 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
-        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
         conn.execute("DELETE FROM users WHERE id = ?1", params![alice])
             .unwrap();
@@ -414,9 +507,22 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
-        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
-        let personal =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+        create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
+        let personal = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Personal".into(),
+            },
+        )
+        .unwrap();
 
         let err = update_group(
             &conn,
@@ -436,8 +542,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
 
         let renamed = update_group(
@@ -450,6 +562,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(renamed.name, "Day job");
-        assert_eq!(list_groups(&conn, alice).unwrap()[0].project_ids, vec![project]);
+        assert_eq!(
+            list_groups(&conn, alice).unwrap()[0].project_ids,
+            vec![project]
+        );
     }
 }

--- a/src/db/queries/projects.rs
+++ b/src/db/queries/projects.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -155,7 +155,9 @@ pub fn get_project(conn: &Connection, id: i64) -> Result<Project, LificError> {
 ///   workspace pages
 fn validate_identifier(identifier: &str) -> Result<(), LificError> {
     if identifier.is_empty() {
-        return Err(LificError::BadRequest("identifier must not be empty".into()));
+        return Err(LificError::BadRequest(
+            "identifier must not be empty".into(),
+        ));
     }
     if identifier.chars().count() > 5 {
         return Err(LificError::BadRequest(
@@ -278,19 +280,16 @@ pub fn update_project(
             // return a 400 with a clear message instead of letting the FK
             // constraint surface as a generic 500.
             if let Some(uid) = lead {
-                let exists = match conn.query_row(
-                    "SELECT 1 FROM users WHERE id = ?1",
-                    params![uid],
-                    |_| Ok(true),
-                ) {
-                    Ok(_) => true,
-                    Err(rusqlite::Error::QueryReturnedNoRows) => false,
-                    Err(e) => return Err(e.into()),
-                };
+                let exists =
+                    match conn.query_row("SELECT 1 FROM users WHERE id = ?1", params![uid], |_| {
+                        Ok(true)
+                    }) {
+                        Ok(_) => true,
+                        Err(rusqlite::Error::QueryReturnedNoRows) => false,
+                        Err(e) => return Err(e.into()),
+                    };
                 if !exists {
-                    return Err(LificError::BadRequest(format!(
-                        "user {uid} not found"
-                    )));
+                    return Err(LificError::BadRequest(format!("user {uid} not found")));
                 }
             }
             conn.execute(
@@ -719,7 +718,8 @@ mod tests {
         seed_named(&conn, "Gamma", "G");
         seed_named(&conn, "Alpha", "A");
         seed_named(&conn, "Beta", "B");
-        conn.execute("UPDATE projects SET sort_order = 0", []).unwrap();
+        conn.execute("UPDATE projects SET sort_order = 0", [])
+            .unwrap();
 
         let names: Vec<String> = list_projects(&conn)
             .unwrap()

--- a/src/db/queries/resources.rs
+++ b/src/db/queries/resources.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -137,16 +137,18 @@ pub fn get_module(conn: &Connection, id: i64) -> Result<Module, LificError> {
         "SELECT id, project_id, name, description, status, emoji, created_at, updated_at
          FROM modules WHERE id = ?1",
         params![id],
-        |row| Ok(Module {
-            id: row.get(0)?,
-            project_id: row.get(1)?,
-            name: row.get(2)?,
-            description: row.get(3)?,
-            status: row.get(4)?,
-            emoji: row.get(5)?,
-            created_at: row.get(6)?,
-            updated_at: row.get(7)?,
-        }),
+        |row| {
+            Ok(Module {
+                id: row.get(0)?,
+                project_id: row.get(1)?,
+                name: row.get(2)?,
+                description: row.get(3)?,
+                status: row.get(4)?,
+                emoji: row.get(5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        },
     )
     .map_err(|e| match e {
         rusqlite::Error::QueryReturnedNoRows => {
@@ -182,7 +184,14 @@ pub fn list_modules(conn: &Connection, project_id: i64) -> Result<Vec<Module>, L
 /// CLI all get the same contract (mirrors how issue status became a real
 /// type in 286d4ac; modules keep the lighter String representation because
 /// nothing branches on module status server-side).
-const MODULE_STATUSES: [&str; 6] = ["backlog", "planned", "active", "paused", "done", "cancelled"];
+const MODULE_STATUSES: [&str; 6] = [
+    "backlog",
+    "planned",
+    "active",
+    "paused",
+    "done",
+    "cancelled",
+];
 
 fn validate_module_status(status: &str) -> Result<(), LificError> {
     if MODULE_STATUSES.contains(&status) {
@@ -573,7 +582,10 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got: {err:?}");
-        assert!(err.to_string().contains("paused"), "error must list the six: {err}");
+        assert!(
+            err.to_string().contains("paused"),
+            "error must list the six: {err}"
+        );
 
         let module = create_module(
             &conn,
@@ -586,7 +598,14 @@ mod tests {
             },
         )
         .unwrap();
-        for status in ["backlog", "planned", "active", "paused", "done", "cancelled"] {
+        for status in [
+            "backlog",
+            "planned",
+            "active",
+            "paused",
+            "done",
+            "cancelled",
+        ] {
             update_module(
                 &conn,
                 module.id,
@@ -771,12 +790,20 @@ mod tests {
         let pid = seed_project(&conn);
         let bug = create_label(
             &conn,
-            &CreateLabel { project_id: pid, name: "bug".into(), color: "#EF4444".into() },
+            &CreateLabel {
+                project_id: pid,
+                name: "bug".into(),
+                color: "#EF4444".into(),
+            },
         )
         .unwrap();
         let defect = create_label(
             &conn,
-            &CreateLabel { project_id: pid, name: "defect".into(), color: "#F97316".into() },
+            &CreateLabel {
+                project_id: pid,
+                name: "defect".into(),
+                color: "#F97316".into(),
+            },
         )
         .unwrap();
 
@@ -825,7 +852,11 @@ mod tests {
         let pid = seed_project(&conn);
         let l = create_label(
             &conn,
-            &CreateLabel { project_id: pid, name: "bug".into(), color: "#EF4444".into() },
+            &CreateLabel {
+                project_id: pid,
+                name: "bug".into(),
+                color: "#EF4444".into(),
+            },
         )
         .unwrap();
         let err = merge_label(&conn, l.id, l.id).unwrap_err();
@@ -1062,24 +1093,56 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn);
-        let module = create_module(&conn, &CreateModule {
-            project_id: pid, name: "M".into(), description: String::new(),
-            status: "active".into(), emoji: None,
-        }).unwrap();
-        let label = create_label(&conn, &CreateLabel {
-            project_id: pid, name: "bug".into(), color: "#EF4444".into(),
-        }).unwrap();
-        let folder = create_folder(&conn, &CreateFolder {
-            project_id: pid, parent_id: None, name: "Docs".into(),
-        }).unwrap();
+        let module = create_module(
+            &conn,
+            &CreateModule {
+                project_id: pid,
+                name: "M".into(),
+                description: String::new(),
+                status: "active".into(),
+                emoji: None,
+            },
+        )
+        .unwrap();
+        let label = create_label(
+            &conn,
+            &CreateLabel {
+                project_id: pid,
+                name: "bug".into(),
+                color: "#EF4444".into(),
+            },
+        )
+        .unwrap();
+        let folder = create_folder(
+            &conn,
+            &CreateFolder {
+                project_id: pid,
+                parent_id: None,
+                name: "Docs".into(),
+            },
+        )
+        .unwrap();
 
-        assert_eq!(get_resource_project_id(&conn, ResourceTable::Modules, module.id).unwrap(), pid);
-        assert_eq!(get_resource_project_id(&conn, ResourceTable::Labels, label.id).unwrap(), pid);
-        assert_eq!(get_resource_project_id(&conn, ResourceTable::Folders, folder.id).unwrap(), pid);
+        assert_eq!(
+            get_resource_project_id(&conn, ResourceTable::Modules, module.id).unwrap(),
+            pid
+        );
+        assert_eq!(
+            get_resource_project_id(&conn, ResourceTable::Labels, label.id).unwrap(),
+            pid
+        );
+        assert_eq!(
+            get_resource_project_id(&conn, ResourceTable::Folders, folder.id).unwrap(),
+            pid
+        );
 
         // The only table names reachable from the enum are these three bare
         // identifiers, so no call site can smuggle SQL in through the name.
-        for table in [ResourceTable::Modules, ResourceTable::Labels, ResourceTable::Folders] {
+        for table in [
+            ResourceTable::Modules,
+            ResourceTable::Labels,
+            ResourceTable::Folders,
+        ] {
             let name = table.as_table();
             assert!(
                 ["modules", "labels", "folders"].contains(&name),
@@ -1101,9 +1164,15 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn);
-        let folder = create_folder(&conn, &CreateFolder {
-            project_id: pid, parent_id: None, name: "Design".into(),
-        }).unwrap();
+        let folder = create_folder(
+            &conn,
+            &CreateFolder {
+                project_id: pid,
+                parent_id: None,
+                name: "Design".into(),
+            },
+        )
+        .unwrap();
 
         assert_eq!(get_folder_name(&conn, folder.id).unwrap(), "Design");
         let err = get_folder_name(&conn, 999_999).unwrap_err();

--- a/src/db/queries/settings.rs
+++ b/src/db/queries/settings.rs
@@ -125,7 +125,10 @@ pub fn update(
     patch: InstanceSettingsPatch,
 ) -> Result<InstanceSettings, LificError> {
     // Guarantee the single row exists before we UPDATE it (write conn).
-    conn.execute("INSERT OR IGNORE INTO instance_settings (id) VALUES (1)", [])?;
+    conn.execute(
+        "INSERT OR IGNORE INTO instance_settings (id) VALUES (1)",
+        [],
+    )?;
     let cur = get(conn)?;
 
     let allow_signup = patch.allow_signup.unwrap_or(cur.allow_signup);
@@ -238,7 +241,8 @@ fn is_plausible_domain(d: &str) -> bool {
     if d.contains("..") {
         return false;
     }
-    d.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+    d.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
 }
 
 #[cfg(test)]
@@ -260,8 +264,14 @@ mod tests {
         assert!(s.signup_email_domains.is_empty());
         assert_eq!(s.session_lifetime_days, 30);
         assert!(s.login_message.is_none());
-        assert!(!s.web_auto_login, "single-user auto-login is off by default");
-        assert!(!s.authz_enforced, "authorization enforcement is off by default");
+        assert!(
+            !s.web_auto_login,
+            "single-user auto-login is off by default"
+        );
+        assert!(
+            !s.authz_enforced,
+            "authorization enforcement is off by default"
+        );
     }
 
     #[test]
@@ -278,10 +288,16 @@ mod tests {
         let pool = conn();
         let c = pool.write().unwrap();
         ensure(&c, false).unwrap();
-        assert!(!get(&c).unwrap().allow_signup, "first ensure seeds the value");
+        assert!(
+            !get(&c).unwrap().allow_signup,
+            "first ensure seeds the value"
+        );
         // A later ensure with a different default must NOT overwrite.
         ensure(&c, true).unwrap();
-        assert!(!get(&c).unwrap().allow_signup, "row already existed, left intact");
+        assert!(
+            !get(&c).unwrap().allow_signup,
+            "row already existed, left intact"
+        );
     }
 
     // ── LIF-261: authz_enforced seed default depends on the install ──────
@@ -349,7 +365,10 @@ mod tests {
         // An admin flips it off at runtime…
         let s = update(
             &c,
-            InstanceSettingsPatch { authz_enforced: Some(false), ..Default::default() },
+            InstanceSettingsPatch {
+                authz_enforced: Some(false),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(!s.authz_enforced);
@@ -368,14 +387,20 @@ mod tests {
         let c = pool.write().unwrap();
         let s = update(
             &c,
-            InstanceSettingsPatch { instance_name: Some("  Acme Eng  ".into()), ..Default::default() },
+            InstanceSettingsPatch {
+                instance_name: Some("  Acme Eng  ".into()),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert_eq!(s.instance_name.as_deref(), Some("Acme Eng")); // trimmed
         // Empty clears back to NULL.
         let s = update(
             &c,
-            InstanceSettingsPatch { instance_name: Some("   ".into()), ..Default::default() },
+            InstanceSettingsPatch {
+                instance_name: Some("   ".into()),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.instance_name.is_none());
@@ -404,21 +429,36 @@ mod tests {
     fn update_rejects_bad_domain_and_bad_session() {
         let pool = conn();
         let c = pool.write().unwrap();
-        assert!(update(
-            &c,
-            InstanceSettingsPatch { signup_email_domains: Some(vec!["not a domain".into()]), ..Default::default() },
-        )
-        .is_err());
-        assert!(update(
-            &c,
-            InstanceSettingsPatch { session_lifetime_days: Some(0), ..Default::default() },
-        )
-        .is_err());
-        assert!(update(
-            &c,
-            InstanceSettingsPatch { session_lifetime_days: Some(999), ..Default::default() },
-        )
-        .is_err());
+        assert!(
+            update(
+                &c,
+                InstanceSettingsPatch {
+                    signup_email_domains: Some(vec!["not a domain".into()]),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            update(
+                &c,
+                InstanceSettingsPatch {
+                    session_lifetime_days: Some(0),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            update(
+                &c,
+                InstanceSettingsPatch {
+                    session_lifetime_days: Some(999),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -447,21 +487,30 @@ mod tests {
 
         let s = update(
             &c,
-            InstanceSettingsPatch { web_auto_login: Some(true), ..Default::default() },
+            InstanceSettingsPatch {
+                web_auto_login: Some(true),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.web_auto_login);
         // Persisted, and an unrelated patch leaves it intact.
         let s = update(
             &c,
-            InstanceSettingsPatch { instance_name: Some("Solo".into()), ..Default::default() },
+            InstanceSettingsPatch {
+                instance_name: Some("Solo".into()),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.web_auto_login, "unrelated patch must not clear the flag");
 
         let s = update(
             &c,
-            InstanceSettingsPatch { web_auto_login: Some(false), ..Default::default() },
+            InstanceSettingsPatch {
+                web_auto_login: Some(false),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(!s.web_auto_login);
@@ -476,21 +525,30 @@ mod tests {
 
         let s = update(
             &c,
-            InstanceSettingsPatch { authz_enforced: Some(true), ..Default::default() },
+            InstanceSettingsPatch {
+                authz_enforced: Some(true),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.authz_enforced);
         // Persisted, and an unrelated patch leaves it intact.
         let s = update(
             &c,
-            InstanceSettingsPatch { instance_name: Some("Solo".into()), ..Default::default() },
+            InstanceSettingsPatch {
+                instance_name: Some("Solo".into()),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.authz_enforced, "unrelated patch must not clear the flag");
 
         let s = update(
             &c,
-            InstanceSettingsPatch { authz_enforced: Some(false), ..Default::default() },
+            InstanceSettingsPatch {
+                authz_enforced: Some(false),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(!s.authz_enforced);

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -1,8 +1,8 @@
 use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
 };
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -316,7 +316,9 @@ pub fn update_profile(
     if let Some(dn) = display_name {
         let dn = dn.trim();
         if dn.is_empty() {
-            return Err(LificError::BadRequest("display name cannot be empty".into()));
+            return Err(LificError::BadRequest(
+                "display name cannot be empty".into(),
+            ));
         }
         if dn.chars().count() > 100 {
             return Err(LificError::BadRequest(
@@ -333,15 +335,18 @@ pub fn update_profile(
         if em.is_empty() || !em.contains('@') {
             return Err(LificError::BadRequest("invalid email address".into()));
         }
-        conn.execute("UPDATE users SET email = ?1 WHERE id = ?2", params![em, user_id])
-            .map_err(|e| match e {
-                rusqlite::Error::SqliteFailure(err, _)
-                    if err.code == rusqlite::ErrorCode::ConstraintViolation =>
-                {
-                    LificError::BadRequest("that email is already in use".into())
-                }
-                other => other.into(),
-            })?;
+        conn.execute(
+            "UPDATE users SET email = ?1 WHERE id = ?2",
+            params![em, user_id],
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::SqliteFailure(err, _)
+                if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                LificError::BadRequest("that email is already in use".into())
+            }
+            other => other.into(),
+        })?;
     }
     get_user_by_id(conn, user_id)
 }
@@ -471,7 +476,11 @@ fn derive_username(conn: &Connection, display_name: &str) -> Result<String, Lifi
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("-");
-    let base = if slug.is_empty() { "admin".to_string() } else { slug };
+    let base = if slug.is_empty() {
+        "admin".to_string()
+    } else {
+        slug
+    };
     let mut candidate = base.clone();
     let mut n = 1;
     loop {
@@ -906,7 +915,6 @@ pub fn assign_key_to_user(
     }
     Ok(())
 }
-
 
 // ── Bots (connected tools) ───────────────────────────────────
 
@@ -1387,14 +1395,20 @@ pub fn delete_bot(
     conn.execute("DELETE FROM api_keys WHERE user_id = ?1", params![bot_id])?;
     // Delete the bot's OAuth tokens (LIFIC-13 follow-up): leaves no dangling
     // rows pointing at a removed identity.
-    conn.execute("DELETE FROM oauth_tokens WHERE user_id = ?1", params![bot_id])?;
+    conn.execute(
+        "DELETE FROM oauth_tokens WHERE user_id = ?1",
+        params![bot_id],
+    )?;
     // And its in-flight OAuth handshakes (PR #23 review): a pending device or
     // auth code bound to a deleted identity must not stay exchangeable.
     conn.execute(
         "DELETE FROM oauth_device_codes WHERE user_id = ?1",
         params![bot_id],
     )?;
-    conn.execute("DELETE FROM oauth_codes WHERE user_id = ?1", params![bot_id])?;
+    conn.execute(
+        "DELETE FROM oauth_codes WHERE user_id = ?1",
+        params![bot_id],
+    )?;
 
     // Delete any comments made by this bot (or reassign — deleting for now)
     conn.execute("DELETE FROM comments WHERE user_id = ?1", params![bot_id])?;
@@ -1494,7 +1508,10 @@ mod tests {
         assert!(!has_human_users(&conn).unwrap(), "fresh db has no humans");
 
         test_create_user(&conn);
-        assert!(has_human_users(&conn).unwrap(), "human signup flips it true");
+        assert!(
+            has_human_users(&conn).unwrap(),
+            "human signup flips it true"
+        );
     }
 
     #[test]
@@ -1558,8 +1575,12 @@ mod tests {
         let conn = pool.write().unwrap();
         let owner = test_create_user(&conn);
 
-        let first = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap().id;
-        let second = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap().id;
+        let first = ensure_bot(&conn, owner.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
+        let second = ensure_bot(&conn, owner.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
         assert_eq!(first, second, "re-approval must reuse, not duplicate");
     }
 
@@ -1581,8 +1602,12 @@ mod tests {
         )
         .unwrap();
 
-        let a = ensure_bot(&conn, owner_a.id, "opencode", "OpenCode").unwrap().id;
-        let b = ensure_bot(&conn, owner_b.id, "opencode", "OpenCode").unwrap().id;
+        let a = ensure_bot(&conn, owner_a.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
+        let b = ensure_bot(&conn, owner_b.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
         assert_ne!(a, b, "each owner gets its own bot for the same tool");
     }
 
@@ -1598,7 +1623,9 @@ mod tests {
         let conn = pool.write().unwrap();
         let owner = test_create_user(&conn); // username "blake"
 
-        let first = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap().id;
+        let first = ensure_bot(&conn, owner.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
 
         // Simulate the owner renaming their account: username changes, id stays.
         conn.execute(
@@ -1607,8 +1634,13 @@ mod tests {
         )
         .unwrap();
 
-        let second = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap().id;
-        assert_eq!(first, second, "renaming the owner must not orphan the agent");
+        let second = ensure_bot(&conn, owner.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
+        assert_eq!(
+            first, second,
+            "renaming the owner must not orphan the agent"
+        );
     }
 
     // Bots minted before the tool_id column existed (tool_id NULL) are still
@@ -1621,8 +1653,7 @@ mod tests {
         let conn = pool.write().unwrap();
         let owner = test_create_user(&conn); // username "blake"
         // A pre-migration bot: username "opencode-blake", tool_id NULL.
-        let legacy = create_bot_user(&conn, owner.id, "opencode-blake", "OpenCode", None)
-            .unwrap();
+        let legacy = create_bot_user(&conn, owner.id, "opencode-blake", "OpenCode", None).unwrap();
 
         let reused = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap();
         assert_eq!(
@@ -1636,7 +1667,11 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(stored.as_deref(), Some("opencode"), "legacy bot tool_id backfilled");
+        assert_eq!(
+            stored.as_deref(),
+            Some("opencode"),
+            "legacy bot tool_id backfilled"
+        );
     }
 
     // The legacy backfill holds even when the owner renamed *before* the
@@ -1648,8 +1683,8 @@ mod tests {
         let conn = pool.write().unwrap();
         let owner = test_create_user(&conn); // username "blake"
         // A pre-migration bot whose username still has the old owner name.
-        let legacy = create_bot_user(&conn, owner.id, "opencode-oldname", "OpenCode", None)
-            .unwrap();
+        let legacy =
+            create_bot_user(&conn, owner.id, "opencode-oldname", "OpenCode", None).unwrap();
         // The owner renames before ever reconnecting.
         conn.execute(
             "UPDATE users SET username = ?1 WHERE id = ?2",
@@ -1838,7 +1873,8 @@ mod tests {
     fn migration_038_keeps_the_oldest_bot_and_repoints_every_reference() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        conn.execute_batch("DROP INDEX idx_users_owner_tool;").unwrap();
+        conn.execute_batch("DROP INDEX idx_users_owner_tool;")
+            .unwrap();
 
         let owner = test_create_user(&conn);
         raw_insert_bot(&conn, "opencode-blake", owner.id, Some("opencode")).unwrap();
@@ -1941,8 +1977,10 @@ mod tests {
         )
         .unwrap();
 
-        conn.execute_batch(include_str!("../../../migrations/038_bot_identity_unique.sql"))
-            .unwrap();
+        conn.execute_batch(include_str!(
+            "../../../migrations/038_bot_identity_unique.sql"
+        ))
+        .unwrap();
 
         // The loser is gone, the survivor and the unrelated bot are not.
         let remaining: Vec<i64> = conn
@@ -2003,7 +2041,8 @@ mod tests {
     fn migration_038_merges_colliding_rows_instead_of_dropping_them() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        conn.execute_batch("DROP INDEX idx_users_owner_tool;").unwrap();
+        conn.execute_batch("DROP INDEX idx_users_owner_tool;")
+            .unwrap();
 
         let owner = test_create_user(&conn);
         raw_insert_bot(&conn, "opencode-blake", owner.id, Some("opencode")).unwrap();
@@ -2067,8 +2106,10 @@ mod tests {
             .unwrap();
         }
 
-        conn.execute_batch(include_str!("../../../migrations/038_bot_identity_unique.sql"))
-            .unwrap();
+        conn.execute_batch(include_str!(
+            "../../../migrations/038_bot_identity_unique.sql"
+        ))
+        .unwrap();
 
         // The strongest role wins per project; nothing is dropped.
         let members: Vec<(i64, i64, String)> = conn
@@ -2664,7 +2705,11 @@ mod tests {
         test_create_user(&conn);
 
         let known = password_challenge(&conn, "blake");
-        assert_ne!(known.hash(), DUMMY_HASH, "a real user verifies their own hash");
+        assert_ne!(
+            known.hash(),
+            DUMMY_HASH,
+            "a real user verifies their own hash"
+        );
         assert!(verify_password("securepassword123", known.hash()).unwrap());
 
         let unknown = password_challenge(&conn, "nobody");
@@ -2698,8 +2743,11 @@ mod tests {
                 .to_string()
         );
 
-        conn.execute("UPDATE users SET is_active = 0 WHERE id = ?1", params![user.id])
-            .unwrap();
+        conn.execute(
+            "UPDATE users SET is_active = 0 WHERE id = ?1",
+            params![user.id],
+        )
+        .unwrap();
         let challenge = password_challenge(&conn, "blake");
         let ok = verify_password("securepassword123", challenge.hash()).unwrap();
         let err = challenge.finish(ok).unwrap_err().to_string();
@@ -2732,7 +2780,9 @@ mod tests {
         assert_eq!(user.email, "mixedcase@example.com", "email is lowercased");
         assert_eq!(user.display_name, "spaced");
         assert_eq!(
-            authenticate(&conn, "spaced", "securepassword123").unwrap().id,
+            authenticate(&conn, "spaced", "securepassword123")
+                .unwrap()
+                .id,
             user.id,
             "the externally-hashed password still logs in"
         );
@@ -3408,7 +3458,10 @@ mod tests {
         let admin = create_passwordless_admin(&conn, "Operator Blake").unwrap();
 
         assert!(admin.is_admin, "first admin is an admin");
-        assert!(!admin.is_bot, "first admin is a person, not a connected tool");
+        assert!(
+            !admin.is_bot,
+            "first admin is a person, not a connected tool"
+        );
         assert_eq!(admin.display_name, "Operator Blake");
     }
 
@@ -3418,7 +3471,9 @@ mod tests {
         let conn = pool.write().unwrap();
         let admin = create_passwordless_admin(&conn, "Operator Blake").unwrap();
 
-        let resolved = first_admin(&conn).unwrap().expect("resolves as first admin");
+        let resolved = first_admin(&conn)
+            .unwrap()
+            .expect("resolves as first admin");
         assert_eq!(resolved.id, admin.id);
         assert_eq!(resolved.username, admin.username);
     }
@@ -3438,7 +3493,10 @@ mod tests {
         let first = create_passwordless_admin(&conn, "Blake").unwrap();
         let second = create_passwordless_admin(&conn, "blake!").unwrap();
 
-        assert_ne!(first.username, second.username, "usernames must not collide");
+        assert_ne!(
+            first.username, second.username,
+            "usernames must not collide"
+        );
         assert!(!first.username.is_empty());
         assert!(!second.username.is_empty());
     }

--- a/src/db/queries/views.rs
+++ b/src/db/queries/views.rs
@@ -132,7 +132,13 @@ pub fn create_view(
         conn.execute(
             "INSERT INTO saved_views (project_id, user_id, name, config, is_default)
              VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![project_id, user_id, input.name, input.config, input.is_default],
+            params![
+                project_id,
+                user_id,
+                input.name,
+                input.config,
+                input.is_default
+            ],
         )
         .map_err(constraint_err(&input.name))?;
         get_view_row(conn, conn.last_insert_rowid())
@@ -356,7 +362,11 @@ mod tests {
             created.id,
             project,
             alice,
-            &UpdateSavedView { name: None, config: Some(r#"{"a":1}"#.into()), is_default: None },
+            &UpdateSavedView {
+                name: None,
+                config: Some(r#"{"a":1}"#.into()),
+                is_default: None,
+            },
         )
         .unwrap();
 
@@ -396,7 +406,11 @@ mod tests {
             alice_view.id,
             project,
             bob,
-            &UpdateSavedView { name: Some("Hijacked".into()), config: None, is_default: None },
+            &UpdateSavedView {
+                name: Some("Hijacked".into()),
+                config: None,
+                is_default: None,
+            },
         )
         .unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
@@ -438,7 +452,10 @@ mod tests {
         assert!(second.is_default);
 
         let refreshed_first = get_view_row(&conn, first.id).unwrap();
-        assert!(!refreshed_first.is_default, "creating a new default must clear the old one");
+        assert!(
+            !refreshed_first.is_default,
+            "creating a new default must clear the old one"
+        );
 
         let defaults: i64 = conn
             .query_row(
@@ -466,7 +483,11 @@ mod tests {
             b.id,
             project,
             alice,
-            &UpdateSavedView { name: None, config: None, is_default: Some(true) },
+            &UpdateSavedView {
+                name: None,
+                config: None,
+                is_default: Some(true),
+            },
         )
         .unwrap();
         assert!(promoted.is_default);
@@ -483,11 +504,16 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
 
-        let alice_default = create_view(&conn, project, alice, &view_input("Alice default", true)).unwrap();
-        let bob_default = create_view(&conn, project, bob, &view_input("Bob default", true)).unwrap();
+        let alice_default =
+            create_view(&conn, project, alice, &view_input("Alice default", true)).unwrap();
+        let bob_default =
+            create_view(&conn, project, bob, &view_input("Bob default", true)).unwrap();
 
         assert!(alice_default.is_default);
-        assert!(bob_default.is_default, "bob's default must not be cleared by alice's");
+        assert!(
+            bob_default.is_default,
+            "bob's default must not be cleared by alice's"
+        );
     }
 
     // ── Validation ──────────────────────────────────────────────
@@ -503,7 +529,11 @@ mod tests {
             &conn,
             project,
             alice,
-            &CreateSavedView { name: "Bad".into(), config: "{not json".into(), is_default: false },
+            &CreateSavedView {
+                name: "Bad".into(),
+                config: "{not json".into(),
+                is_default: false,
+            },
         )
         .unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got {err:?}");
@@ -521,7 +551,11 @@ mod tests {
             &conn,
             project,
             alice,
-            &CreateSavedView { name: "Too big".into(), config: huge, is_default: false },
+            &CreateSavedView {
+                name: "Too big".into(),
+                config: huge,
+                is_default: false,
+            },
         )
         .unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got {err:?}");
@@ -553,9 +587,16 @@ mod tests {
                 &conn,
                 project,
                 alice,
-                &CreateSavedView { name, config: config.into(), is_default: false },
+                &CreateSavedView {
+                    name,
+                    config: config.into(),
+                    is_default: false,
+                },
             );
-            assert!(result.is_ok(), "expected {config} to be accepted, got {result:?}");
+            assert!(
+                result.is_ok(),
+                "expected {config} to be accepted, got {result:?}"
+            );
         }
     }
 
@@ -603,7 +644,11 @@ mod tests {
             999999,
             project,
             alice,
-            &UpdateSavedView { name: Some("x".into()), config: None, is_default: None },
+            &UpdateSavedView {
+                name: Some("x".into()),
+                config: None,
+                is_default: None,
+            },
         )
         .unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
@@ -620,14 +665,22 @@ mod tests {
         let conn = pool.write().unwrap();
         let project = seed_project(&conn, "CDP");
         let alice = seed_user(&conn, "alice");
-        create_view(&conn, project, alice, &view_input("Gone with project", false)).unwrap();
+        create_view(
+            &conn,
+            project,
+            alice,
+            &view_input("Gone with project", false),
+        )
+        .unwrap();
 
         queries::delete_project(&conn, project).unwrap();
 
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM saved_views WHERE project_id = ?1", params![project], |row| {
-                row.get(0)
-            })
+            .query_row(
+                "SELECT COUNT(*) FROM saved_views WHERE project_id = ?1",
+                params![project],
+                |row| row.get(0),
+            )
             .unwrap();
         assert_eq!(count, 0);
     }
@@ -640,10 +693,15 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         create_view(&conn, project, alice, &view_input("Gone with user", false)).unwrap();
 
-        conn.execute("DELETE FROM users WHERE id = ?1", params![alice]).unwrap();
+        conn.execute("DELETE FROM users WHERE id = ?1", params![alice])
+            .unwrap();
 
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM saved_views WHERE user_id = ?1", params![alice], |row| row.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM saved_views WHERE user_id = ?1",
+                params![alice],
+                |row| row.get(0),
+            )
             .unwrap();
         assert_eq!(count, 0);
     }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -252,7 +252,10 @@ fn set_owner_only(path: &Path) -> std::io::Result<()> {
 }
 
 /// Set 0600 on an already-open handle, so no pathname is resolved again.
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn set_owner_only_file(file: &File) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -267,7 +270,10 @@ fn set_owner_only_file(file: &File) -> std::io::Result<()> {
 }
 
 /// Set 0700 permissions on a directory (owner-only) on Unix. No-op elsewhere.
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn set_owner_only_dir(path: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -283,7 +289,10 @@ fn set_owner_only_dir(path: &Path) -> std::io::Result<()> {
 
 /// fsync a directory so a rename into it is durable. Unix only: Windows has no
 /// directory handle to sync, and its rename ordering does not need one.
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn sync_dir(path: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -312,9 +321,9 @@ impl TempFile {
             use std::os::unix::fs::OpenOptionsExt;
             options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
         }
-        let file = options
-            .open(&path)
-            .map_err(|error| LificError::Internal(format!("create secure staging file: {error}")))?;
+        let file = options.open(&path).map_err(|error| {
+            LificError::Internal(format!("create secure staging file: {error}"))
+        })?;
         Ok(Self { file, path })
     }
 
@@ -673,9 +682,10 @@ impl VerifiedBlob {
         let digest = hashing.hex_digest();
         // The header already promised `size` bytes; publishing an archive whose
         // body is shorter would leave every later entry misaligned.
-        let written = self.file.stream_position().map_err(|e| {
-            LificError::Internal(format!("measure attachment {expected_sha}: {e}"))
-        })?;
+        let written = self
+            .file
+            .stream_position()
+            .map_err(|e| LificError::Internal(format!("measure attachment {expected_sha}: {e}")))?;
         if written != size {
             return Err(LificError::Internal(format!(
                 "attachment {expected_sha} changed size while being archived \
@@ -723,7 +733,10 @@ impl<R: Read> Read for HashingReader<R> {
 /// Refuse to publish a dump onto a destination another user could have
 /// prepared: a symlink or hard link at the target, a symlinked parent, or a
 /// group/world-writable parent without the sticky bit.
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn validate_dump_destination(out_path: &Path) -> Result<(), LificError> {
     #[cfg(unix)]
     {
@@ -1025,7 +1038,9 @@ fn validate_attachment_schema(conn: &rusqlite::Connection) -> Result<(), LificEr
     let invalid_mime_sha = "b".repeat(64);
     let invalid_size_sha = "c".repeat(64);
     insert(&valid_sha, "text/plain", 0).map_err(|e| {
-        LificError::BadRequest(format!("staged attachment schema rejects valid metadata: {e}"))
+        LificError::BadRequest(format!(
+            "staged attachment schema rejects valid metadata: {e}"
+        ))
     })?;
 
     for (sha256, mime, size_bytes) in [
@@ -1269,8 +1284,8 @@ fn validate_staged_database(
     for entry in std::fs::read_dir(&attachments_dir)
         .map_err(|e| LificError::BadRequest(format!("read staged attachments: {e}")))?
     {
-        let entry = entry
-            .map_err(|e| LificError::BadRequest(format!("read staged attachment: {e}")))?;
+        let entry =
+            entry.map_err(|e| LificError::BadRequest(format!("read staged attachment: {e}")))?;
         let path = entry.path();
         let metadata = std::fs::symlink_metadata(&path).map_err(|e| {
             LificError::BadRequest(format!("inspect staged attachment {}: {e}", path.display()))
@@ -1586,9 +1601,9 @@ pub fn run_restore_with(
                 )?;
                 set_owner_only(&path)
                     .map_err(|e| LificError::Internal(format!("chmod staged attachment: {e}")))?;
-                output.sync_all().map_err(|e| {
-                    LificError::Internal(format!("sync staged attachment: {e}"))
-                })?;
+                output
+                    .sync_all()
+                    .map_err(|e| LificError::Internal(format!("sync staged attachment: {e}")))?;
                 attachment_count += 1;
             } else {
                 return Err(LificError::BadRequest(format!(
@@ -1900,21 +1915,9 @@ mod tests {
         fs::create_dir_all(&att).unwrap();
         let first_sha = crate::storage::AttachmentStore::hash_bytes(b"blob one");
         let second_sha = crate::storage::AttachmentStore::hash_bytes(b"second blob bytes");
-        fs::write(
-            att.join(&first_sha),
-            b"blob one",
-        )
-        .unwrap();
-        fs::write(
-            att.join(&second_sha),
-            b"second blob bytes",
-        )
-        .unwrap();
-        fs::write(
-            att.join(format!("{second_sha}.tmp")),
-            b"partial write",
-        )
-        .unwrap();
+        fs::write(att.join(&first_sha), b"blob one").unwrap();
+        fs::write(att.join(&second_sha), b"second blob bytes").unwrap();
+        fs::write(att.join(format!("{second_sha}.tmp")), b"partial write").unwrap();
         (tmp, db_path)
     }
 
@@ -2025,7 +2028,10 @@ mod tests {
         let out = dir.join("out.tar.gz");
         write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap();
         assert!(out.exists());
-        assert!(!has_dump_staging(dir), "staging is removed on the happy path");
+        assert!(
+            !has_dump_staging(dir),
+            "staging is removed on the happy path"
+        );
     }
 
     #[cfg(unix)]
@@ -2041,12 +2047,14 @@ mod tests {
         fs::hard_link(&outside, dir.join("attachments").join("c".repeat(64))).unwrap();
 
         let out = dir.join("late.tar.gz");
-        let error =
-            write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap_err();
+        let error = write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap_err();
 
         assert!(error.to_string().contains("hard-linked"), "got {error}");
         assert!(!out.exists(), "a failed dump publishes nothing");
-        assert!(!has_dump_staging(dir), "staging must not survive the failure");
+        assert!(
+            !has_dump_staging(dir),
+            "staging must not survive the failure"
+        );
     }
 
     #[cfg(unix)]
@@ -2154,8 +2162,7 @@ mod tests {
         fs::remove_file(&entry).unwrap();
         fs::hard_link(&outside, &entry).unwrap();
         let out = dir.join("hardlink.tar.gz");
-        let error =
-            write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap_err();
+        let error = write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap_err();
         assert!(error.to_string().contains("hard-linked"), "got {error}");
     }
 
@@ -2186,8 +2193,7 @@ mod tests {
         // restore, bytes intact.
         let (src_tmp, src_db) = seed_data_dir("hash_round_trip");
         let archive = src_tmp.path().join("backup.tar.gz");
-        let manifest =
-            write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
+        let manifest = write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
         assert_eq!(manifest.attachment_count, 2);
 
         let dst = temp_dir("hash_round_trip_dst");
@@ -2228,8 +2234,7 @@ mod tests {
         let dumper = std::thread::spawn({
             let out = out.clone();
             move || {
-                let result =
-                    write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out);
+                let result = write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out);
                 done_tx.send(()).unwrap();
                 result
             }
@@ -2422,9 +2427,11 @@ mod tests {
 
         // Blob bytes identical.
         assert_eq!(
-            fs::read(dst_dir.join("attachments").join(
-                crate::storage::AttachmentStore::hash_bytes(b"blob one"),
-            ))
+            fs::read(
+                dst_dir
+                    .join("attachments")
+                    .join(crate::storage::AttachmentStore::hash_bytes(b"blob one"),)
+            )
             .unwrap(),
             b"blob one"
         );
@@ -3085,7 +3092,9 @@ mod tests {
 
         assert!(matches!(error, LificError::Conflict(_)), "got {error:?}");
         assert!(
-            error.to_string().contains("attachment backup already exists"),
+            error
+                .to_string()
+                .contains("attachment backup already exists"),
             "the original cause must survive the rollback: {error}"
         );
         assert!(
@@ -3100,9 +3109,14 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(live, 1, "and it must be the user's database, not the dump's");
+        assert_eq!(
+            live, 1,
+            "and it must be the user's database, not the dump's"
+        );
         assert!(
-            !root.join(format!("{}.pre-restore-clash", ARCHIVE_DB_NAME)).exists(),
+            !root
+                .join(format!("{}.pre-restore-clash", ARCHIVE_DB_NAME))
+                .exists(),
             "nothing may be stranded under the pre-restore name"
         );
         assert_eq!(
@@ -3200,15 +3214,17 @@ mod tests {
         // exceeds.
         let (src_dir_tmp, src_db) = seed_data_dir("allow_large_src");
         let archive = src_dir_tmp.path().join("backup.tar.gz");
-        let manifest =
-            write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
+        let manifest = write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
         let tight = RestoreLimits {
             max_db_bytes: manifest.db_size_bytes - 1,
             ..RestoreLimits::default()
         };
 
         let error = inspect_archive(&archive, &tight).unwrap_err();
-        assert!(error.to_string().contains("exceeds restore limit"), "got {error}");
+        assert!(
+            error.to_string().contains("exceeds restore limit"),
+            "got {error}"
+        );
         inspect_archive(&archive, &RestoreLimits::trusted())
             .expect("--allow-large accepts a trusted oversized archive");
 
@@ -3311,7 +3327,8 @@ mod tests {
             attachment_bytes: 4,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("content address"));
     }
 
@@ -3347,7 +3364,8 @@ mod tests {
             attachment_bytes: 4,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("MIME image/png"));
     }
 
@@ -3385,10 +3403,13 @@ mod tests {
             attachment_bytes: 4,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("invalid content address, MIME, or size"));
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("invalid content address, MIME, or size")
+        );
     }
 
     #[test]
@@ -3413,7 +3434,8 @@ mod tests {
             attachment_bytes: 4,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("content address"));
     }
 
@@ -3444,7 +3466,8 @@ mod tests {
             attachment_bytes: 0,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("attachments table"));
     }
 
@@ -3478,7 +3501,8 @@ mod tests {
             attachment_count: 1,
             attachment_bytes: 4,
         };
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("missing attachment"));
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,9 +76,9 @@ impl LificError {
                 ),
                 current: Box::new(current),
             },
-            Err(error) => LificError::Internal(format!(
-                "failed to serialize conflicting {entity}: {error}"
-            )),
+            Err(error) => {
+                LificError::Internal(format!("failed to serialize conflicting {entity}: {error}"))
+            }
         }
     }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -540,11 +540,15 @@ fn export_project_snapshot(
     )?;
     let project = bounded_project(conn, project_id)?;
     let issue_ids = conn
-        .prepare_cached("SELECT id FROM issues WHERE project_id = ?1 AND deleted_at IS NULL ORDER BY id")?
+        .prepare_cached(
+            "SELECT id FROM issues WHERE project_id = ?1 AND deleted_at IS NULL ORDER BY id",
+        )?
         .query_map([project.id], |row| row.get(0))?
         .collect::<Result<Vec<i64>, _>>()?;
     let page_ids = conn
-        .prepare_cached("SELECT id FROM pages WHERE project_id = ?1 AND deleted_at IS NULL ORDER BY id")?
+        .prepare_cached(
+            "SELECT id FROM pages WHERE project_id = ?1 AND deleted_at IS NULL ORDER BY id",
+        )?
         .query_map([project.id], |row| row.get(0))?
         .collect::<Result<Vec<i64>, _>>()?;
 
@@ -1183,14 +1187,18 @@ mod tests {
         let bundle = export_project(&conn, "EXP").unwrap();
         assert_eq!(bundle.root, "EXP");
         assert_eq!(bundle.files.len(), 2);
-        assert!(bundle
-            .files
-            .iter()
-            .any(|file| file.path.starts_with("EXP/issues/exp-1-ship-export")));
-        assert!(bundle
-            .files
-            .iter()
-            .any(|file| file.path == "EXP/pages/docs/guides/exp-doc-1-getting-started.md"));
+        assert!(
+            bundle
+                .files
+                .iter()
+                .any(|file| file.path.starts_with("EXP/issues/exp-1-ship-export"))
+        );
+        assert!(
+            bundle
+                .files
+                .iter()
+                .any(|file| file.path == "EXP/pages/docs/guides/exp-doc-1-getting-started.md")
+        );
         let issue_file = bundle
             .files
             .iter()
@@ -1560,9 +1568,8 @@ mod tests {
             .unwrap();
         }
 
-        let error =
-            ensure_project_preflight(&conn, project.id, 32, MAX_EXPORT_PROJECT_COMMENTS)
-                .unwrap_err();
+        let error = ensure_project_preflight(&conn, project.id, 32, MAX_EXPORT_PROJECT_COMMENTS)
+            .unwrap_err();
         assert!(error.to_string().contains("project source exceeds"));
     }
 
@@ -1619,13 +1626,8 @@ mod tests {
             }
         }
 
-        let error = ensure_project_preflight(
-            &conn,
-            project.id,
-            MAX_EXPORT_TOTAL_BYTES as i64,
-            501,
-        )
-        .unwrap_err();
+        let error = ensure_project_preflight(&conn, project.id, MAX_EXPORT_TOTAL_BYTES as i64, 501)
+            .unwrap_err();
         assert!(error.to_string().contains("too many comments"));
     }
 

--- a/src/import/github.rs
+++ b/src/import/github.rs
@@ -790,7 +790,11 @@ mod tests {
         ));
 
         let error = collect_with(&fetcher).unwrap_err();
-        assert_eq!(error.limit(), None, "a network drop is not a resource limit");
+        assert_eq!(
+            error.limit(),
+            None,
+            "a network drop is not a resource limit"
+        );
         assert!(matches!(error, GithubImportError::Upstream(_)));
     }
 

--- a/src/import/jira.rs
+++ b/src/import/jira.rs
@@ -420,8 +420,10 @@ pub fn map_issue(
 pub trait JiraFetcher {
     /// Fetch one page of issues. `next_token` is the opaque page token (`None`
     /// for the first page). Returns `(issues, next_token)`.
-    fn fetch_page(&self, next_token: Option<&str>)
-    -> Result<(Vec<JiraIssue>, Option<String>), String>;
+    fn fetch_page(
+        &self,
+        next_token: Option<&str>,
+    ) -> Result<(Vec<JiraIssue>, Option<String>), String>;
 
     /// Fetch all comments for one issue key.
     fn fetch_comments(&self, key: &str) -> Result<Vec<JiraComment>, String>;
@@ -552,7 +554,10 @@ impl JiraFetcher for LiveJira {
             .query(&[
                 ("jql", jql.as_str()),
                 ("maxResults", "50"),
-                ("fields", "summary,description,status,priority,labels,assignee,issuetype"),
+                (
+                    "fields",
+                    "summary,description,status,priority,labels,assignee,issuetype",
+                ),
             ]);
         if let Some(t) = next_token {
             req = req.query(&[("nextPageToken", t)]);

--- a/src/import/linear.rs
+++ b/src/import/linear.rs
@@ -182,11 +182,12 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
     }
 }
 
-/// Abstraction over Linear's GraphQL endpoint for testability. Returns one page
-/// of issues plus the next cursor (`None` when exhausted).
+/// One page of Linear issues plus the next cursor (`None` when exhausted).
+pub type LinearPage = (Vec<LinearIssue>, Option<String>);
+
+/// Abstraction over Linear's GraphQL endpoint for testability.
 pub trait LinearFetcher {
-    fn fetch_page(&self, after: Option<&str>)
-    -> Result<(Vec<LinearIssue>, Option<String>), String>;
+    fn fetch_page(&self, after: Option<&str>) -> Result<LinearPage, String>;
 }
 
 /// Walk all cursor pages and normalize. Assignee/estimate are counted as
@@ -302,10 +303,7 @@ impl LiveLinear {
 }
 
 impl LinearFetcher for LiveLinear {
-    fn fetch_page(
-        &self,
-        after: Option<&str>,
-    ) -> Result<(Vec<LinearIssue>, Option<String>), String> {
+    fn fetch_page(&self, after: Option<&str>) -> Result<LinearPage, String> {
         let body = serde_json::json!({
             "query": ISSUES_QUERY,
             "variables": { "team": self.team, "after": after },
@@ -416,13 +414,10 @@ mod tests {
     }
 
     struct FakeLinear {
-        pages: Vec<(Vec<LinearIssue>, Option<String>)>,
+        pages: Vec<LinearPage>,
     }
     impl LinearFetcher for FakeLinear {
-        fn fetch_page(
-            &self,
-            after: Option<&str>,
-        ) -> Result<(Vec<LinearIssue>, Option<String>), String> {
+        fn fetch_page(&self, after: Option<&str>) -> Result<LinearPage, String> {
             // Page 0 has after=None; subsequent pages keyed by cursor value.
             let idx = match after {
                 None => 0,

--- a/src/import/linear.rs
+++ b/src/import/linear.rs
@@ -185,7 +185,8 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
 /// Abstraction over Linear's GraphQL endpoint for testability. Returns one page
 /// of issues plus the next cursor (`None` when exhausted).
 pub trait LinearFetcher {
-    fn fetch_page(&self, after: Option<&str>) -> Result<(Vec<LinearIssue>, Option<String>), String>;
+    fn fetch_page(&self, after: Option<&str>)
+    -> Result<(Vec<LinearIssue>, Option<String>), String>;
 }
 
 /// Walk all cursor pages and normalize. Assignee/estimate are counted as
@@ -301,7 +302,10 @@ impl LiveLinear {
 }
 
 impl LinearFetcher for LiveLinear {
-    fn fetch_page(&self, after: Option<&str>) -> Result<(Vec<LinearIssue>, Option<String>), String> {
+    fn fetch_page(
+        &self,
+        after: Option<&str>,
+    ) -> Result<(Vec<LinearIssue>, Option<String>), String> {
         let body = serde_json::json!({
             "query": ISSUES_QUERY,
             "variables": { "team": self.team, "after": after },
@@ -433,10 +437,7 @@ mod tests {
         let issues = fixture();
         let (a, b) = issues.split_at(1);
         let fetcher = FakeLinear {
-            pages: vec![
-                (a.to_vec(), Some("1".into())),
-                (b.to_vec(), None),
-            ],
+            pages: vec![(a.to_vec(), Some("1".into())), (b.to_vec(), None)],
         };
         let fetched = collect(&fetcher, &LinearStatusMap::default()).unwrap();
         assert_eq!(fetched.issues.len(), issues.len());

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -212,10 +212,7 @@ pub fn ensure_label(
     if queries::resolve_label_name(conn, project_id, &label.name).is_ok() {
         return Ok(false);
     }
-    let color = label
-        .color
-        .clone()
-        .unwrap_or_else(|| "#6B7280".to_string());
+    let color = label.color.clone().unwrap_or_else(|| "#6B7280".to_string());
     queries::create_label(
         conn,
         &CreateLabel {
@@ -322,7 +319,8 @@ pub fn run_import(
         // once across the whole batch even if several issues carry it and it
         // doesn't already exist.
         let conn = pool.read()?;
-        let mut planned_labels: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut planned_labels: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         for issue in &fetched.issues {
             if source_exists(&conn, &issue.source)? {
                 summary.issues_skipped_existing += 1;
@@ -629,9 +627,11 @@ mod tests {
         let deleted_id = {
             let conn = pool.write().unwrap();
             let id: i64 = conn
-                .query_row("SELECT id FROM issues WHERE source = 'github:o/n#1'", [], |r| {
-                    r.get(0)
-                })
+                .query_row(
+                    "SELECT id FROM issues WHERE source = 'github:o/n#1'",
+                    [],
+                    |r| r.get(0),
+                )
                 .unwrap();
             crate::db::queries::delete_issue(&conn, id).unwrap();
             id

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,10 @@ fn write_private_config(path: &std::path::Path, contents: &str) -> std::io::Resu
 /// `sync_all` persists its bytes; the name that reaches them lives in the
 /// parent directory and survives a crash only once that is synced too.
 /// Unix only: Windows exposes no directory handle to sync.
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn sync_parent_dir(_dir: &std::path::Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -554,9 +554,9 @@ mod tests {
         use crate::error::LificError;
 
         assert_eq!(
-            sanitize_error(LificError::Database(
-                rusqlite::Error::InvalidColumnName("secret_column".into())
-            )),
+            sanitize_error(LificError::Database(rusqlite::Error::InvalidColumnName(
+                "secret_column".into()
+            ))),
             "internal server error"
         );
         assert_eq!(
@@ -574,7 +574,9 @@ mod tests {
                 "Bad request: invalid status 'nope'",
             ),
             (
-                LificError::Forbidden("requires at least 'maintainer' access to this project".into()),
+                LificError::Forbidden(
+                    "requires at least 'maintainer' access to this project".into(),
+                ),
                 "Forbidden: requires at least 'maintainer' access to this project",
             ),
             (

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -208,9 +208,7 @@ pub struct CreatePageInput {
     pub folder: Option<String>,
     #[schemars(description = "Status: draft, active, complete, archived")]
     pub status: Option<String>,
-    #[schemars(
-        description = "Label names to attach (project-scoped; ignored on workspace pages)"
-    )]
+    #[schemars(description = "Label names to attach (project-scoped; ignored on workspace pages)")]
     pub labels: Option<Vec<String>>,
 }
 
@@ -282,9 +280,13 @@ pub struct DeleteInput {
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ListResourcesInput {
-    #[schemars(description = "Resource type: project, module, label, folder, page, issue, or plan")]
+    #[schemars(
+        description = "Resource type: project, module, label, folder, page, issue, or plan"
+    )]
     pub resource_type: String,
-    #[schemars(description = "Project ID (required for issues, plans, modules, labels, and folders; optional for pages and projects)")]
+    #[schemars(
+        description = "Project ID (required for issues, plans, modules, labels, and folders; optional for pages and projects)"
+    )]
     pub project: Option<String>,
     #[schemars(description = "Folder name (for pages)")]
     pub folder: Option<String>,
@@ -300,7 +302,9 @@ pub struct ListResourcesInput {
     pub order_by: Option<String>,
     #[schemars(description = "Sort direction (for page lists): asc (default) or desc")]
     pub order: Option<String>,
-    #[schemars(description = "Max results (plans default to 50 and cap at 500; issues and pages default to 100; other lists ignore this field)")]
+    #[schemars(
+        description = "Max results (plans default to 50 and cap at 500; issues and pages default to 100; other lists ignore this field)"
+    )]
     pub limit: Option<i64>,
     #[schemars(description = "Zero-indexed offset for issue, page, or plan paging")]
     pub offset: Option<i64>,
@@ -340,7 +344,9 @@ pub struct ManageResourceInput {
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct AddCommentInput {
-    #[schemars(description = "Issue ID (e.g. LIF-1), project page ID (e.g. LIF-DOC-1), or workspace page ID (e.g. DOC-1)")]
+    #[schemars(
+        description = "Issue ID (e.g. LIF-1), project page ID (e.g. LIF-DOC-1), or workspace page ID (e.g. DOC-1)"
+    )]
     pub identifier: String,
     #[schemars(description = "Comment content (markdown)")]
     pub content: String,
@@ -348,7 +354,9 @@ pub struct AddCommentInput {
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ListCommentsInput {
-    #[schemars(description = "Issue ID (e.g. LIF-1), project page ID (e.g. LIF-DOC-1), or workspace page ID (e.g. DOC-1)")]
+    #[schemars(
+        description = "Issue ID (e.g. LIF-1), project page ID (e.g. LIF-DOC-1), or workspace page ID (e.g. DOC-1)"
+    )]
     pub identifier: String,
     #[schemars(description = "Filter to comments by this author username")]
     pub author: Option<String>,
@@ -470,7 +478,9 @@ pub struct UpdatePlanStepInput {
     pub move_position: Option<i64>,
     #[schemars(description = "Delete the step and its subtree")]
     pub delete: Option<bool>,
-    #[schemars(description = "Return the full re-rendered tree instead of the delta (default false)")]
+    #[schemars(
+        description = "Return the full re-rendered tree instead of the delta (default false)"
+    )]
     pub echo_tree: Option<bool>,
 }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -10,12 +10,12 @@ use rmcp::{handler::server::wrapper::Parameters, tool, tool_router};
 
 use crate::{
     authz::filter_visible,
-    db::{models, queries, DbPool},
+    db::{DbPool, models, queries},
     links::{IssueLinkContext, MarkdownReference},
 };
 
 use super::schemas::*;
-use super::{current_issue_link_context, sanitize_error, LificMcp};
+use super::{LificMcp, current_issue_link_context, sanitize_error};
 
 /// Self-onboarding nudge (LIF-257): shown by cold read tools when the DB has
 /// **zero** projects, so the first agent connecting to a fresh install learns
@@ -1963,22 +1963,14 @@ impl LificMcp {
         .map_err(|error| format!("export worker failed: {error}"))??;
 
         match kind {
-            Kind::Page => Ok(bundle
-                .files
-                .into_iter()
-                .next()
-                .map_or_else(
-                    || "Error: page export produced no files".into(),
-                    |file| file.content,
-                )),
-            Kind::Issue => Ok(bundle
-                .files
-                .into_iter()
-                .next()
-                .map_or_else(
-                    || "Error: issue export produced no files".into(),
-                    |file| file.content,
-                )),
+            Kind::Page => Ok(bundle.files.into_iter().next().map_or_else(
+                || "Error: page export produced no files".into(),
+                |file| file.content,
+            )),
+            Kind::Issue => Ok(bundle.files.into_iter().next().map_or_else(
+                || "Error: issue export produced no files".into(),
+                |file| file.content,
+            )),
             Kind::Project => Ok(render_response(|output| {
                 writeln!(output, "{} exported file(s):", bundle.files.len())?;
                 bundle
@@ -3264,7 +3256,11 @@ impl LificMcp {
                 let lead_user_id = super::current_auth_user().and_then(|u| {
                     self.read(|conn| {
                         Ok(conn
-                            .query_row("SELECT 1 FROM users WHERE id = ?1", rusqlite::params![u.id], |_| Ok(()))
+                            .query_row(
+                                "SELECT 1 FROM users WHERE id = ?1",
+                                rusqlite::params![u.id],
+                                |_| Ok(()),
+                            )
                             .is_ok())
                     })
                     .ok()
@@ -3407,10 +3403,7 @@ impl LificMcp {
                         &models::CreateLabel {
                             project_id: pid,
                             name: name.clone(),
-                            color: input
-                                .color
-                                .clone()
-                                .unwrap_or_else(|| "#6B7280".into()),
+                            color: input.color.clone().unwrap_or_else(|| "#6B7280".into()),
                         },
                     )
                 })?;
@@ -6522,9 +6515,11 @@ mod tests {
 
         let deleted_at: Option<String> = m
             .read(|conn| {
-                Ok(conn.query_row("SELECT deleted_at FROM pages WHERE sequence = 1", [], |row| {
-                    row.get(0)
-                })?)
+                Ok(conn.query_row(
+                    "SELECT deleted_at FROM pages WHERE sequence = 1",
+                    [],
+                    |row| row.get(0),
+                )?)
             })
             .unwrap();
         assert!(deleted_at.is_some(), "the row survives for delta sync");
@@ -7843,7 +7838,9 @@ mod tests {
         // 1 and 2 fell off the front, 3 leads, and the newest closes it.
         assert!(!result.contains("comment number 1\n"), "got: {result}");
         assert!(!result.contains("comment number 2\n"), "got: {result}");
-        let first = result.find("comment number 3\n").expect("oldest of the window");
+        let first = result
+            .find("comment number 3\n")
+            .expect("oldest of the window");
         let last = result
             .find(&format!("comment number {total}\n"))
             .expect("newest comment");
@@ -7898,7 +7895,10 @@ mod tests {
             .find(&format!("comment number {}\n", total - 2))
             .unwrap();
         let newest = recent.find(&format!("comment number {total}\n")).unwrap();
-        assert!(oldest < newest, "the trail must read oldest first: {recent}");
+        assert!(
+            oldest < newest,
+            "the trail must read oldest first: {recent}"
+        );
     }
 
     #[test]
@@ -9934,7 +9934,9 @@ mod tests {
         );
         assert_eq!(
             deleted,
-            format!("Comment #{comment_id} deleted from [PRJ-1](https://tracker.example/PRJ/issues/PRJ-1)")
+            format!(
+                "Comment #{comment_id} deleted from [PRJ-1](https://tracker.example/PRJ/issues/PRJ-1)"
+            )
         );
     }
 
@@ -10645,10 +10647,7 @@ mod tests {
             got.contains("    Second line survives too."),
             "multi-line descriptions keep tree indentation: {got}"
         );
-        assert!(
-            !got.contains('…'),
-            "no ellipsis in the rehydrate: {got}"
-        );
+        assert!(!got.contains('…'), "no ellipsis in the rehydrate: {got}");
     }
 
     #[tokio::test]
@@ -11631,7 +11630,12 @@ mod tests {
             offset: None,
             limit: None,
         }));
-        assert!(result.content.iter().all(|content| content.as_image().is_none()));
+        assert!(
+            result
+                .content
+                .iter()
+                .all(|content| content.as_image().is_none())
+        );
         assert!(text_of(&result).contains("Binary, download at"));
     }
 
@@ -12487,7 +12491,12 @@ mod authz_gating_tests {
         });
         assert!(created.starts_with("Created"), "got: {created}");
 
-        let [edit_comment_id, delete_comment_id, foreign_edit_id, foreign_delete_id] = [
+        let [
+            edit_comment_id,
+            delete_comment_id,
+            foreign_edit_id,
+            foreign_delete_id,
+        ] = [
             (&viewer, "Keep this comment"),
             (&viewer, "Keep this one too"),
             (&lead, "Do not disclose ownership"),

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -35,8 +35,7 @@ const MAX_DYNAMIC_CLIENT_STORAGE_BYTES: i64 = 4 * 1024 * 1024;
 const MAX_DEVICE_CODE_ROWS: i64 = 1024;
 
 /// Per-process CSRF secret, generated randomly on startup.
-static CSRF_SECRET: std::sync::LazyLock<[u8; 32]> =
-    std::sync::LazyLock::new(rand::random);
+static CSRF_SECRET: std::sync::LazyLock<[u8; 32]> = std::sync::LazyLock::new(rand::random);
 
 /// Generate a CSRF token bound to the approving session: `timestamp.hmac(ts || binding)`.
 ///
@@ -170,10 +169,7 @@ fn device_confirmation_token(session: &str, user_code: &str) -> String {
 }
 
 fn validate_device_confirmation_token(token: &str, session: &str, user_code: &str) -> bool {
-    validate_csrf_token(
-        token,
-        &format!("device-confirmation:{session}:{user_code}"),
-    )
+    validate_csrf_token(token, &format!("device-confirmation:{session}:{user_code}"))
 }
 
 #[derive(Clone)]
@@ -282,9 +278,7 @@ pub(crate) fn validate_redirect_uri(uri: &str) -> Result<(), &'static str> {
     }
     // Require some host after `://`.
     let rest = &after_scheme[3..];
-    let host_end = rest
-        .find(['/', '?', '#'])
-        .unwrap_or(rest.len());
+    let host_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     if rest[..host_end].is_empty() {
         return Err("redirect_uri must include a host");
     }
@@ -314,10 +308,7 @@ pub fn router(state: OAuthState) -> Router {
             "/oauth/authorize",
             get(authorize_page).post(authorize_approve),
         )
-        .route(
-            "/oauth/device_authorization",
-            post(device_authorization),
-        )
+        .route("/oauth/device_authorization", post(device_authorization))
         .route("/oauth/device", get(device_page).post(device_approve))
         .route("/oauth/token", post(token_exchange))
         .route("/oauth/revoke", post(revoke_token))
@@ -427,15 +418,19 @@ async fn register_client(
             })),
         )
             .into_response();
-        if retry > 0 && let Ok(v) = retry.to_string().parse() {
+        if retry > 0
+            && let Ok(v) = retry.to_string().parse()
+        {
             resp.headers_mut().insert("retry-after", v);
         }
         return resp;
     }
 
-    let device_only =
-        matches!(req.grant_types.as_deref(), Some([grant]) if grant == DEVICE_CODE_GRANT)
-        && req.response_types.as_deref().is_none_or(<[String]>::is_empty);
+    let device_only = matches!(req.grant_types.as_deref(), Some([grant]) if grant == DEVICE_CODE_GRANT)
+        && req
+            .response_types
+            .as_deref()
+            .is_none_or(<[String]>::is_empty);
     if req.redirect_uris.is_empty() && !device_only {
         return (
             StatusCode::BAD_REQUEST,
@@ -464,9 +459,7 @@ async fn register_client(
     }
 
     let client_name = req.client_name.unwrap_or_else(|| "MCP Client".into());
-    if client_name.len() > MAX_CLIENT_NAME_BYTES
-        || client_name.chars().any(|c| c.is_control())
-    {
+    if client_name.len() > MAX_CLIENT_NAME_BYTES || client_name.chars().any(|c| c.is_control()) {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -741,7 +734,10 @@ async fn authorize_page(
     let Some(client_name) = client_name else {
         return (
             StatusCode::BAD_REQUEST,
-            Html("<h1>Invalid OAuth client</h1><p>The client or redirect URI is not registered.</p>".to_string()),
+            Html(
+                "<h1>Invalid OAuth client</h1><p>The client or redirect URI is not registered.</p>"
+                    .to_string(),
+            ),
         )
             .into_response();
     };
@@ -1063,28 +1059,28 @@ async fn authorize_approve(
     // Validate the redirect_uri against the client's registered URIs
     let redirect_ok = validate_redirect_uri(&form.redirect_uri).is_ok()
         && if let Ok(conn) = oauth.db.read() {
-        let registered: Result<String, _> = conn.query_row(
-            "SELECT redirect_uris FROM oauth_clients WHERE client_id = ?1",
-            params![form.client_id],
-            |row| row.get(0),
-        );
-        match registered {
-            Ok(uris_json) => {
-                let uris: Vec<String> = serde_json::from_str(&uris_json).unwrap_or_default();
-                uris.iter().any(|u| u == &form.redirect_uri)
+            let registered: Result<String, _> = conn.query_row(
+                "SELECT redirect_uris FROM oauth_clients WHERE client_id = ?1",
+                params![form.client_id],
+                |row| row.get(0),
+            );
+            match registered {
+                Ok(uris_json) => {
+                    let uris: Vec<String> = serde_json::from_str(&uris_json).unwrap_or_default();
+                    uris.iter().any(|u| u == &form.redirect_uri)
+                }
+                Err(_) => false,
             }
-            Err(_) => false,
-        }
-    } else {
-        false
-    };
+        } else {
+            false
+        };
 
     if !redirect_ok {
         return (
             StatusCode::BAD_REQUEST,
             Html("Invalid client_id or redirect_uri does not match registered URIs.".to_string()),
         )
-        .into_response();
+            .into_response();
     }
 
     // Denial must never create an authorization code. The redirect was already
@@ -1369,18 +1365,17 @@ fn resolve_approval_bot(
 ) -> Result<i64, (StatusCode, String)> {
     let tool_text = match (tool, tool_custom) {
         // A specific known tool chosen from the pick-list.
-        (Some(id), _)
-            if !id.trim().is_empty() && id.trim() != CUSTOM_TOOL_OPTION =>
-        {
-            id.clone()
-        }
+        (Some(id), _) if !id.trim().is_empty() && id.trim() != CUSTOM_TOOL_OPTION => id.clone(),
         // "Custom tool…" chosen — the free-text name is required.
-        (Some(id), Some(name))
-            if id.trim() == CUSTOM_TOOL_OPTION && !name.trim().is_empty() =>
-        {
+        (Some(id), Some(name)) if id.trim() == CUSTOM_TOOL_OPTION && !name.trim().is_empty() => {
             name.clone()
         }
-        _ => return Err((StatusCode::BAD_REQUEST, "Pick which tool is connecting".into())),
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Pick which tool is connecting".into(),
+            ));
+        }
     };
     let (tool_id, display_name) = match resolve_tool(&tool_text) {
         Ok(v) => v,
@@ -1471,7 +1466,9 @@ async fn device_authorization(
             })),
         )
             .into_response();
-        if retry > 0 && let Ok(v) = retry.to_string().parse() {
+        if retry > 0
+            && let Ok(v) = retry.to_string().parse()
+        {
             resp.headers_mut().insert("retry-after", v);
         }
         return resp;
@@ -1546,7 +1543,6 @@ async fn device_authorization(
         }
     };
 
-
     // High-entropy device code — return raw once, store only its hash.
     let device_code = format!("{}{}", uuid_v4(), uuid_v4()).replace('-', "");
     let device_code_hash = sha256_hex(device_code.as_bytes());
@@ -1563,17 +1559,16 @@ async fn device_authorization(
         warn!(%error, "failed to clean up expired OAuth device codes");
         return (StatusCode::SERVICE_UNAVAILABLE, "database cleanup error").into_response();
     }
-    let device_count: i64 = match conn.query_row(
-        "SELECT COUNT(*) FROM oauth_device_codes",
-        [],
-        |row| row.get(0),
-    ) {
-        Ok(count) => count,
-        Err(error) => {
-            warn!(%error, "failed to inspect OAuth device-code storage");
-            return (StatusCode::SERVICE_UNAVAILABLE, "database error").into_response();
-        }
-    };
+    let device_count: i64 =
+        match conn.query_row("SELECT COUNT(*) FROM oauth_device_codes", [], |row| {
+            row.get(0)
+        }) {
+            Ok(count) => count,
+            Err(error) => {
+                warn!(%error, "failed to inspect OAuth device-code storage");
+                return (StatusCode::SERVICE_UNAVAILABLE, "database error").into_response();
+            }
+        };
     if device_count >= MAX_DEVICE_CODE_ROWS {
         warn!("OAuth device-code storage limit reached");
         return (
@@ -2257,7 +2252,11 @@ async fn token_exchange(
 /// `expired_token`) or, on approval, mints and returns an access token.
 fn device_token_exchange(state: &OAuthState, req: &TokenRequest) -> Response {
     let Some(device_code) = req.device_code.as_deref().filter(|c| !c.is_empty()) else {
-        return device_error(StatusCode::BAD_REQUEST, "invalid_request", Some("missing device_code"));
+        return device_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            Some("missing device_code"),
+        );
     };
     let device_code_hash = sha256_hex(device_code.as_bytes());
 
@@ -2541,12 +2540,10 @@ async fn revoke_token(
         .map(|s| s.trim().to_string());
 
     let is_authenticated = match &caller_token {
-        Some(t) if t.starts_with("lific_sess_") => {
-            match state.db.read() {
-                Ok(conn) => crate::db::queries::users::validate_session(&conn, t).is_ok(),
-                Err(_) => false,
-            }
-        }
+        Some(t) if t.starts_with("lific_sess_") => match state.db.read() {
+            Ok(conn) => crate::db::queries::users::validate_session(&conn, t).is_ok(),
+            Err(_) => false,
+        },
         Some(t) if t.starts_with("lific_at_") => authenticate_oauth_token(&state.db, t).is_some(),
         // LIF-208: default-deny unknown bearer shapes. The previous
         // `Some(_) => true` treated *any* other string (including arbitrary
@@ -2773,14 +2770,22 @@ pub fn resolve_oauth_credential(db: &DbPool, token: &str) -> Result<OAuthCredent
     let Some(bound_user_id) = row.bound_user_id else {
         return Ok(OAuthCredential::LegacyUnbound);
     };
-    let (Some(user_id), Some(username), Some(display_name), Some(is_admin), Some(is_active), Some(is_bot)) = (
+    let (
+        Some(user_id),
+        Some(username),
+        Some(display_name),
+        Some(is_admin),
+        Some(is_active),
+        Some(is_bot),
+    ) = (
         row.user_id,
         row.username,
         row.display_name,
         row.is_admin,
         row.is_active,
         row.is_bot,
-    ) else {
+    )
+    else {
         return Err(OAuthReject::DeadBinding);
     };
     debug_assert_eq!(user_id, bound_user_id);
@@ -2972,7 +2977,9 @@ mod tests {
     }
 
     fn test_code_challenge() -> String {
-        base64_url_encode(&Sha256::digest(b"test_verifier_abcdefghijklmnopqrstuvwxyz_0123456789"))
+        base64_url_encode(&Sha256::digest(
+            b"test_verifier_abcdefghijklmnopqrstuvwxyz_0123456789",
+        ))
     }
 
     // ── Authorization approval validates tokens ─────────────
@@ -3019,8 +3026,15 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let body = String::from_utf8(resp.into_body().collect().await.unwrap().to_bytes().to_vec())
-            .unwrap();
+        let body = String::from_utf8(
+            resp.into_body()
+                .collect()
+                .await
+                .unwrap()
+                .to_bytes()
+                .to_vec(),
+        )
+        .unwrap();
         assert!(body.contains("Test Client"));
         assert!(body.contains("MCP issue-tracker access"));
         assert!(body.contains("http://localhost/callback"));
@@ -3053,8 +3067,15 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-        let body = String::from_utf8(resp.into_body().collect().await.unwrap().to_bytes().to_vec())
-            .unwrap();
+        let body = String::from_utf8(
+            resp.into_body()
+                .collect()
+                .await
+                .unwrap()
+                .to_bytes()
+                .to_vec(),
+        )
+        .unwrap();
         assert!(
             body.contains("/#/login"),
             "signed-out consent must link to sign-in: {body}"
@@ -3072,7 +3093,12 @@ mod tests {
         );
         let resp = app
             .clone()
-            .oneshot(Request::builder().uri(bad_scope).body(axum::body::Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri(bad_scope)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -3081,7 +3107,12 @@ mod tests {
             "/oauth/authorize?client_id=unknown&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&response_type=code&scope=mcp&code_challenge={challenge}&code_challenge_method=S256"
         );
         let resp = app
-            .oneshot(Request::builder().uri(unknown).body(axum::body::Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri(unknown)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -3155,7 +3186,10 @@ mod tests {
         if !resp.status().is_redirection() {
             let status = resp.status();
             let body = resp.into_body().collect().await.unwrap().to_bytes();
-            panic!("deny status={status}, body={}", String::from_utf8_lossy(&body));
+            panic!(
+                "deny status={status}, body={}",
+                String::from_utf8_lossy(&body)
+            );
         }
         let location = resp.headers().get("location").unwrap().to_str().unwrap();
         assert!(location.starts_with("http://localhost/callback?error=access_denied"));
@@ -3212,7 +3246,12 @@ mod tests {
             urlencoding::encode("http://localhost/callback")
         );
         let resp = app
-            .oneshot(Request::builder().uri(uri).body(axum::body::Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -3432,7 +3471,10 @@ mod tests {
     #[test]
     fn csrf_rejects_tampered_and_malformed_signatures() {
         let t = generate_csrf_token("sess");
-        assert!(validate_csrf_token(&t, "sess"), "honest token must validate");
+        assert!(
+            validate_csrf_token(&t, "sess"),
+            "honest token must validate"
+        );
 
         let (ts, sig) = t.split_once('.').unwrap();
 
@@ -3809,11 +3851,7 @@ mod tests {
     // public_url is never overridden, and forwarded headers are ignored.
 
     /// GET a metadata path and parse the JSON body.
-    async fn get_metadata(
-        app: &Router,
-        path: &str,
-        headers: &[(&str, &str)],
-    ) -> serde_json::Value {
+    async fn get_metadata(app: &Router, path: &str, headers: &[(&str, &str)]) -> serde_json::Value {
         let mut builder = Request::builder().uri(path);
         for (name, value) in headers {
             builder = builder.header(*name, *value);
@@ -3839,10 +3877,7 @@ mod tests {
         )
         .await;
         assert_eq!(val["issuer"], "http://localhost:3456");
-        assert_eq!(
-            val["token_endpoint"],
-            "http://localhost:3456/oauth/token"
-        );
+        assert_eq!(val["token_endpoint"], "http://localhost:3456/oauth/token");
 
         let val = get_metadata(
             &app,
@@ -4587,11 +4622,13 @@ mod tests {
             )
         };
 
-        assert!(approve(app.clone())
-            .await
-            .unwrap()
-            .status()
-            .is_redirection());
+        assert!(
+            approve(app.clone())
+                .await
+                .unwrap()
+                .status()
+                .is_redirection()
+        );
         let first_id: i64 = {
             let conn = db.read().unwrap();
             conn.query_row(
@@ -4602,11 +4639,13 @@ mod tests {
             .unwrap()
         };
         // Re-approval of the same tool+owner must reuse the same bot.
-        assert!(approve(app.clone())
-            .await
-            .unwrap()
-            .status()
-            .is_redirection());
+        assert!(
+            approve(app.clone())
+                .await
+                .unwrap()
+                .status()
+                .is_redirection()
+        );
         let second_id: i64 = {
             let conn = db.read().unwrap();
             conn.query_row(
@@ -4941,10 +4980,7 @@ mod tests {
     }
 
     /// POST the device grant to /oauth/token and return (status, json).
-    async fn poll_device_token(
-        app: &Router,
-        device_code: &str,
-    ) -> (StatusCode, serde_json::Value) {
+    async fn poll_device_token(app: &Router, device_code: &str) -> (StatusCode, serde_json::Value) {
         let body = format!(
             "grant_type={}&device_code={}",
             urlencoding::encode("urn:ietf:params:oauth:grant-type:device_code"),
@@ -5225,7 +5261,12 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK, "approval should succeed");
         let confirmation_page = String::from_utf8(
-            resp.into_body().collect().await.unwrap().to_bytes().to_vec(),
+            resp.into_body()
+                .collect()
+                .await
+                .unwrap()
+                .to_bytes()
+                .to_vec(),
         )
         .unwrap();
         let status: String = db
@@ -5646,7 +5687,10 @@ mod tests {
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let html = String::from_utf8_lossy(&bytes);
         // Normalized + uppercased + dash-inserted into the input value.
-        assert!(html.contains("value=\"BCDF-GHJK\""), "prefill missing: {html}");
+        assert!(
+            html.contains("value=\"BCDF-GHJK\""),
+            "prefill missing: {html}"
+        );
     }
 
     /// Approval is two steps now, and the confirmation page is the one that

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -107,9 +107,9 @@ fn le_u32(bytes: &[u8], off: usize) -> Option<u32> {
 }
 
 fn le_u64(bytes: &[u8], off: usize) -> Option<u64> {
-    bytes.get(off..off + 8).map(|s| {
-        u64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]])
-    })
+    bytes
+        .get(off..off + 8)
+        .map(|s| u64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]))
 }
 
 /// Locate the end-of-central-directory record. It sits at the very end unless
@@ -132,7 +132,10 @@ fn central_directory_location(bytes: &[u8], eocd: usize) -> Option<(usize, usize
     let offset = le_u32(bytes, eocd + 16)? as u64;
 
     if entries != u64::from(u16::MAX) && offset != u64::from(u32::MAX) {
-        return Some((usize::try_from(offset).ok()?, usize::try_from(entries).ok()?));
+        return Some((
+            usize::try_from(offset).ok()?,
+            usize::try_from(entries).ok()?,
+        ));
     }
 
     // Zip64: a 20-byte locator immediately precedes the EOCD and points at
@@ -147,7 +150,10 @@ fn central_directory_location(bytes: &[u8], eocd: usize) -> Option<(usize, usize
     }
     let entries = le_u64(bytes, eocd64 + 32)?;
     let offset = le_u64(bytes, eocd64 + 48)?;
-    Some((usize::try_from(offset).ok()?, usize::try_from(entries).ok()?))
+    Some((
+        usize::try_from(offset).ok()?,
+        usize::try_from(entries).ok()?,
+    ))
 }
 
 /// Walk a zip's central directory and list what it contains.
@@ -418,7 +424,9 @@ mod tests {
 
     #[test]
     fn zip_preview_caps_entries_and_flags_truncation() {
-        let names: Vec<String> = (0..MAX_ZIP_ENTRIES + 5).map(|i| format!("f{i}.txt")).collect();
+        let names: Vec<String> = (0..MAX_ZIP_ENTRIES + 5)
+            .map(|i| format!("f{i}.txt"))
+            .collect();
         let files: Vec<(&str, &[u8])> = names.iter().map(|n| (n.as_str(), &b"x"[..])).collect();
         let zip = build_zip(&files);
 

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -156,8 +156,7 @@ pub fn client_ip(peer: IpAddr, headers: &HeaderMap, trusted_proxies: &[IpNetwork
     let client = if headers.contains_key("x-forwarded-for") {
         x_forwarded_for_client_ip(headers, trusted_proxies).unwrap_or(peer)
     } else {
-        header_ip(headers, "x-real-ip")
-            .map_or(peer, normalize_ip)
+        header_ip(headers, "x-real-ip").map_or(peer, normalize_ip)
     };
     normalize_ip(client).to_string()
 }
@@ -264,9 +263,7 @@ impl RateLimiter {
         let now = Instant::now();
         let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
 
-        if !state.attempts.contains_key(key)
-            && !Self::make_room(&mut state, now, self.window)
-        {
+        if !state.attempts.contains_key(key) && !Self::make_room(&mut state, now, self.window) {
             return None;
         }
 
@@ -387,9 +384,7 @@ impl<'a> Reservation<'a> {
         first: &str,
         second: &str,
     ) -> Result<Self, ReservationRejection> {
-        let first_id = limiter
-            .reserve(first)
-            .ok_or(ReservationRejection::First)?;
+        let first_id = limiter.reserve(first).ok_or(ReservationRejection::First)?;
         let Some(second_id) = limiter.reserve(second) else {
             limiter.refund(first, first_id);
             return Err(ReservationRejection::Second);
@@ -789,8 +784,7 @@ mod tests {
 
     #[test]
     fn trusted_proxy_chain_skips_trusted_intermediate_hops() {
-        let trusted = parse_trusted_proxies(&["127.0.0.0/8".into(), "10.0.0.0/8".into()])
-            .unwrap();
+        let trusted = parse_trusted_proxies(&["127.0.0.0/8".into(), "10.0.0.0/8".into()]).unwrap();
         let peer = "127.0.0.1".parse().unwrap();
         let mut h = HeaderMap::new();
         h.insert("x-forwarded-for", "203.0.113.9, 10.0.0.2".parse().unwrap());
@@ -799,8 +793,7 @@ mod tests {
 
     #[test]
     fn all_trusted_forwarded_for_hops_fall_back_to_peer() {
-        let trusted = parse_trusted_proxies(&["127.0.0.0/8".into(), "10.0.0.0/8".into()])
-            .unwrap();
+        let trusted = parse_trusted_proxies(&["127.0.0.0/8".into(), "10.0.0.0/8".into()]).unwrap();
         let peer = "127.0.0.1".parse().unwrap();
         let mut h = HeaderMap::new();
         h.insert("x-forwarded-for", "10.0.0.2, 127.0.0.2".parse().unwrap());

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -278,10 +278,7 @@ impl RealtimeHub {
             return;
         }
 
-        let Ok(json) = serde_json::to_string(&EventEnvelope {
-            event: &event,
-            seq,
-        }) else {
+        let Ok(json) = serde_json::to_string(&EventEnvelope { event: &event, seq }) else {
             warn!("failed to serialize realtime event");
             return;
         };
@@ -491,7 +488,8 @@ pub async fn serve_socket(
                 .await
             }
             SocketInput::Message(message) => {
-                handle_client_message(&mut socket, &hub, &db, &auth_user, &mut client, message).await
+                handle_client_message(&mut socket, &hub, &db, &auth_user, &mut client, message)
+                    .await
             }
             SocketInput::ProgressDeadline => close_socket(&mut socket).await,
         };
@@ -668,7 +666,10 @@ enum ClientAction {
     Send(Message),
     ActivityBaseline,
     /// LIF-440: replay this project's buffered events past `cursor`.
-    Resume { project_id: i64, cursor: i64 },
+    Resume {
+        project_id: i64,
+        cursor: i64,
+    },
     Heartbeat,
     /// A reply to one of the server's own pings. Every conforming WebSocket
     /// client sends these without any application-level cooperation, which is
@@ -1279,7 +1280,10 @@ mod tests {
             publish(&hub, 1, seq, seq);
         }
 
-        assert_eq!(replayed_seqs(hub.resume(1, 3, Instant::now())), vec![4, 5, 6]);
+        assert_eq!(
+            replayed_seqs(hub.resume(1, 3, Instant::now())),
+            vec![4, 5, 6]
+        );
     }
 
     /// The cursor is inclusive of what the client already applied, so resuming
@@ -1296,7 +1300,10 @@ mod tests {
             replayed_seqs(hub.resume(1, 3, Instant::now())),
             Vec::<i64>::new()
         );
-        assert_eq!(replayed_seqs(hub.resume(1, 0, Instant::now())), vec![1, 2, 3]);
+        assert_eq!(
+            replayed_seqs(hub.resume(1, 0, Instant::now())),
+            vec![1, 2, 3]
+        );
     }
 
     /// A project this process has published nothing for cannot have a gap, so
@@ -1335,7 +1342,10 @@ mod tests {
 
         // The oldest event still buffered is well past seq 1, so the events
         // between are unrecoverable from memory.
-        assert_eq!(hub.resume(1, 1, Instant::now()), ResumeOutcome::SyncRequired);
+        assert_eq!(
+            hub.resume(1, 1, Instant::now()),
+            ResumeOutcome::SyncRequired
+        );
         // A cursor inside the surviving window is still served.
         assert_eq!(
             replayed_seqs(hub.resume(1, published - 2, Instant::now())),
@@ -1383,7 +1393,10 @@ mod tests {
 
         let ring = &buffer.projects[&1];
         assert_eq!(
-            ring.events.iter().map(|event| event.seq).collect::<Vec<_>>(),
+            ring.events
+                .iter()
+                .map(|event| event.seq)
+                .collect::<Vec<_>>(),
             vec![2],
             "the aged-out entry must not survive the next publish"
         );

--- a/src/resolve_caller.rs
+++ b/src/resolve_caller.rs
@@ -81,8 +81,8 @@ pub fn resolve_caller(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{self, queries};
     use crate::db::models::CreateUser;
+    use crate::db::{self, queries};
 
     fn test_db() -> db::DbPool {
         db::open_memory().expect("test db")
@@ -138,7 +138,12 @@ mod tests {
         let conn = pool.read().unwrap();
         let regular = seed_regular(&conn, "alice");
 
-        for transport in [Transport::Web, Transport::Mcp, Transport::Api, Transport::Cli] {
+        for transport in [
+            Transport::Web,
+            Transport::Mcp,
+            Transport::Api,
+            Transport::Cli,
+        ] {
             let id = resolve_caller_conn(&conn, Some(regular.clone()), transport)
                 .unwrap()
                 .expect("Some(credential) always resolves");
@@ -196,9 +201,11 @@ mod tests {
         drop(conn);
 
         let conn = pool.read().unwrap();
-        assert!(resolve_caller_conn(&conn, None, Transport::Api)
-            .unwrap()
-            .is_none());
+        assert!(
+            resolve_caller_conn(&conn, None, Transport::Api)
+                .unwrap()
+                .is_none()
+        );
     }
 
     // Zero-user bootstrap: no credential and no users at all → None. This is
@@ -207,9 +214,11 @@ mod tests {
     fn none_credential_zero_users_returns_none() {
         let pool = test_db();
         let conn = pool.read().unwrap();
-        assert!(resolve_caller_conn(&conn, None, Transport::System)
-            .unwrap()
-            .is_none());
+        assert!(
+            resolve_caller_conn(&conn, None, Transport::System)
+                .unwrap()
+                .is_none()
+        );
     }
 
     // ── DbPool wrapper mirrors the conn core ──────────────────────────────

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,7 +32,9 @@ use tracing::{info, warn};
 use api_keys_simplified::ApiKeyManagerV0;
 
 use crate::config::{self, Config};
-use crate::{actor, api, auth, backup, db, links, mcp, oauth, ratelimit, realtime, resolve_caller, storage};
+use crate::{
+    actor, api, auth, backup, db, links, mcp, oauth, ratelimit, realtime, resolve_caller, storage,
+};
 
 /// Embedded frontend assets compiled from web/dist/.
 /// Falls back gracefully if dist/ doesn't exist (e.g. dev builds without frontend).
@@ -269,10 +271,11 @@ fn build_app_with_store(
     // so reverse proxies (Tailscale funnel, nginx, etc.) can forward requests.
     if let Some(ref url) = cfg.server.public_url
         && let Ok(parsed) = url.parse::<axum::http::Uri>()
-            && let Some(authority) = parsed.authority() {
-                let host: String = authority.host().to_string();
-                mcp_allowed_hosts.push(host);
-            }
+        && let Some(authority) = parsed.authority()
+    {
+        let host: String = authority.host().to_string();
+        mcp_allowed_hosts.push(host);
+    }
 
     let mcp_config = StreamableHttpServerConfig::default()
         .with_stateful_mode(false)
@@ -397,14 +400,12 @@ fn build_app_with_store(
                             }),
                         // LIFIC-8: the "no credential → first admin"
                         // fallback is consolidated in `resolve_caller`.
-                        None => resolve_caller::resolve_caller_conn(
-                            &conn,
-                            None,
-                            actor::Transport::Mcp,
-                        )
-                        .ok()
-                        .flatten()
-                        .map(|i| i.user),
+                        None => {
+                            resolve_caller::resolve_caller_conn(&conn, None, actor::Transport::Mcp)
+                                .ok()
+                                .flatten()
+                                .map(|i| i.user)
+                        }
                     },
                     Err(_) => None,
                 }
@@ -567,7 +568,9 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         // A human operator exists (should_mint was false for lack of
         // keys alone) but no key has been created yet: keys are minted
         // on demand via `lific key create`.
-        info!("human operator present — passwordless mode; mint keys on demand with `lific key create`");
+        info!(
+            "human operator present — passwordless mode; mint keys on demand with `lific key create`"
+        );
     } else {
         let count = auth::list_api_keys(&pool)?
             .iter()
@@ -596,10 +599,7 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     // request router so its operation lock covers both upload and GC paths.
     let attachment_store = storage::AttachmentStore::from_db_path(&cfg.database.path);
     let gc_attachment_store = attachment_store.clone();
-    storage::start_gc_task(
-        pool.clone(),
-        gc_attachment_store,
-    );
+    storage::start_gc_task(pool.clone(), gc_attachment_store);
 
     let app = build_app_with_store(
         cfg,
@@ -675,10 +675,8 @@ fn build_global_cors(cors_origins: &[String]) -> CorsLayer {
     if cors_origins.is_empty() {
         layer.allow_origin(Any)
     } else {
-        let origins: Vec<HeaderValue> = cors_origins
-            .iter()
-            .filter_map(|o| o.parse().ok())
-            .collect();
+        let origins: Vec<HeaderValue> =
+            cors_origins.iter().filter_map(|o| o.parse().ok()).collect();
         layer.allow_origin(origins)
     }
 }
@@ -708,12 +706,7 @@ fn build_authless_mcp_router(
         .with_json_response(true)
         .with_allowed_hosts(allowed_hosts);
     let service = StreamableHttpService::new(
-        move || {
-            Ok(mcp::LificMcp::with_realtime(
-                pool.clone(),
-                realtime.clone(),
-            ))
-        },
+        move || Ok(mcp::LificMcp::with_realtime(pool.clone(), realtime.clone())),
         Arc::new(LocalSessionManager::default()),
         config,
     );
@@ -921,7 +914,10 @@ mod cors_tests {
             .uri("/mcp")
             .header("origin", "https://claude.ai")
             .header("access-control-request-method", "POST")
-            .header("access-control-request-headers", "authorization,content-type")
+            .header(
+                "access-control-request-headers",
+                "authorization,content-type",
+            )
             .body(Body::empty())
             .unwrap();
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -72,7 +72,7 @@ fn existing_regular_file(path: &Path, label: &str) -> Result<bool, LificError> {
         Err(error) => {
             return Err(LificError::Internal(format!(
                 "inspect {label} path: {error}"
-            )))
+            )));
         }
     };
     if !metadata.file_type().is_file() {
@@ -84,9 +84,7 @@ fn existing_regular_file(path: &Path, label: &str) -> Result<bool, LificError> {
     {
         use std::os::unix::fs::MetadataExt;
         if metadata.nlink() != 1 {
-            return Err(LificError::Internal(format!(
-                "{label} path is hard-linked"
-            )));
+            return Err(LificError::Internal(format!("{label} path is hard-linked")));
         }
     }
     Ok(true)
@@ -99,7 +97,10 @@ fn existing_regular_file(path: &Path, label: &str) -> Result<bool, LificError> {
 /// its own fsync. Without this, a crash right after an upload can leave a
 /// database row pointing at a blob whose directory entry never landed.
 /// Unix only: Windows has no directory handle to sync.
-#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn sync_dir(_dir: &Path) -> Result<(), LificError> {
     #[cfg(unix)]
     {
@@ -1403,10 +1404,7 @@ mod tests {
             Some(7),
             "and must proceed once the store is free"
         );
-        assert_eq!(
-            requester.try_with_string_lock(|_| Ok(8)).unwrap(),
-            Some(8)
-        );
+        assert_eq!(requester.try_with_string_lock(|_| Ok(8)).unwrap(), Some(8));
     }
 
     #[test]
@@ -1768,7 +1766,9 @@ mod tests {
             match (&in_memory, &streamed) {
                 (Ok(a), Ok(b)) => assert_eq!(a, b, "disagreement on {declared:?} {bytes:?}"),
                 (Err(_), Err(_)) => {}
-                _ => panic!("streamed and in-memory sniffing disagree: {in_memory:?} vs {streamed:?}"),
+                _ => panic!(
+                    "streamed and in-memory sniffing disagree: {in_memory:?} vs {streamed:?}"
+                ),
             }
         }
     }


### PR DESCRIPTION
## Summary

spending an annoying amount of tokens on formatting so I wanted this to make it stop wasting effort.

- apply `cargo fmt --all` to the current Rust sources
- add a local `pre-commit` hook that runs `cargo fmt --all -- --check` alongside the existing Clippy hook
- make CI install rustfmt and fail when formatting drifts
- document the formatter, hook setup, and fix command in `CONTRIBUTING.md`
- preserve useful pre-format history by listing the full reformat commit hash in `.git-blame-ignore-revs`

No tests were added because this is a formatting and tooling-only change; the existing suite exercises the same code before and after the rustfmt-only rewrite. The local hook and CI deliberately run the same formatter command so contributors see the same failure before commit that the upstream check would report.