### PR TITLE
chore: apply Clippy pedantic autofixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
 
       - name: Ensure web/dist exists for rust-embed
         run: mkdir -p web/dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,14 +48,23 @@ The whole suite runs in seconds. Every new MCP tool and REST endpoint ships with
 
 ## What CI runs (run it before pushing)
 
-CI lints with warnings-as-errors, so `cargo test` passing is not enough. Reproduce CI locally with both commands:
+CI checks formatting and lints with warnings-as-errors, so `cargo test` passing is not enough. Reproduce the Rust checks locally with:
 
 ```bash
+cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
 cargo test --all-targets
 ```
 
 If clippy complains, fix it. Don't `#[allow]` a lint without a comment explaining why.
+
+To run the same formatting check before each commit, install the repository's `pre-commit` hook once:
+
+```bash
+pre-commit install
+```
+
+Use `cargo fmt --all` to apply formatting fixes.
 
 ## Commit message style
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -125,7 +125,11 @@ mod tests {
             user_id: Some(2),
             transport: Transport::Mcp,
         };
-        let seen = scope(outer, async move { scope(inner, async { current() }).await }).await;
+        let seen = scope(
+            outer,
+            async move { scope(inner, async { current() }).await },
+        )
+        .await;
         assert_eq!(seen.user_id, Some(2));
         assert_eq!(seen.transport, Transport::Mcp);
     }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -20,7 +20,7 @@ use std::sync::OnceLock;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Transport {
-    /// Browser session (lific_sess_ token).
+    /// Browser session (`lific_sess`_ token).
     Web,
     /// MCP request (any token presented to /mcp).
     Mcp,
@@ -33,7 +33,7 @@ pub enum Transport {
 }
 
 impl Transport {
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Transport::Web => "web",
             Transport::Mcp => "mcp",

--- a/src/api/activity.rs
+++ b/src/api/activity.rs
@@ -1,5 +1,5 @@
 //! LIF-156: REST read surface for the audit log (captured in migration
-//! 018's triggers — see queries::activity for the read layer).
+//! 018's triggers — see `queries::activity` for the read layer).
 
 use axum::{
     Extension,
@@ -18,9 +18,9 @@ use super::with_read;
 
 /// Resolve the `project_id` an activity scope belongs to, for the
 /// `Viewer` gate (LIF-197 scope item 2: single-resource reads resolve
-/// project_id from the target then check). Workspace-level pages
+/// `project_id` from the target then check). Workspace-level pages
 /// (`project_id = None`) fall back to admin-only.
-async fn require_scope_viewer(
+fn require_scope_viewer(
     db: &DbPool,
     identity: &Option<crate::resolve_caller::ResolvedIdentity>,
     scope: &ActivityScope,
@@ -58,7 +58,7 @@ pub(super) async fn issue_activity(
     Query(q): Query<ActivityQuery>,
 ) -> Result<Json<ActivityFeed>, LificError> {
     let scope = ActivityScope::Issue(id);
-    require_scope_viewer(&db, &identity, &scope).await?;
+    require_scope_viewer(&db, &identity, &scope)?;
     with_read(&db, |conn| list_activity(conn, scope, q.limit, q.offset)).map(Json)
 }
 
@@ -70,7 +70,7 @@ pub(super) async fn page_activity(
     Query(q): Query<ActivityQuery>,
 ) -> Result<Json<ActivityFeed>, LificError> {
     let scope = ActivityScope::Page(id);
-    require_scope_viewer(&db, &identity, &scope).await?;
+    require_scope_viewer(&db, &identity, &scope)?;
     with_read(&db, |conn| list_activity(conn, scope, q.limit, q.offset)).map(Json)
 }
 
@@ -83,7 +83,7 @@ pub(super) async fn plan_activity(
     Query(q): Query<ActivityQuery>,
 ) -> Result<Json<ActivityFeed>, LificError> {
     let scope = ActivityScope::Plan(id);
-    require_scope_viewer(&db, &identity, &scope).await?;
+    require_scope_viewer(&db, &identity, &scope)?;
     with_read(&db, |conn| list_activity(conn, scope, q.limit, q.offset)).map(Json)
 }
 
@@ -96,7 +96,7 @@ pub(super) async fn project_activity(
     Query(q): Query<ActivityQuery>,
 ) -> Result<Json<ActivityFeed>, LificError> {
     let scope = ActivityScope::Project(id);
-    require_scope_viewer(&db, &identity, &scope).await?;
+    require_scope_viewer(&db, &identity, &scope)?;
     with_read(&db, |conn| list_activity(conn, scope, q.limit, q.offset)).map(Json)
 }
 

--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -30,7 +30,10 @@ use axum::{
 use std::sync::Arc;
 
 use crate::authz;
-use crate::db::models::*;
+use crate::db::models::{
+    Attachment, AttachmentEntity, AuthUser, PendingOrphanList, ProjectAttachmentPage,
+    ProjectAttachmentQuery, Role,
+};
 use crate::db::queries::attachments as q;
 use crate::db::{DbPool, queries};
 use crate::error::LificError;
@@ -115,7 +118,7 @@ pub(super) async fn upload_attachment(
                 if let Some(fname) = field.file_name() {
                     filename = sanitize_filename(fname);
                 }
-                declared_mime = field.content_type().map(|s| s.to_string());
+                declared_mime = field.content_type().map(std::string::ToString::to_string);
                 let mut data = Vec::new();
                 while let Some(chunk) = field
                     .chunk()
@@ -488,8 +491,7 @@ pub(super) async fn download_attachment(
     let requested = headers
         .get(header::RANGE)
         .and_then(|v| v.to_str().ok())
-        .map(|v| parse_range(v, total))
-        .unwrap_or(RangeRequest::Whole);
+        .map_or(RangeRequest::Whole, |v| parse_range(v, total));
 
     let (status, body, content_range) = match requested {
         RangeRequest::Whole => (StatusCode::OK, bytes, None),
@@ -645,26 +647,25 @@ pub(super) async fn attachment_thumbnail(
         ));
     }
 
-    let thumb = match store.read_thumb(&attachment.sha256)? {
-        Some(bytes) => bytes,
-        None => {
-            let source = store.read(&attachment.sha256)?;
-            match storage::generate_thumbnail(&source) {
-                Ok(Some(bytes)) => {
-                    // Best-effort cache write: a read-only or full disk should
-                    // still serve the thumbnail it just built.
-                    if let Err(e) = store.write_thumb(&attachment.sha256, &bytes) {
-                        tracing::warn!(error = %e, "failed to cache attachment thumbnail");
-                    }
-                    bytes
+    let thumb = if let Some(bytes) = store.read_thumb(&attachment.sha256)? {
+        bytes
+    } else {
+        let source = store.read(&attachment.sha256)?;
+        match storage::generate_thumbnail(&source) {
+            Ok(Some(bytes)) => {
+                // Best-effort cache write: a read-only or full disk should
+                // still serve the thumbnail it just built.
+                if let Err(e) = store.write_thumb(&attachment.sha256, &bytes) {
+                    tracing::warn!(error = %e, "failed to cache attachment thumbnail");
                 }
-                // Small enough to need none, or undecodable: both are "there
-                // is no thumbnail here", not a server error.
-                Ok(None) | Err(_) => {
-                    return Err(LificError::NotFound(
-                        "no thumbnail for this attachment".into(),
-                    ));
-                }
+                bytes
+            }
+            // Small enough to need none, or undecodable: both are "there
+            // is no thumbnail here", not a server error.
+            Ok(None) | Err(_) => {
+                return Err(LificError::NotFound(
+                    "no thumbnail for this attachment".into(),
+                ));
             }
         }
     };
@@ -959,7 +960,7 @@ fn comment_title(content: &str) -> String {
 
 /// `GET /api/attachments/{id}/preview`: what is inside a container upload.
 ///
-/// Zip archives report their central directory, SQLite databases report their
+/// Zip archives report their central directory, `SQLite` databases report their
 /// tables and row counts, and everything else reports `{"kind":"none"}`. Gated
 /// exactly like the download, because a preview is a read of the same bytes in
 /// a more convenient shape. See `crate::preview` for how both parsers are kept
@@ -2639,7 +2640,7 @@ mod media_tests {
             )))
     }
 
-    /// A tiny but structurally valid WebM header the sniffer accepts.
+    /// A tiny but structurally valid `WebM` header the sniffer accepts.
     fn webm_bytes() -> Vec<u8> {
         let mut v = vec![0x1A, 0x45, 0xDF, 0xA3];
         v.extend_from_slice(&[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1F]);
@@ -3547,7 +3548,7 @@ mod cookie_fallback_tests {
 
     /// Build a router that wraps the production `api::router` in the real
     /// `require_api_key` middleware, plus the attachment layers. Returns the
-    /// app and the shared DbPool.
+    /// app and the shared `DbPool`.
     fn real_middleware_app(db: crate::db::DbPool) -> axum::Router {
         let auth_state = crate::auth::AuthState {
             db: db.clone(),
@@ -3568,7 +3569,7 @@ mod cookie_fallback_tests {
             ))
     }
 
-    /// Create a user and a live session, returning (user_id, session token).
+    /// Create a user and a live session, returning (`user_id`, session token).
     fn user_with_session(db: &crate::db::DbPool, username: &str) -> (i64, String) {
         let conn = db.write().unwrap();
         let user = crate::db::queries::users::create_user(

--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -206,55 +206,57 @@ pub(super) async fn upload_attachment(
     // is inserted.
     // Non-blocking: a REST handler must not park a Tokio worker for the
     // length of a dump. Busy means "retry", not "failed".
-    let (attachment, event) = store.try_with_lock(|store| {
-        // Same definition of "already there" the writer uses, so a path that
-        // is present but not a usable regular file fails here rather than
-        // being read as "this upload created it" during cleanup.
-        let blob_existed = store.blob_exists(&sha)?;
-        let thumb_existed = match thumbnail.as_ref() {
-            Some(_) => store.thumb_exists(&sha)?,
-            None => false,
-        };
-        let result = db.transaction(|conn| {
-            let mut att = q::create_attachment(conn, &sha, &filename, &mime, size, Some(user.id))?;
-            store.write_unlocked(&bytes)?;
-            if let Some(thumb) = thumbnail.as_deref()
-                && let Err(e) = store.write_thumb(&sha, thumb)
-            {
-                tracing::warn!(error = %e, "failed to cache attachment thumbnail");
-            }
-            if let Some((w, h)) = dimensions {
-                q::set_dimensions(conn, att.id, i64::from(w), i64::from(h))?;
-                att = q::get_attachment(conn, att.id)?;
-            }
-            if q::is_extractable(&mime, size)
-                && let Ok(text) = std::str::from_utf8(&bytes)
-            {
-                q::set_extracted_text(conn, att.id, text)?;
-            }
-            let event = match link {
-                Some((entity, eid)) => {
-                    authorize_link_conn(conn, &identity, entity, eid)?;
-                    q::link_attachment(conn, att.id, entity, eid)?;
-                    linked_entity_event(conn, entity, eid)?
-                }
-                None => None,
+    let (attachment, event) = store
+        .try_with_lock(|store| {
+            // Same definition of "already there" the writer uses, so a path that
+            // is present but not a usable regular file fails here rather than
+            // being read as "this upload created it" during cleanup.
+            let blob_existed = store.blob_exists(&sha)?;
+            let thumb_existed = match thumbnail.as_ref() {
+                Some(_) => store.thumb_exists(&sha)?,
+                None => false,
             };
-            Ok((att, event))
-        });
-        if result.is_err() {
-            discard_failed_upload(
-                &db,
-                store,
-                &sha,
-                blob_existed,
-                thumb_existed,
-                thumbnail.is_some(),
-            );
-        }
-        result
-    })?
-    .ok_or_else(AttachmentStore::busy_error)?;
+            let result = db.transaction(|conn| {
+                let mut att =
+                    q::create_attachment(conn, &sha, &filename, &mime, size, Some(user.id))?;
+                store.write_unlocked(&bytes)?;
+                if let Some(thumb) = thumbnail.as_deref()
+                    && let Err(e) = store.write_thumb(&sha, thumb)
+                {
+                    tracing::warn!(error = %e, "failed to cache attachment thumbnail");
+                }
+                if let Some((w, h)) = dimensions {
+                    q::set_dimensions(conn, att.id, i64::from(w), i64::from(h))?;
+                    att = q::get_attachment(conn, att.id)?;
+                }
+                if q::is_extractable(&mime, size)
+                    && let Ok(text) = std::str::from_utf8(&bytes)
+                {
+                    q::set_extracted_text(conn, att.id, text)?;
+                }
+                let event = match link {
+                    Some((entity, eid)) => {
+                        authorize_link_conn(conn, &identity, entity, eid)?;
+                        q::link_attachment(conn, att.id, entity, eid)?;
+                        linked_entity_event(conn, entity, eid)?
+                    }
+                    None => None,
+                };
+                Ok((att, event))
+            });
+            if result.is_err() {
+                discard_failed_upload(
+                    &db,
+                    store,
+                    &sha,
+                    blob_existed,
+                    thumb_existed,
+                    thumbnail.is_some(),
+                );
+            }
+            result
+        })?
+        .ok_or_else(AttachmentStore::busy_error)?;
     if let Some(event) = event {
         realtime.send(event);
     }
@@ -761,21 +763,22 @@ pub(super) async fn delete_attachment(
 
     authorize_delete(&db, &identity, &user, &attachment)?;
 
-    let events = store.try_with_lock(|store| {
-        let events = with_write(&db, |conn| {
-            let events = linked_attachment_events(conn, id)?;
-            q::delete_attachment(conn, id)?;
-            Ok(events)
-        })?;
+    let events = store
+        .try_with_lock(|store| {
+            let events = with_write(&db, |conn| {
+                let events = linked_attachment_events(conn, id)?;
+                q::delete_attachment(conn, id)?;
+                Ok(events)
+            })?;
 
-        // GC the sidecar only when no remaining row references the same bytes.
-        let remaining = with_read(&db, |conn| q::count_rows_for_sha(conn, &attachment.sha256))?;
-        if remaining == 0 {
-            store.delete_unlocked(&attachment.sha256)?;
-        }
-        Ok(events)
-    })?
-    .ok_or_else(AttachmentStore::busy_error)?;
+            // GC the sidecar only when no remaining row references the same bytes.
+            let remaining = with_read(&db, |conn| q::count_rows_for_sha(conn, &attachment.sha256))?;
+            if remaining == 0 {
+                store.delete_unlocked(&attachment.sha256)?;
+            }
+            Ok(events)
+        })?
+        .ok_or_else(AttachmentStore::busy_error)?;
     for event in events {
         realtime.send(event);
     }
@@ -900,34 +903,39 @@ fn describe_entity(
     entity_id: i64,
 ) -> Result<Option<LinkedEntity>, LificError> {
     with_read(db, |conn| {
-        let described = match entity {
-            AttachmentEntity::Issue => queries::get_issue(conn, entity_id).ok().map(|issue| {
-                LinkedEntity {
-                    entity_type: "issue".into(),
-                    entity_id,
-                    identifier: Some(issue.identifier),
-                    title: issue.title,
+        let described =
+            match entity {
+                AttachmentEntity::Issue => {
+                    queries::get_issue(conn, entity_id)
+                        .ok()
+                        .map(|issue| LinkedEntity {
+                            entity_type: "issue".into(),
+                            entity_id,
+                            identifier: Some(issue.identifier),
+                            title: issue.title,
+                        })
                 }
-            }),
-            AttachmentEntity::Page => {
-                queries::get_page(conn, entity_id).ok().map(|page| LinkedEntity {
-                    entity_type: "page".into(),
-                    entity_id,
-                    identifier: Some(page.identifier),
-                    title: page.title,
-                })
-            }
-            AttachmentEntity::Comment => queries::comments::get_comment(conn, entity_id)
-                .ok()
-                .map(|comment| LinkedEntity {
-                    entity_type: "comment".into(),
-                    entity_id,
-                    // A comment is not addressable by identifier; the client
-                    // navigates to it through its parent issue or page.
-                    identifier: None,
-                    title: comment_title(&comment.content),
-                }),
-        };
+                AttachmentEntity::Page => {
+                    queries::get_page(conn, entity_id)
+                        .ok()
+                        .map(|page| LinkedEntity {
+                            entity_type: "page".into(),
+                            entity_id,
+                            identifier: Some(page.identifier),
+                            title: page.title,
+                        })
+                }
+                AttachmentEntity::Comment => queries::comments::get_comment(conn, entity_id)
+                    .ok()
+                    .map(|comment| LinkedEntity {
+                        entity_type: "comment".into(),
+                        entity_id,
+                        // A comment is not addressable by identifier; the client
+                        // navigates to it through its parent issue or page.
+                        identifier: None,
+                        title: comment_title(&comment.content),
+                    }),
+            };
         Ok(described)
     })
 }
@@ -1289,7 +1297,11 @@ mod tests {
         assert!(matches!(error, LificError::Unavailable(_)), "got {error:?}");
         let response = error.into_response();
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-        assert!(response.headers().contains_key(axum::http::header::RETRY_AFTER));
+        assert!(
+            response
+                .headers()
+                .contains_key(axum::http::header::RETRY_AFTER)
+        );
 
         release_tx.send(()).unwrap();
         worker.join().unwrap().unwrap();
@@ -1430,12 +1442,18 @@ mod tests {
 
     #[test]
     fn ranges_outside_the_resource_are_unsatisfiable() {
-        assert_eq!(parse_range("bytes=1000-", 1000), RangeRequest::Unsatisfiable);
+        assert_eq!(
+            parse_range("bytes=1000-", 1000),
+            RangeRequest::Unsatisfiable
+        );
         assert_eq!(
             parse_range("bytes=1500-1600", 1000),
             RangeRequest::Unsatisfiable
         );
-        assert_eq!(parse_range("bytes=50-10", 1000), RangeRequest::Unsatisfiable);
+        assert_eq!(
+            parse_range("bytes=50-10", 1000),
+            RangeRequest::Unsatisfiable
+        );
         assert_eq!(parse_range("bytes=-0", 1000), RangeRequest::Unsatisfiable);
         assert_eq!(parse_range("bytes=0-0", 0), RangeRequest::Unsatisfiable);
     }
@@ -1729,7 +1747,11 @@ mod api_tests {
 
         for (name, mime, bytes) in [
             ("shot.png", "image/png", png_bytes()),
-            ("logo.svg", "image/svg+xml", b"<svg xmlns=\"x\"></svg>".to_vec()),
+            (
+                "logo.svg",
+                "image/svg+xml",
+                b"<svg xmlns=\"x\"></svg>".to_vec(),
+            ),
             ("notes.txt", "text/plain", b"hello\n".to_vec()),
         ] {
             let resp = upload(&app, name, mime, &bytes, None).await;
@@ -1861,15 +1883,17 @@ mod api_tests {
                 display_name: lead.display_name.clone(),
                 is_admin: false,
             })))
-            .layer(axum::Extension(Some(crate::resolve_caller::ResolvedIdentity {
-                user: AuthUser {
-                    id: lead.id,
-                    username: lead.username.clone(),
-                    display_name: lead.display_name.clone(),
-                    is_admin: false,
+            .layer(axum::Extension(Some(
+                crate::resolve_caller::ResolvedIdentity {
+                    user: AuthUser {
+                        id: lead.id,
+                        username: lead.username.clone(),
+                        display_name: lead.display_name.clone(),
+                        is_admin: false,
+                    },
+                    transport: crate::actor::Transport::Web,
                 },
-                transport: crate::actor::Transport::Web,
-            })));
+            )));
 
         let issue = parse_json(
             json_post(
@@ -2241,15 +2265,17 @@ mod api_tests {
                 display_name: "GC".into(),
                 is_admin: true,
             })))
-            .layer(axum::Extension(Some(crate::resolve_caller::ResolvedIdentity {
-                user: AuthUser {
-                    id: admin_id,
-                    username: "gc".into(),
-                    display_name: "GC".into(),
-                    is_admin: true,
+            .layer(axum::Extension(Some(
+                crate::resolve_caller::ResolvedIdentity {
+                    user: AuthUser {
+                        id: admin_id,
+                        username: "gc".into(),
+                        display_name: "GC".into(),
+                        is_admin: true,
+                    },
+                    transport: crate::actor::Transport::Web,
                 },
-                transport: crate::actor::Transport::Web,
-            })));
+            )));
         let (project_id2, _) = seed_project(&app).await;
 
         // Upload two: one linked to an issue, one left dangling.
@@ -2350,8 +2376,9 @@ mod api_tests {
         // Unlinked: belongs to no project, so it stays out of the listing.
         upload(&app, "stray.txt", "text/plain", b"nowhere\n", None).await;
 
-        let body = parse_json(json_get(&app, &format!("/api/projects/{project_id}/attachments")).await)
-            .await;
+        let body =
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/attachments")).await)
+                .await;
         assert_eq!(body["total_count"], 2);
         assert_eq!(body["has_more"], false);
         let items = body["items"].as_array().unwrap();
@@ -2455,7 +2482,14 @@ mod api_tests {
             Some(("issue", issue_id)),
         )
         .await;
-        upload(&app, "abandoned.txt", "text/plain", b"draft that never landed\n", None).await;
+        upload(
+            &app,
+            "abandoned.txt",
+            "text/plain",
+            b"draft that never landed\n",
+            None,
+        )
+        .await;
 
         let body = parse_json(
             json_get(
@@ -2623,7 +2657,12 @@ mod media_tests {
     }
 
     async fn body_bytes(resp: axum::response::Response) -> Vec<u8> {
-        resp.into_body().collect().await.unwrap().to_bytes().to_vec()
+        resp.into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .to_vec()
     }
 
     fn header(resp: &axum::response::Response, name: &str) -> Option<String> {
@@ -2817,8 +2856,9 @@ mod media_tests {
     #[tokio::test]
     async fn upload_records_raster_dimensions() {
         let app = test_app();
-        let data = parse_json(upload(&app, "big.png", "image/png", &png_image(800, 200), None).await)
-            .await;
+        let data =
+            parse_json(upload(&app, "big.png", "image/png", &png_image(800, 200), None).await)
+                .await;
         assert_eq!(data["width"], 800);
         assert_eq!(data["height"], 200);
         assert_eq!(data["has_thumbnail"], true);
@@ -2834,10 +2874,11 @@ mod media_tests {
     #[tokio::test]
     async fn thumbnail_endpoint_serves_a_downscaled_webp() {
         let app = test_app();
-        let id = parse_json(upload(&app, "big.png", "image/png", &png_image(1200, 600), None).await)
-            .await["id"]
-            .as_i64()
-            .unwrap();
+        let id =
+            parse_json(upload(&app, "big.png", "image/png", &png_image(1200, 600), None).await)
+                .await["id"]
+                .as_i64()
+                .unwrap();
 
         let resp = json_get(&app, &format!("/api/attachments/{id}/thumbnail")).await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -2872,10 +2913,10 @@ mod media_tests {
         );
 
         // Not a raster image at all.
-        let text = parse_json(upload(&app, "n.txt", "text/plain", b"hello\n", None).await).await
-            ["id"]
-            .as_i64()
-            .unwrap();
+        let text =
+            parse_json(upload(&app, "n.txt", "text/plain", b"hello\n", None).await).await["id"]
+                .as_i64()
+                .unwrap();
         assert_eq!(
             json_get(&app, &format!("/api/attachments/{text}/thumbnail"))
                 .await
@@ -2909,11 +2950,9 @@ mod media_tests {
             .unwrap();
         let sha: String = {
             let conn = db.read().unwrap();
-            conn.query_row(
-                "SELECT sha256 FROM attachments WHERE id = ?1",
-                [id],
-                |r| r.get(0),
-            )
+            conn.query_row("SELECT sha256 FROM attachments WHERE id = ?1", [id], |r| {
+                r.get(0)
+            })
             .unwrap()
         };
 
@@ -3068,7 +3107,12 @@ mod media_tests {
         assert_eq!(data["alt_text"], serde_json::Value::Null);
 
         // An empty patch is a no-op rather than a 400.
-        let resp = json_patch(&app, &format!("/api/attachments/{id}"), serde_json::json!({})).await;
+        let resp = json_patch(
+            &app,
+            &format!("/api/attachments/{id}"),
+            serde_json::json!({}),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
@@ -3185,7 +3229,14 @@ mod media_tests {
 
         let bytes = png_image(20, 20);
         let id = parse_json(
-            upload(&app, "shot.png", "image/png", &bytes, Some(("issue", issue_id))).await,
+            upload(
+                &app,
+                "shot.png",
+                "image/png",
+                &bytes,
+                Some(("issue", issue_id)),
+            )
+            .await,
         )
         .await["id"]
             .as_i64()
@@ -3219,7 +3270,10 @@ mod media_tests {
         assert_eq!(issue["title"], "Broken export");
         assert!(issue["identifier"].as_str().unwrap().contains('-'));
 
-        let page = entities.iter().find(|e| e["entity_type"] == "page").unwrap();
+        let page = entities
+            .iter()
+            .find(|e| e["entity_type"] == "page")
+            .unwrap();
         assert_eq!(page["title"], "Runbook");
         assert!(page["identifier"].as_str().unwrap().contains("-DOC-"));
 
@@ -3257,7 +3311,14 @@ mod media_tests {
 
         let bytes = png_image(24, 24);
         let first = parse_json(
-            upload(&app, "a.png", "image/png", &bytes, Some(("issue", issue_id))).await,
+            upload(
+                &app,
+                "a.png",
+                "image/png",
+                &bytes,
+                Some(("issue", issue_id)),
+            )
+            .await,
         )
         .await["id"]
             .as_i64()
@@ -3320,10 +3381,9 @@ mod media_tests {
             .as_i64()
             .unwrap();
 
-        let links = parse_json(
-            json_get(&outsider_app, &format!("/api/attachments/{mine}/links")).await,
-        )
-        .await;
+        let links =
+            parse_json(json_get(&outsider_app, &format!("/api/attachments/{mine}/links")).await)
+                .await;
         let dupes = links["duplicates"].as_array().unwrap();
         assert_eq!(dupes.len(), 1);
         assert_eq!(dupes[0]["attachment_id"], hidden);

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -6,7 +6,10 @@ use axum::{
 };
 use std::{net::SocketAddr, sync::Arc};
 
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{Bot, CreateUser, LoginRequest, User, UserApiKey},
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
@@ -21,12 +24,10 @@ use super::{require_admin, require_user, with_read, with_write};
 fn session_cookie(token: &str, expires_at: &str, secure: bool) -> String {
     use chrono::DateTime;
     // Parse expiry for Max-Age calculation; fall back to 30 days
-    let max_age = DateTime::parse_from_rfc3339(expires_at)
-        .map(|exp| {
-            let exp_utc: DateTime<chrono::Utc> = exp.into();
-            (exp_utc - chrono::Utc::now()).num_seconds().max(0)
-        })
-        .unwrap_or(30 * 24 * 3600);
+    let max_age = DateTime::parse_from_rfc3339(expires_at).map_or(30 * 24 * 3600, |exp| {
+        let exp_utc: DateTime<chrono::Utc> = exp.into();
+        (exp_utc - chrono::Utc::now()).num_seconds().max(0)
+    });
 
     let secure_attr = if secure { "; Secure" } else { "" };
     format!("lific_token={token}; Path=/; Max-Age={max_age}; HttpOnly{secure_attr}; SameSite=Lax")
@@ -41,7 +42,7 @@ fn clear_cookie(secure: bool) -> String {
 
 // ── Auth endpoints ───────────────────────────────────────────
 
-/// Public signup request — intentionally excludes is_admin and is_bot
+/// Public signup request — intentionally excludes `is_admin` and `is_bot`
 /// to prevent privilege escalation. Those can only be set via CLI, with one
 /// carve-out: the first user on a zero-user instance is granted admin by the
 /// handler itself (LIF-364), because a client-supplied flag and a
@@ -297,9 +298,8 @@ pub(super) async fn auth_login(
     let verified_hash = user.password_hash.clone();
     let (user, session) = db.transaction(|tx| {
         let user = crate::db::queries::users::finalize_login(tx, user.id, &verified_hash)?;
-        let lifetime_days = crate::db::queries::settings::get(tx)
-            .map(|s| s.session_lifetime_days)
-            .unwrap_or(30);
+        let lifetime_days =
+            crate::db::queries::settings::get(tx).map_or(30, |s| s.session_lifetime_days);
         let session =
             crate::db::queries::users::create_session(tx, user.id, Some(lifetime_days * 24))?;
         Ok((user, session))
@@ -735,28 +735,25 @@ pub(super) async fn refresh_session(
         _ => None,
     };
 
-    let verified_hash = match supplied_password {
-        Some(password) => {
-            crate::db::queries::users::reject_oversized_password(&password)?;
-            let hash = current_hash.clone();
-            let ok = tokio::task::spawn_blocking(move || {
-                crate::db::queries::users::verify_password(&password, &hash).unwrap_or(false)
-            })
-            .await
-            .map_err(|e| LificError::Internal(format!("password verification task failed: {e}")))?;
-            if !ok {
-                return Err(LificError::BadRequest("incorrect password".into()));
-            }
-            Some(current_hash)
+    let verified_hash = if let Some(password) = supplied_password {
+        crate::db::queries::users::reject_oversized_password(&password)?;
+        let hash = current_hash.clone();
+        let ok = tokio::task::spawn_blocking(move || {
+            crate::db::queries::users::verify_password(&password, &hash).unwrap_or(false)
+        })
+        .await
+        .map_err(|e| LificError::Internal(format!("password verification task failed: {e}")))?;
+        if !ok {
+            return Err(LificError::BadRequest("incorrect password".into()));
         }
-        None => {
-            if !passwordless {
-                return Err(LificError::BadRequest(
-                    "your password is required to confirm this".into(),
-                ));
-            }
-            None
+        Some(current_hash)
+    } else {
+        if !passwordless {
+            return Err(LificError::BadRequest(
+                "your password is required to confirm this".into(),
+            ));
         }
+        None
     };
 
     let (user, session) = db.transaction(|tx| {
@@ -854,7 +851,7 @@ pub(super) async fn refresh_session(
 /// body for clients that hold it outside the cookie.
 ///
 /// Verification, lockdown and replacement all happen under one hold of the
-/// writer, inside one savepoint. SQLite serializes writers, so a credential
+/// writer, inside one savepoint. `SQLite` serializes writers, so a credential
 /// creation racing this either lands entirely before it (and is revoked) or
 /// entirely after it (and revalidates against the post-lockdown state).
 // Axum handlers take their dependencies as extractors; the count is the
@@ -1040,7 +1037,7 @@ pub(super) struct CreateKeyRequest {
 /// the authentication middleware.
 ///
 /// The key material is drawn before the writer is taken, then the session is
-/// revalidated and the key inserted in one transaction. Because SQLite
+/// revalidated and the key inserted in one transaction. Because `SQLite`
 /// serializes writers, an account lockdown either wins the race outright (this
 /// transaction then finds no session and writes nothing) or loses it (and
 /// revokes the key it finds). Neither order can leave a live key behind a
@@ -2073,7 +2070,7 @@ mod tests {
         }
 
         /// The linearizability claim, exercised at the transaction seam rather
-        /// than by racing threads: whichever order SQLite's writer lock picks,
+        /// than by racing threads: whichever order `SQLite`'s writer lock picks,
         /// no live key survives a lockdown.
         ///
         /// Creation-then-lockdown is the order that actually needs proving.
@@ -3629,7 +3626,7 @@ mod tests {
     }
 
     /// LIF-214's deactivation message is produced after the verify, so it
-    /// has to come back through the spawn_blocking path unchanged.
+    /// has to come back through the `spawn_blocking` path unchanged.
     #[tokio::test]
     async fn login_still_reports_a_deactivated_account() {
         let db = crate::db::open_memory().expect("test db");

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -225,7 +225,9 @@ async fn authenticate_off_writer(
 
     // The read connection is released with this binding, before the verify.
     let challenge = with_read(db, |conn| {
-        Ok(crate::db::queries::users::password_challenge(conn, identity))
+        Ok(crate::db::queries::users::password_challenge(
+            conn, identity,
+        ))
     })?;
 
     let password = password.to_string();
@@ -370,12 +372,11 @@ pub(super) async fn auth_auto_login(
     // LIFIC-8: the "no credential → first admin" fallback is consolidated in
     // `resolve_caller`. Auto-login has no credential (it is the thing that
     // *produces* a session), so the passwordless fallback applies.
-    let admin = crate::resolve_caller::resolve_caller_conn(
-        &conn,
-        None,
-        crate::actor::Transport::Web,
-    )?
-    .ok_or_else(|| LificError::BadRequest("no admin account exists to sign in as".into()))?;
+    let admin =
+        crate::resolve_caller::resolve_caller_conn(&conn, None, crate::actor::Transport::Web)?
+            .ok_or_else(|| {
+                LificError::BadRequest("no admin account exists to sign in as".into())
+            })?;
     let admin = admin.user;
 
     let session = crate::db::queries::users::create_session(
@@ -720,9 +721,7 @@ pub(super) async fn refresh_session(
                 Err(rejected) => {
                     let retry = match rejected {
                         crate::ratelimit::ReservationRejection::First => rl.retry_after(&ip_key),
-                        crate::ratelimit::ReservationRejection::Second => {
-                            rl.retry_after(&user_key)
-                        }
+                        crate::ratelimit::ReservationRejection::Second => rl.retry_after(&user_key),
                     };
                     return Err(LificError::BadRequest(
                         crate::ratelimit::retry_after_message(
@@ -894,9 +893,7 @@ pub(super) async fn change_password(
                 Err(rejected) => {
                     let retry = match rejected {
                         crate::ratelimit::ReservationRejection::First => rl.retry_after(&ip_key),
-                        crate::ratelimit::ReservationRejection::Second => {
-                            rl.retry_after(&user_key)
-                        }
+                        crate::ratelimit::ReservationRejection::Second => rl.retry_after(&user_key),
                     };
                     return Err(LificError::BadRequest(
                         crate::ratelimit::retry_after_message(
@@ -2949,9 +2946,9 @@ mod tests {
     /// This exercises the handler directly with a resolved identity of None.
     #[tokio::test]
     async fn user_roster_handler_refuses_without_an_identity() {
-        let app = zero_user_app(crate::db::open_memory().expect("test db")).layer(
-            axum::Extension(None::<crate::resolve_caller::ResolvedIdentity>),
-        );
+        let app = zero_user_app(crate::db::open_memory().expect("test db")).layer(axum::Extension(
+            None::<crate::resolve_caller::ResolvedIdentity>,
+        ));
         let resp = json_get(&app, "/api/users").await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
@@ -3201,7 +3198,7 @@ mod tests {
             "/api/instance/settings",
             serde_json::json!({ "authz_enforced": true }),
         )
-            .await;
+        .await;
         assert_eq!(patch.status(), StatusCode::OK);
         assert_eq!(parse_json(patch).await["authz_enforced"], true);
 
@@ -3283,8 +3280,8 @@ mod tests {
                 "/api/instance/settings",
                 serde_json::json!({ "allow_signup": true })
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
     }
@@ -3561,16 +3558,20 @@ mod tests {
     // ── LIF-412: login verifies off the database writer ──────
 
     fn login_app(db: crate::db::DbPool) -> axum::Router {
-        with_client_ip_test_layers(crate::api::router(db, &[]), test_peer()).layer(
-            axum::Extension(crate::config::AuthConfig {
+        with_client_ip_test_layers(crate::api::router(db, &[]), test_peer()).layer(axum::Extension(
+            crate::config::AuthConfig {
                 allow_signup: true,
                 required: true,
                 secure_cookies: false,
-            }),
-        )
+            },
+        ))
     }
 
-    async fn login(app: &axum::Router, identity: &str, password: &str) -> (StatusCode, serde_json::Value) {
+    async fn login(
+        app: &axum::Router,
+        identity: &str,
+        password: &str,
+    ) -> (StatusCode, serde_json::Value) {
         let resp = json_post(
             app,
             "/api/auth/login",
@@ -4637,7 +4638,12 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::FORBIDDEN, "create is admin-only");
 
         for action in ["promote", "demote", "deactivate", "reactivate"] {
-            let resp = json_post(&app, &format!("/api/users/{}/{action}", admin.id), json!({})).await;
+            let resp = json_post(
+                &app,
+                &format!("/api/users/{}/{action}", admin.id),
+                json!({}),
+            )
+            .await;
             assert_eq!(
                 resp.status(),
                 StatusCode::FORBIDDEN,
@@ -4673,8 +4679,12 @@ mod tests {
         );
 
         for action in ["demote", "deactivate"] {
-            let resp =
-                json_post(&app, &format!("/api/users/{}/{action}", admin.id), json!({})).await;
+            let resp = json_post(
+                &app,
+                &format!("/api/users/{}/{action}", admin.id),
+                json!({}),
+            )
+            .await;
             assert_eq!(
                 resp.status(),
                 StatusCode::CONFLICT,
@@ -4682,7 +4692,10 @@ mod tests {
             );
             let data = parse_json(resp).await;
             assert!(
-                data["error"].as_str().unwrap().contains("last instance admin"),
+                data["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("last instance admin"),
                 "{action}: {data}"
             );
         }

--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -657,8 +657,8 @@ mod tests {
         .await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-        let listing = parse_json(json_get(&app, &format!("/api/issues/{issue_id}/comments")).await)
-            .await;
+        let listing =
+            parse_json(json_get(&app, &format!("/api/issues/{issue_id}/comments")).await).await;
         let comments = listing.as_array().unwrap();
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0]["content"], "Original");

--- a/src/api/comments.rs
+++ b/src/api/comments.rs
@@ -5,7 +5,11 @@ use axum::{
 
 use crate::authz;
 use crate::db::queries::comments::{self, CommentContext, CommentParent};
-use crate::db::{DbPool, models::*, queries};
+use crate::db::{
+    DbPool,
+    models::{Comment, CommentActor, CreateComment, MentionCandidate, Role, UpdateComment},
+    queries,
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
@@ -310,7 +314,7 @@ mod tests {
     use tower::ServiceExt;
 
     /// Set up a test app with a user, project, and issue pre-seeded.
-    /// Returns (app_with_user_extension, issue_id, user_id).
+    /// Returns (`app_with_user_extension`, `issue_id`, `user_id`).
     fn setup_comment_test() -> (axum::Router, i64, i64) {
         let db = crate::db::open_memory().expect("test db");
         let conn = db.write().unwrap();
@@ -1014,7 +1018,7 @@ mod tests {
     // ── LIF-106: page comments ─────────────────────────────────────────────
 
     /// Set up a test app with a user, project, and page pre-seeded.
-    /// Returns (app, page_id, user_id).
+    /// Returns (app, `page_id`, `user_id`).
     fn setup_page_comment_test() -> (axum::Router, i64, i64) {
         let db = crate::db::open_memory().expect("test db");
 
@@ -1383,7 +1387,7 @@ mod tests {
 
     // ── LIF-263: @mentions ──────────────────────────────────────────
 
-    /// Read the recorded mention user_ids for a comment straight from the DB.
+    /// Read the recorded mention `user_ids` for a comment straight from the DB.
     fn mention_ids(db: &crate::db::DbPool, comment_id: i64) -> Vec<i64> {
         let conn = db.read().unwrap();
         crate::db::queries::comments::list_mention_user_ids(&conn, comment_id).unwrap()

--- a/src/api/export.rs
+++ b/src/api/export.rs
@@ -1,15 +1,15 @@
+use axum::Extension;
 use axum::body::{Body, Bytes};
 use axum::extract::{Path, Query, State};
-use axum::http::{header, HeaderMap, HeaderValue};
+use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::IntoResponse;
-use axum::Extension;
 use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::sync::OwnedSemaphorePermit;
 
 use crate::authz;
-use crate::db::models::Role;
 use crate::db::DbPool;
+use crate::db::models::Role;
 use crate::error::LificError;
 
 use super::with_read;
@@ -369,7 +369,7 @@ mod tests {
     use tower::ServiceExt;
 
     use super::{
-        blocking_export, stream_response, ExportTestGate, PreparedExport, EXPORT_TEST_GATE,
+        EXPORT_TEST_GATE, ExportTestGate, PreparedExport, blocking_export, stream_response,
     };
     use crate::api::test_helpers::{
         json_post, parse_json, seed_project, setup_membership_test, test_app,
@@ -457,10 +457,12 @@ mod tests {
         let bundle = parse_json(resp).await;
         assert_eq!(bundle["root"], "TST");
         assert_eq!(bundle["files"][0]["path"], "TST/issues/tst-1-export-me.md");
-        assert!(bundle["files"][0]["content"]
-            .as_str()
-            .unwrap()
-            .contains("# Export me"));
+        assert!(
+            bundle["files"][0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("# Export me")
+        );
     }
 
     #[tokio::test]
@@ -560,10 +562,11 @@ mod tests {
             resp.headers()[axum::http::header::CONTENT_TYPE],
             "application/zip"
         );
-        assert!(resp
-            .headers()
-            .get(axum::http::header::CONTENT_LENGTH)
-            .is_none());
+        assert!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_LENGTH)
+                .is_none()
+        );
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         assert!(!body.is_empty());
         assert_eq!(&body[..2], b"PK");

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -4,7 +4,12 @@ use axum::{
 };
 
 use crate::authz;
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{
+        AttachmentEntity, CreateIssue, Issue, ListIssuesQuery, ProjectRelation, Role, UpdateIssue,
+    },
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
@@ -138,7 +143,7 @@ pub(super) async fn delete_issue_handler(
 
 /// LIF-363: every relation edge inside one project, in one round trip. Feeds
 /// the dependency-graph view; the client filters to `blocks` edges itself so
-/// a future view mode (e.g. relates_to clusters) needs no new endpoint.
+/// a future view mode (e.g. `relates_to` clusters) needs no new endpoint.
 pub(super) async fn project_relations(
     State(db): State<DbPool>,
     Extension(identity): Extension<Option<crate::resolve_caller::ResolvedIdentity>>,
@@ -656,7 +661,7 @@ mod tests {
 
     /// LIF-385: `status` and `priority` are enums, so a value outside the set
     /// is refused by the extractor. Before, it travelled all the way to
-    /// SQLite's CHECK constraint and came back as a 500.
+    /// `SQLite`'s CHECK constraint and came back as a 500.
     #[tokio::test]
     async fn out_of_set_status_and_priority_are_refused() {
         let app = test_app();

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -492,7 +492,11 @@ mod tests {
             );
         }
         // Numeric ids come along for O(1) node lookup client-side.
-        assert!(edges.iter().all(|e| e["source_id"].is_i64() && e["target_id"].is_i64()));
+        assert!(
+            edges
+                .iter()
+                .all(|e| e["source_id"].is_i64() && e["target_id"].is_i64())
+        );
 
         let resp = json_get(&app, &format!("/api/projects/{other_id}/relations")).await;
         let edges: serde_json::Value = parse_json(resp).await;
@@ -544,7 +548,8 @@ mod tests {
         assert_eq!(body["reversed"], true);
 
         let edges: serde_json::Value =
-            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await).await;
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await)
+                .await;
         let edges = edges.as_array().unwrap();
         assert_eq!(edges.len(), 1, "reversal must not duplicate the edge");
         assert_eq!(edges[0]["source_identifier"], "TST-2");
@@ -585,10 +590,9 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-        let edges: serde_json::Value = parse_json(
-            json_get(&lead_app, &format!("/api/projects/{project_id}/relations")).await,
-        )
-        .await;
+        let edges: serde_json::Value =
+            parse_json(json_get(&lead_app, &format!("/api/projects/{project_id}/relations")).await)
+                .await;
         let edges = edges.as_array().unwrap();
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0]["source_identifier"], "MEM-1");
@@ -620,7 +624,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
         let edges: serde_json::Value =
-            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await).await;
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await)
+                .await;
         assert_eq!(edges.as_array().unwrap().len(), 0);
 
         // An edge running the other way is not a match either: reversing
@@ -641,7 +646,8 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         let edges: serde_json::Value =
-            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await).await;
+            parse_json(json_get(&app, &format!("/api/projects/{project_id}/relations")).await)
+                .await;
         let edges = edges.as_array().unwrap();
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0]["source_identifier"], "TST-2");
@@ -679,7 +685,9 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/api/issues?project_id={project_id}&status=shipped"))
+                    .uri(format!(
+                        "/api/issues?project_id={project_id}&status=shipped"
+                    ))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )

--- a/src/api/members.rs
+++ b/src/api/members.rs
@@ -28,7 +28,10 @@ use axum::{
 
 use crate::authz;
 use crate::db::queries::members;
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{AddMember, ChangeMemberRole, MemberWithUser, ProjectMember, Role},
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
@@ -87,7 +90,7 @@ pub(super) async fn my_project_role(
     })?;
 
     Ok(Json(serde_json::json!({
-        "role": role.map(|r| r.as_str()),
+        "role": role.map(super::super::db::models::Role::as_str),
         "enforced": enforced,
         "is_admin": is_admin,
     })))
@@ -153,7 +156,7 @@ pub(super) async fn add_project_member(
     Ok(Json(member))
 }
 
-/// PATCH /api/projects/{id}/members/{user_id} — change an existing
+/// PATCH /`api/projects/{id}/members/{user_id`} — change an existing
 /// member's role. 404 if they aren't a member; 409 if this would demote
 /// the project's sole `lead`.
 ///
@@ -217,7 +220,7 @@ pub(super) async fn update_project_member(
     Ok(Json(member))
 }
 
-/// DELETE /api/projects/{id}/members/{user_id} — remove a member. 404 if
+/// DELETE /`api/projects/{id}/members/{user_id`} — remove a member. 404 if
 /// they aren't a member; 409 if they're the project's sole `lead`.
 ///
 /// Not gated on recency: removing a member only ever takes access away.
@@ -424,7 +427,7 @@ mod tests {
 
     #[tokio::test]
     async fn demoting_or_removing_the_sole_lead_is_rejected_until_a_second_lead_exists() {
-        let (db, _admin, lead, _maintainer, _viewer, _non_member, project_id) =
+        let (db, _admin, lead, _maintainer, _viewer, non_member, project_id) =
             setup_membership_test();
         let lead_app = app_as_user(db.clone(), &lead);
 
@@ -448,7 +451,7 @@ mod tests {
         let resp = json_post(
             &lead_app,
             &format!("/api/projects/{project_id}/members"),
-            serde_json::json!({ "user_id": _non_member.id, "role": "lead" }),
+            serde_json::json!({ "user_id": non_member.id, "role": "lead" }),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -492,7 +495,7 @@ mod tests {
         let resp = json_post(
             &lead_app,
             &format!("/api/projects/{project_id}/members"),
-            serde_json::json!({ "user_id": 999999 }),
+            serde_json::json!({ "user_id": 999_999 }),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -38,7 +38,11 @@ const UPLOAD_BODY_LIMIT: usize = 64 * 1024 * 1024;
 // `visible_project_ids` that produces its input. Re-exported here so the
 // route modules keep reaching for it through `super::`.
 use crate::authz::filter_visible;
-use crate::db::{DbPool, models::*, queries};
+use crate::db::{
+    DbPool,
+    models::{AuthUser, Role, SearchQuery, SearchResult},
+    queries,
+};
 use crate::error::LificError;
 
 pub use attachments::{AttachmentConfig, AttachmentUploadLimiter};
@@ -561,7 +565,7 @@ where
 
 /// Check if the authenticated user can manage a project (update settings, manage structure).
 /// Returns Ok(()) if: user is admin, or user is project lead.
-/// Default-deny: returns Forbidden when auth_user is None (OAuth tokens, legacy keys).
+/// Default-deny: returns Forbidden when `auth_user` is None (OAuth tokens, legacy keys).
 ///
 /// LIF-102: when `project.lead_user_id IS NULL`, only admins can edit. This
 /// prevents the previous behavior where `Some(user.id) == None` was always
@@ -2397,7 +2401,7 @@ mod authz_gating_tests {
                 tokio::time::timeout(std::time::Duration::from_secs(2), socket.next()).await;
             match received {
                 Ok(Some(Ok(Message::Text(text)))) => return serde_json::from_str(&text).unwrap(),
-                Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
+                Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => {}
                 other => panic!("expected a realtime event, got {other:?}"),
             }
         }
@@ -2439,10 +2443,7 @@ mod authz_gating_tests {
                 continue;
             }
             assert!(
-                matches!(
-                    received,
-                    Ok(Some(Ok(Message::Close(_)))) | Ok(Some(Err(_))) | Ok(None)
-                ),
+                matches!(received, Ok(Some(Ok(Message::Close(_)) | Err(_)) | None)),
                 "expected the socket to be closed, got {received:?}"
             );
             return;
@@ -2959,7 +2960,7 @@ mod authz_gating_tests {
     /// LIF-431: a browser talking straight to the server (no reverse proxy)
     /// sends no `x-forwarded-proto`/`forwarded` headers, and the same-origin
     /// check used to fail closed on the missing scheme — every direct
-    /// handshake at http://localhost:3456 got a 403 and realtime never
+    /// handshake at <http://localhost:3456> got a 403 and realtime never
     /// worked outside a proxy. Direct plaintext handshakes must pass; an
     /// https Origin against the plaintext listener must still be rejected.
     #[tokio::test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -348,16 +348,16 @@ pub fn router(db: DbPool, cors_origins: &[String]) -> Router {
         .route("/api/health", get(health))
         .layer(
             cors.allow_methods([
-                    axum::http::Method::GET,
-                    axum::http::Method::POST,
+                axum::http::Method::GET,
+                axum::http::Method::POST,
                 axum::http::Method::PATCH,
-                    axum::http::Method::PUT,
-                    axum::http::Method::DELETE,
-                ])
-                .allow_headers([
-                    axum::http::header::CONTENT_TYPE,
-                    axum::http::header::AUTHORIZATION,
-                ]),
+                axum::http::Method::PUT,
+                axum::http::Method::DELETE,
+            ])
+            .allow_headers([
+                axum::http::header::CONTENT_TYPE,
+                axum::http::header::AUTHORIZATION,
+            ]),
         )
         .with_state(db)
         .layer(Extension(cors_origins.to_vec()))
@@ -448,7 +448,7 @@ fn websocket_origin_allowed(headers: &HeaderMap, allowed_origins: &[String]) -> 
         Some(Ok(origin)) => {
             allowed_origins.iter().any(|allowed| allowed == origin)
                 || headers
-                .get(header::HOST)
+                    .get(header::HOST)
                     .and_then(|value| value.to_str().ok())
                     .is_some_and(|host| {
                         websocket_same_origin(origin, host, websocket_request_scheme(headers))
@@ -1133,7 +1133,7 @@ pub(crate) mod test_helpers {
             maintainer.id,
             Role::Maintainer,
         )
-            .unwrap();
+        .unwrap();
         crate::db::queries::members::upsert_member(&conn, project.id, viewer.id, Role::Viewer)
             .unwrap();
 
@@ -1642,8 +1642,8 @@ mod authz_gating_tests {
                 &format!("/api/issues/{issue_id}"),
                 serde_json::json!({"title": "hijack"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
         let non_member_app = app_as_user(db.clone(), &non_member);
@@ -1653,8 +1653,8 @@ mod authz_gating_tests {
                 &format!("/api/issues/{issue_id}"),
                 serde_json::json!({"title": "hijack"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 
@@ -1665,8 +1665,8 @@ mod authz_gating_tests {
                 &format!("/api/issues/{issue_id}"),
                 serde_json::json!({"title": "renamed"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
 
@@ -1774,8 +1774,8 @@ mod authz_gating_tests {
                 "/api/modules",
                 serde_json::json!({"project_id": project_id, "name": "Nope"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
         let non_member_app = app_as_user(db.clone(), &non_member);
@@ -1785,8 +1785,8 @@ mod authz_gating_tests {
                 "/api/labels",
                 serde_json::json!({"project_id": project_id, "name": "nope"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 
@@ -1797,8 +1797,8 @@ mod authz_gating_tests {
                 "/api/modules",
                 serde_json::json!({"project_id": project_id, "name": "Backend"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK,
             "maintainer should manage structure once enforcement loosens the gate"
         );
@@ -1808,8 +1808,8 @@ mod authz_gating_tests {
                 "/api/folders",
                 serde_json::json!({"project_id": project_id, "name": "Docs"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
     }
@@ -1828,8 +1828,8 @@ mod authz_gating_tests {
                 &format!("/api/projects/{project_id}"),
                 serde_json::json!({"name": "Nope"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 
@@ -1840,8 +1840,8 @@ mod authz_gating_tests {
                 &format!("/api/projects/{project_id}"),
                 serde_json::json!({"name": "Renamed"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
     }
@@ -1930,7 +1930,7 @@ mod authz_gating_tests {
                 maintainer.id,
                 Role::Maintainer,
             )
-                .unwrap();
+            .unwrap();
         }
         assert_eq!(
             json_post(&maintainer_app, "/api/issues/link", link_body)
@@ -1955,8 +1955,8 @@ mod authz_gating_tests {
                 "/api/pages",
                 serde_json::json!({"title": "Workspace doc"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
 
@@ -2019,8 +2019,8 @@ mod authz_gating_tests {
                 "/api/issues",
                 serde_json::json!({ "project_id": project_id, "title": "by admin" })
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
         assert_eq!(
@@ -2029,8 +2029,8 @@ mod authz_gating_tests {
                 &format!("/api/issues/{issue_id}"),
                 serde_json::json!({"title": "renamed by admin"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
 
@@ -2253,8 +2253,8 @@ mod authz_gating_tests {
                 "/api/modules",
                 serde_json::json!({"project_id": project_id, "name": "Nope"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
         let lead_app = app_as_user(db.clone(), &lead);
@@ -2264,8 +2264,8 @@ mod authz_gating_tests {
                 "/api/modules",
                 serde_json::json!({"project_id": project_id, "name": "Yes"})
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::OK
         );
 
@@ -2306,7 +2306,7 @@ mod authz_gating_tests {
             "/api/instance/settings",
             serde_json::json!({"authz_enforced": true}),
         )
-            .await;
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(parse_json(resp).await["authz_enforced"], true);
 

--- a/src/api/pages.rs
+++ b/src/api/pages.rs
@@ -4,7 +4,10 @@ use axum::{
 };
 
 use crate::authz;
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{AttachmentEntity, CreatePage, Page, Role, UpdatePage},
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
@@ -48,7 +51,7 @@ pub(super) struct PageQuery {
     /// LIF-112: filter pages by lifecycle status. Mirrors `?status=` on
     /// the issue list endpoint.
     status: Option<String>,
-    /// Sort column: sort_order (default), title, status, created, updated.
+    /// Sort column: `sort_order` (default), title, status, created, updated.
     /// Whitelisted in `list_pages`.
     order_by: Option<String>,
     /// Sort direction: asc (default) or desc.
@@ -210,7 +213,7 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    /// Seed a page-friendly project plus two labels, return (project_id).
+    /// Seed a page-friendly project plus two labels, return (`project_id`).
     async fn seed_project_with_labels(app: &axum::Router) -> i64 {
         let (project_id, _) = seed_project(app).await;
         for (name, color) in [("design", "#22C55E"), ("draft", "#F59E0B")] {

--- a/src/api/plans.rs
+++ b/src/api/plans.rs
@@ -5,7 +5,10 @@ use axum::{
 
 use crate::authz;
 use crate::db::queries::plans::{self, StepDoneEffect};
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{CreatePlan, CreatePlanStep, ListPlansQuery, Plan, Role, UpdatePlan},
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
@@ -728,7 +731,7 @@ mod tests {
         assert!(
             plan_b_after["steps"][0]["steps"]
                 .as_array()
-                .is_none_or(|children| children.is_empty()),
+                .is_none_or(std::vec::Vec::is_empty),
             "nothing may have been grafted under the foreign step: {plan_b_after}"
         );
 

--- a/src/api/plans.rs
+++ b/src/api/plans.rs
@@ -22,7 +22,8 @@ fn require_issue_project_role(
     identity: &Option<crate::resolve_caller::ResolvedIdentity>,
     issue_id: i64,
 ) -> Result<(), LificError> {
-    let project_id = with_read(db, |conn| crate::db::queries::get_issue(conn, issue_id))?.project_id;
+    let project_id =
+        with_read(db, |conn| crate::db::queries::get_issue(conn, issue_id))?.project_id;
     authz::require_role(db, identity, project_id, Role::Maintainer)
 }
 
@@ -96,7 +97,9 @@ pub(super) async fn create_plan(
     authz::require_role(&db, &identity, input.project_id, Role::Maintainer)?;
     require_create_plan_issue_roles(&db, &identity, &input)?;
     let plan = with_write(&db, |conn| plans::create_plan(conn, &input))?;
-    realtime.send(RealtimeEvent::ProjectUpdated { project_id: plan.project_id });
+    realtime.send(RealtimeEvent::ProjectUpdated {
+        project_id: plan.project_id,
+    });
     Ok(Json(plan))
 }
 
@@ -396,10 +399,20 @@ mod tests {
             assert_eq!(response.status(), StatusCode::OK);
         }
 
-        let first = body_json(json_get(&app, &format!("/api/plans?project_id={project_id}&order_by=id&limit=2")).await).await;
+        let first = body_json(
+            json_get(
+                &app,
+                &format!("/api/plans?project_id={project_id}&order_by=id&limit=2"),
+            )
+            .await,
+        )
+        .await;
         let first = first.as_array().unwrap();
         assert_eq!(first.len(), 2);
-        let first_ids = first.iter().map(|plan| plan["id"].as_i64().unwrap()).collect::<Vec<_>>();
+        let first_ids = first
+            .iter()
+            .map(|plan| plan["id"].as_i64().unwrap())
+            .collect::<Vec<_>>();
         let cursor_id = first[1]["id"].as_i64().unwrap();
 
         let response = json_get(

--- a/src/api/project_groups.rs
+++ b/src/api/project_groups.rs
@@ -313,7 +313,11 @@ mod tests {
 
         let resp = json_get(&app, "/api/project-groups").await;
         let groups = parse_json(resp).await;
-        assert_eq!(groups.as_array().unwrap().len(), 1, "the group itself stays");
+        assert_eq!(
+            groups.as_array().unwrap().len(),
+            1,
+            "the group itself stays"
+        );
         assert!(
             groups[0]["project_ids"].as_array().unwrap().is_empty(),
             "a project the caller can no longer see must not be listed"

--- a/src/api/project_groups.rs
+++ b/src/api/project_groups.rs
@@ -18,7 +18,10 @@ use axum::{
 
 use crate::authz;
 use crate::db::queries::project_groups;
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{AssignProjectGroup, CreateProjectGroup, ProjectGroup, Role, UpdateProjectGroup},
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 

--- a/src/api/projects.rs
+++ b/src/api/projects.rs
@@ -805,8 +805,7 @@ mod tests {
     /// filter_visible), not just the authz unit.
     #[tokio::test]
     async fn enforced_admin_sees_all_projects_non_member_sees_none() {
-        let (db, admin, _lead, _maint, _viewer, non_member, project_id) =
-            setup_membership_test();
+        let (db, admin, _lead, _maint, _viewer, non_member, project_id) = setup_membership_test();
 
         let resp = json_get(&app_as_user(db.clone(), &admin), "/api/projects").await;
         assert_eq!(resp.status(), StatusCode::OK);

--- a/src/api/projects.rs
+++ b/src/api/projects.rs
@@ -7,7 +7,13 @@ use std::sync::{Arc, Mutex, OnceLock, Weak};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::authz;
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{
+        CreateProject, Issue, IssueStatusCounts, ListIssuesQuery, Project, ReorderProjects, Role,
+        UpdateProject,
+    },
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
@@ -133,26 +139,23 @@ pub(super) async fn update_project(
         // When this grants a lead membership the gate re-runs against the
         // freshly read session user, so a lead revoked since the request
         // arrived cannot hand the role to anyone.
-        let gate_identity = match &recent {
-            Some((token, granter_id)) => {
-                let fresh = crate::auth::revalidate_recent_session(tx, token, *granter_id)?;
-                Some(crate::auth::fresh_identity(
-                    &fresh,
-                    crate::actor::Transport::Web,
-                ))
-            }
+        let gate_identity = if let Some((token, granter_id)) = &recent {
+            let fresh = crate::auth::revalidate_recent_session(tx, token, *granter_id)?;
+            Some(crate::auth::fresh_identity(
+                &fresh,
+                crate::actor::Transport::Web,
+            ))
+        } else {
             // Not a grant (a rename, or clearing the lead). No recency, but
             // still not the middleware's snapshot: the caller is re-read here
             // so a demoted admin cannot edit on the strength of a stale
             // `is_admin`.
-            None => {
-                let caller = super::require_user(&identity)?;
-                let fresh = crate::auth::fresh_caller(tx, caller.id)?;
-                Some(crate::auth::fresh_identity(
-                    &fresh,
-                    crate::actor::Transport::Web,
-                ))
-            }
+            let caller = super::require_user(&identity)?;
+            let fresh = crate::auth::fresh_caller(tx, caller.id)?;
+            Some(crate::auth::fresh_identity(
+                &fresh,
+                crate::actor::Transport::Web,
+            ))
         };
         crate::authz::require_role_conn(tx, &gate_identity, id, Role::Lead)?;
         crate::db::queries::update_project(tx, id, &input)
@@ -458,7 +461,7 @@ pub(super) fn import_github_with(
     };
     // A resource-ceiling refusal surfaces as 413 (see the `GithubImportError`
     // conversion in `crate::error`); GitHub being unreachable stays a 500.
-    let fetched = crate::import::github::collect(fetcher, slug, state, &status_map)?;
+    let imported = crate::import::github::collect(fetcher, slug, state, &status_map)?;
 
     // A dry run never mints a bot or writes; a real run resolves/creates the
     // import bot owned by the requester.
@@ -476,7 +479,7 @@ pub(super) fn import_github_with(
         }
     };
 
-    crate::import::run_import(db, project_id, bot, &fetched, req.dry_run)
+    crate::import::run_import(db, project_id, bot, &imported, req.dry_run)
 }
 
 #[cfg(test)]
@@ -801,8 +804,8 @@ mod tests {
     /// LIF-364 (dr.leech's report): with `authz_enforced` ON, an instance
     /// admin must see every project in `GET /api/projects` — including ones
     /// they are not a member of — while a plain non-member sees none. This
-    /// pins the full REST stack (identity extension → visible_project_ids →
-    /// filter_visible), not just the authz unit.
+    /// pins the full REST stack (identity extension → `visible_project_ids` →
+    /// `filter_visible`), not just the authz unit.
     #[tokio::test]
     async fn enforced_admin_sees_all_projects_non_member_sees_none() {
         let (db, admin, _lead, _maint, _viewer, non_member, project_id) = setup_membership_test();

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -44,8 +44,7 @@ pub(super) trait Structure: 'static {
 
     fn list(conn: &Connection, project_id: i64) -> Result<Vec<Self::Model>, LificError>;
     fn create(conn: &Connection, input: &Self::Create) -> Result<Self::Model, LificError>;
-    fn update(conn: &Connection, id: i64, input: &Self::Update)
-    -> Result<Self::Model, LificError>;
+    fn update(conn: &Connection, id: i64, input: &Self::Update) -> Result<Self::Model, LificError>;
     fn delete(conn: &Connection, id: i64) -> Result<(), LificError>;
 }
 
@@ -250,7 +249,9 @@ pub(super) async fn merge_label_handler(
     let label = with_write(&db, |conn| {
         crate::db::queries::merge_label(conn, id, input.into)
     })?;
-    realtime.send(RealtimeEvent::ProjectUpdated { project_id: source_project });
+    realtime.send(RealtimeEvent::ProjectUpdated {
+        project_id: source_project,
+    });
     Ok(Json(label))
 }
 

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -6,7 +6,13 @@ use rusqlite::Connection;
 
 use crate::authz;
 use crate::db::queries::ResourceTable;
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{
+        CreateFolder, CreateLabel, CreateModule, Folder, Label, Module, Role, UpdateFolder,
+        UpdateLabel, UpdateModule,
+    },
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -443,8 +443,8 @@ mod tests {
                 &non_member_app,
                 &format!("/api/projects/{project_id}/views/{view_id}")
             )
-                .await
-                .status(),
+            .await
+            .status(),
             StatusCode::FORBIDDEN
         );
     }

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -30,7 +30,10 @@ use axum::{
 
 use crate::authz;
 use crate::db::queries::views;
-use crate::db::{DbPool, models::*};
+use crate::db::{
+    DbPool,
+    models::{CreateSavedView, Role, SavedView, UpdateSavedView},
+};
 use crate::error::LificError;
 use crate::realtime::{RealtimeEvent, RealtimeHub};
 
@@ -75,7 +78,7 @@ pub(super) async fn create_view(
     Ok(Json(view))
 }
 
-/// PATCH /api/projects/{id}/views/{view_id} — rename, replace the config,
+/// PATCH /`api/projects/{id}/views/{view_id`} — rename, replace the config,
 /// and/or (un)set the default flag, all independently addressable. 404 if
 /// `view_id` doesn't exist, belongs to a different project, or belongs to a
 /// different user (see the module doc comment — never a 403 here).
@@ -95,7 +98,7 @@ pub(super) async fn update_view(
     Ok(Json(view))
 }
 
-/// DELETE /api/projects/{id}/views/{view_id} — same ownership 404 as PATCH.
+/// DELETE /`api/projects/{id}/views/{view_id`} — same ownership 404 as PATCH.
 pub(super) async fn delete_view(
     State(db): State<DbPool>,
     Extension(realtime): Extension<RealtimeHub>,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -611,7 +611,9 @@ fn oauth_blocked_reason(method: &Method, path: &str) -> Option<&'static str> {
     // nothing reaches here; the rule is here so moving them behind auth later
     // cannot hand a token authority over the flow that issued it.
     if path == "/oauth" || path.starts_with("/oauth/") {
-        return Some("OAuth client and token administration is not available to OAuth-token callers");
+        return Some(
+            "OAuth client and token administration is not available to OAuth-token callers",
+        );
     }
 
     None
@@ -957,21 +959,33 @@ pub async fn require_api_key(
         Ok(user) => user,
         Err(ApiKeyReject::BadChecksum) => {
             warn!("rejected API key with invalid checksum");
-            return (StatusCode::UNAUTHORIZED,
-                    [("WWW-Authenticate", www_auth.as_str())], "Invalid API key").into_response();
+            return (
+                StatusCode::UNAUTHORIZED,
+                [("WWW-Authenticate", www_auth.as_str())],
+                "Invalid API key",
+            )
+                .into_response();
         }
         Err(ApiKeyReject::Db) => {
             return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
         }
         Err(ApiKeyReject::NotFound) => {
             warn!("rejected invalid API key");
-            return (StatusCode::UNAUTHORIZED,
-                    [("WWW-Authenticate", www_auth.as_str())], "Invalid API key").into_response();
+            return (
+                StatusCode::UNAUTHORIZED,
+                [("WWW-Authenticate", www_auth.as_str())],
+                "Invalid API key",
+            )
+                .into_response();
         }
         Err(ApiKeyReject::HashMismatch) => {
             warn!("API key hash verification failed");
-            return (StatusCode::UNAUTHORIZED,
-                    [("WWW-Authenticate", www_auth.as_str())], "Invalid API key").into_response();
+            return (
+                StatusCode::UNAUTHORIZED,
+                [("WWW-Authenticate", www_auth.as_str())],
+                "Invalid API key",
+            )
+                .into_response();
         }
         Err(ApiKeyReject::Inactive) => {
             warn!("rejected API key: deactivated account, or a bot with a deactivated owner");
@@ -1242,22 +1256,12 @@ mod tests {
         let pool = test_db();
         let manager = create_key_manager().unwrap();
 
-        let live = create_api_key_with_expiry(
-            &pool,
-            &manager,
-            "live",
-            Some(&rfc3339_from_now(1)),
-            None,
-        )
-        .unwrap();
-        let dead = create_api_key_with_expiry(
-            &pool,
-            &manager,
-            "dead",
-            Some(&rfc3339_from_now(-1)),
-            None,
-        )
-        .unwrap();
+        let live =
+            create_api_key_with_expiry(&pool, &manager, "live", Some(&rfc3339_from_now(1)), None)
+                .unwrap();
+        let dead =
+            create_api_key_with_expiry(&pool, &manager, "dead", Some(&rfc3339_from_now(-1)), None)
+                .unwrap();
 
         assert!(
             validate_api_key(&pool, &manager, &live).is_ok(),
@@ -2560,7 +2564,12 @@ mod tests {
         state.required = false;
 
         let resp = operator_probe_app(state, pool.clone())
-            .oneshot(Request::builder().uri("/probe").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -2575,10 +2584,11 @@ mod tests {
     #[tokio::test]
     async fn auth_required_default_credentialless_request_still_401s() {
         let pool = test_db();
-        let resp = echo_app(test_auth_state(&pool)) // required: true
-            .oneshot(Request::builder().uri("/echo").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+        let resp =
+            echo_app(test_auth_state(&pool)) // required: true
+                .oneshot(Request::builder().uri("/echo").body(Body::empty()).unwrap())
+                .await
+                .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
@@ -2593,9 +2603,9 @@ mod tests {
         state.required = false;
 
         for bad in [
-            "lific_sk-garbage",          // malformed API key
-            "lific_sess_expiredorfake",  // unknown session
-            "lific_at_neverissued",      // unknown OAuth token
+            "lific_sk-garbage",         // malformed API key
+            "lific_sess_expiredorfake", // unknown session
+            "lific_at_neverissued",     // unknown OAuth token
         ] {
             let resp = echo_app(state.clone())
                 .oneshot(
@@ -2654,7 +2664,10 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        assert_eq!(bytes.as_ref(), format!("user:{user_id}:optionaluser:false").as_bytes());
+        assert_eq!(
+            bytes.as_ref(),
+            format!("user:{user_id}:optionaluser:false").as_bytes()
+        );
     }
 
     #[tokio::test]
@@ -2971,10 +2984,7 @@ mod tests {
 
     #[test]
     fn is_attachment_download_matches_numeric_id_get() {
-        assert!(is_attachment_download(
-            &Method::GET,
-            "/api/attachments/5"
-        ));
+        assert!(is_attachment_download(&Method::GET, "/api/attachments/5"));
         assert!(is_attachment_download(
             &Method::GET,
             "/api/attachments/12345"
@@ -2983,10 +2993,7 @@ mod tests {
 
     #[test]
     fn is_attachment_download_tolerates_trailing_slash() {
-        assert!(is_attachment_download(
-            &Method::GET,
-            "/api/attachments/7/"
-        ));
+        assert!(is_attachment_download(&Method::GET, "/api/attachments/7/"));
     }
 
     #[test]
@@ -3006,10 +3013,7 @@ mod tests {
             &Method::GET,
             "/api/attachments/5/extra"
         ));
-        assert!(!is_attachment_download(
-            &Method::GET,
-            "/api/attachments/5x"
-        ));
+        assert!(!is_attachment_download(&Method::GET, "/api/attachments/5x"));
     }
 
     /// LIF-418: a thumbnail is loaded by an `<img>` exactly like the full
@@ -3049,10 +3053,7 @@ mod tests {
             &Method::DELETE,
             "/api/attachments/5"
         ));
-        assert!(!is_attachment_download(
-            &Method::POST,
-            "/api/attachments/5"
-        ));
+        assert!(!is_attachment_download(&Method::POST, "/api/attachments/5"));
     }
 
     #[test]
@@ -3060,7 +3061,9 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(
             "cookie",
-            "foo=bar; lific_token=lific_sess_abc123; baz=qux".parse().unwrap(),
+            "foo=bar; lific_token=lific_sess_abc123; baz=qux"
+                .parse()
+                .unwrap(),
         );
         assert_eq!(
             session_cookie_token(&headers).as_deref(),
@@ -3512,11 +3515,7 @@ mod tests {
             ("POST", "/api/auth/bots", Some(serde_json::json!({}))),
             ("POST", "/api/auth/bots/1/disconnect", None),
             ("DELETE", "/api/auth/bots/1", None),
-            (
-                "POST",
-                "/api/auth/me/password",
-                Some(serde_json::json!({})),
-            ),
+            ("POST", "/api/auth/me/password", Some(serde_json::json!({}))),
             ("DELETE", "/api/auth/me/sessions", None),
             ("POST", "/api/users/1/promote", None),
         ];

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -104,8 +104,8 @@ impl PreparedApiKey {
         })?;
         Ok(Self {
             plaintext: api_key.key().expose_secret().to_string(),
-            hash: api_key.expose_hash().hash().to_string(),
-            key_id: api_key.expose_hash().key_id().to_string(),
+            hash: api_key.expose_hash().hash().clone(),
+            key_id: api_key.expose_hash().key_id().clone(),
         })
     }
 
@@ -249,7 +249,7 @@ pub fn session_bearer_token(headers: &HeaderMap) -> Result<String, crate::error:
 /// hand back **the user as the database has them right now**.
 ///
 /// Callers run this as the first statement of the writer transaction that
-/// grants something. SQLite serializes writers, so an account lockdown is
+/// grants something. `SQLite` serializes writers, so an account lockdown is
 /// either wholly before this check (which then fails, because the session row
 /// is gone) or wholly after the write (which then revokes what was granted).
 /// There is no interleaving that leaves a live credential behind a revoked
@@ -658,7 +658,7 @@ fn insert_identity_extensions(
 /// Axum middleware that validates Bearer tokens and resolves user identity.
 ///
 /// After successful auth, inserts `Extension<Option<AuthUser>>` into the request:
-/// - `Some(user)` if the token resolves to a user (session, or API key with user_id)
+/// - `Some(user)` if the token resolves to a user (session, or API key with `user_id`)
 /// - `None` if the token is valid but has no user association (legacy keys, OAuth)
 ///
 /// It also inserts `Extension<CredentialKind>` (LIF-403) so downstream code
@@ -1052,7 +1052,7 @@ enum ApiKeyReject {
 
 /// Shared API-key authentication for both the HTTP middleware and the stdio
 /// `LIFIC_TOKEN` resolver. Verifies the checksum, resolves the key row by
-/// derived key_id (with the pre-migration-010 scan-and-backfill fallback), and
+/// derived `key_id` (with the pre-migration-010 scan-and-backfill fallback), and
 /// verifies the stored hash — exactly one copy of that logic (LIFIC-18 review:
 /// previously duplicated between `require_api_key` and `resolve_api_key_user`).
 ///
@@ -1113,7 +1113,7 @@ fn validate_api_key(
                 })
             })
             .ok()?
-            .filter_map(|r| r.ok())
+            .filter_map(std::result::Result::ok)
             .collect();
         for row in rows {
             if let Ok(KeyStatus::Valid) = manager.verify(&secure_token, &row.hash) {
@@ -1646,8 +1646,8 @@ mod tests {
     /// Everything else about this interaction is asserted sequentially, which
     /// can only show that each order produces the right outcome. What is
     /// claimed on top of that is *linearizability*: that no interleaving
-    /// exists, because both sides run as one SQLite `BEGIN IMMEDIATE`
-    /// transaction and SQLite admits one writer at a time. That claim needs
+    /// exists, because both sides run as one `SQLite` `BEGIN IMMEDIATE`
+    /// transaction and `SQLite` admits one writer at a time. That claim needs
     /// two real connections to a real file, and this is where it is tested.
     ///
     /// Setup: two `DbPool`s opened separately on one tempfile database, which
@@ -1658,7 +1658,7 @@ mod tests {
     /// Exclusion is observed rather than assumed. While one pool holds its
     /// transaction open, a third raw connection with `busy_timeout = 0` tries
     /// `BEGIN IMMEDIATE` and must be refused *now* rather than made to wait.
-    /// That is SQLite telling us directly that the writer is held.
+    /// That is `SQLite` telling us directly that the writer is held.
     mod lockdown_race {
         use super::*;
         use std::sync::mpsc;
@@ -1687,7 +1687,7 @@ mod tests {
         ///
         /// Opens its own connection and disables the busy handler, so
         /// `BEGIN IMMEDIATE` resolves immediately either way: it takes the
-        /// lock (nobody is writing) or returns SQLITE_BUSY (somebody is). No
+        /// lock (nobody is writing) or returns `SQLITE_BUSY` (somebody is). No
         /// waiting, so no flakiness.
         fn writer_is_held(path: &std::path::Path) -> bool {
             let probe = rusqlite::Connection::open(path).expect("probe connection");
@@ -2720,7 +2720,7 @@ mod tests {
     // These drive the real `require_api_key` middleware: a 401 means the key
     // was refused, a 200 means it authenticated (body "none" = no bound user).
 
-    /// Overwrite a key's expires_at directly (bypassing the CLI/date parsing)
+    /// Overwrite a key's `expires_at` directly (bypassing the CLI/date parsing)
     /// so enforcement can be exercised deterministically.
     fn set_key_expiry(pool: &db::DbPool, name: &str, expires_at: &str) {
         let conn = pool.write().unwrap();
@@ -3642,9 +3642,7 @@ mod tests {
             format!(
                 "{}|{}",
                 actor.transport.as_str(),
-                identity
-                    .map(|i| i.transport.as_str().to_string())
-                    .unwrap_or_else(|| "none".into())
+                identity.map_or_else(|| "none".into(), |i| i.transport.as_str().to_string())
             )
         }
 

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -70,6 +70,7 @@ use crate::resolve_caller::ResolvedIdentity;
 /// (shouldn't normally happen, but the FK allows `owner_id IS NULL`) is
 /// evaluated as itself. Non-bot users pass through unchanged. Returns `None`
 /// only when `auth_user` itself is `None`.
+#[allow(clippy::ref_option)]
 pub fn effective_user(conn: &Connection, auth_user: &Option<AuthUser>) -> Option<AuthUser> {
     let user = auth_user.as_ref()?;
 
@@ -107,6 +108,7 @@ pub fn effective_user(conn: &Connection, auth_user: &Option<AuthUser>) -> Option
 /// (the type [`resolve_caller`] produces), but `effective_user` still operates
 /// on `AuthUser` — its job (map a bot to its owner) is user-level, not
 /// identity-level. This is the single adapter between the two.
+#[allow(clippy::ref_option)]
 fn user_of(identity: &Option<ResolvedIdentity>) -> Option<AuthUser> {
     identity.as_ref().map(|i| i.user.clone())
 }
@@ -144,6 +146,7 @@ fn insufficient_role(min: Role) -> LificError {
 /// unbound API key now resolves (via [`resolve_caller`]) to the first admin, so
 /// `identity.user.is_admin` catches it in the same `is_admin` short-circuit
 /// below.
+#[allow(clippy::ref_option)]
 pub fn require_role(
     db: &DbPool,
     identity: &Option<ResolvedIdentity>,
@@ -172,6 +175,7 @@ pub(crate) fn can_view_project(
     ))
 }
 
+#[allow(clippy::ref_option)]
 pub(crate) fn require_role_conn(
     conn: &Connection,
     identity: &Option<ResolvedIdentity>,
@@ -198,6 +202,7 @@ pub(crate) fn require_role_conn(
 }
 
 /// Default-deny mode: resolve the membership row and compare against `min`.
+#[allow(clippy::ref_option)]
 fn require_role_enforced(
     conn: &Connection,
     effective: &Option<AuthUser>,
@@ -216,6 +221,7 @@ fn require_role_enforced(
 /// Legacy mode: reproduces today's exact behavior. Only `min = Lead` can
 /// ever deny; `Maintainer`/`Viewer` allow any request, matching every
 /// existing (non-lead-gated) REST route today.
+#[allow(clippy::ref_option)]
 fn require_role_legacy(
     conn: &Connection,
     effective: &Option<AuthUser>,
@@ -276,6 +282,7 @@ fn require_lead_legacy(
 /// - enforced: `require_role(.., Maintainer)` — the new, looser bar.
 /// - legacy: `require_role(.., Lead)` — literally what `require_project_lead`
 ///   already does, unchanged.
+#[allow(clippy::ref_option)]
 pub fn require_structure_role(
     db: &DbPool,
     identity: &Option<ResolvedIdentity>,
@@ -303,7 +310,8 @@ pub fn require_structure_role(
 /// `identity.user.is_admin` — so an unbound API key (which resolves to the
 /// first admin) is admitted, where before it was `None` and denied. That is
 /// the intended operator-works-everywhere fix (AC: "unbound keys resolve via
-/// first_admin"), not a regression: real non-admin users are still denied.
+/// `first_admin`"), not a regression: real non-admin users are still denied.
+#[allow(clippy::ref_option)]
 pub fn require_project_delete_role(
     db: &DbPool,
     identity: &Option<ResolvedIdentity>,
@@ -320,6 +328,7 @@ pub fn require_project_delete_role(
 /// from a role snapshot taken before the request was routed means an admin
 /// demoted, or a lead removed, a moment ago can still do it. The read has to
 /// be inside the transaction that acts on it.
+#[allow(clippy::ref_option)]
 pub(crate) fn require_project_delete_role_conn(
     conn: &Connection,
     identity: &Option<ResolvedIdentity>,
@@ -345,6 +354,7 @@ pub(crate) fn require_project_delete_role_conn(
 /// LIFIC-10/14: consumes [`ResolvedIdentity`]; the operator bypass is now
 /// `identity.user.is_admin` (an unbound key resolves to the first admin),
 /// not a separate carrier signal.
+#[allow(clippy::ref_option)]
 pub fn require_workspace_admin(
     db: &DbPool,
     identity: &Option<ResolvedIdentity>,
@@ -353,6 +363,7 @@ pub fn require_workspace_admin(
     require_workspace_admin_conn(&conn, identity)
 }
 
+#[allow(clippy::ref_option)]
 pub(crate) fn require_workspace_admin_conn(
     conn: &Connection,
     identity: &Option<ResolvedIdentity>,
@@ -369,6 +380,7 @@ pub(crate) fn require_workspace_admin_conn(
     }
 }
 
+#[allow(clippy::ref_option)]
 pub(crate) fn require_project_or_workspace_role_conn(
     conn: &Connection,
     identity: &Option<ResolvedIdentity>,
@@ -395,6 +407,7 @@ pub(crate) fn require_project_or_workspace_role_conn(
 /// LIFIC-10/14: consumes [`ResolvedIdentity`]; the operator bypass is now
 /// `identity.user.is_admin` (an unbound key resolves to the first admin and
 /// short-circuits below).
+#[allow(clippy::ref_option)]
 pub fn visible_project_ids(
     db: &DbPool,
     identity: &Option<ResolvedIdentity>,
@@ -420,12 +433,13 @@ pub fn visible_project_ids(
 /// list of items. `None` (unrestricted — admin, or enforcement off) keeps
 /// everything. `Some(ids)` keeps only items whose `project_id_of` result is
 /// `Some(pid)` with `pid` in `ids` — a workspace-level item (`None`
-/// project_id) is therefore excluded for any non-admin once enforcement is
+/// `project_id`) is therefore excluded for any non-admin once enforcement is
 /// on, matching design decision #10 (workspace pages are admin-only).
 ///
 /// LIF-377: one implementation for both read surfaces. REST and MCP each had
 /// a byte-identical copy, so "silently absent, never an error" could drift on
 /// one transport without the other noticing.
+#[allow(clippy::ref_option)]
 pub fn filter_visible<T>(
     items: Vec<T>,
     visible: &Option<HashSet<i64>>,
@@ -455,6 +469,7 @@ mod tests {
     /// the gates — only `user` drives membership/admin checks). Mirrors what
     /// [`crate::resolve_caller`] produces in production for a credential that
     /// already names a user.
+    #[allow(clippy::unnecessary_wraps)]
     fn id(user: AuthUser) -> Option<ResolvedIdentity> {
         Some(ResolvedIdentity {
             user,
@@ -507,32 +522,29 @@ mod tests {
 
     /// Seed a bot user owned by `owner_id` (or ownerless when `None`).
     fn seed_bot(conn: &Connection, username: &str, owner_id: Option<i64>) -> AuthUser {
-        match owner_id {
-            Some(owner) => {
-                let bot =
-                    queries::users::create_bot_user(conn, owner, username, username, None).unwrap();
-                AuthUser {
-                    id: bot.id,
-                    username: bot.username,
-                    display_name: bot.display_name,
-                    is_admin: bot.is_admin,
-                }
+        if let Some(owner) = owner_id {
+            let bot =
+                queries::users::create_bot_user(conn, owner, username, username, None).unwrap();
+            AuthUser {
+                id: bot.id,
+                username: bot.username,
+                display_name: bot.display_name,
+                is_admin: bot.is_admin,
             }
-            None => {
-                // create_bot_user requires an owner; insert an ownerless bot directly.
-                conn.execute(
-                    "INSERT INTO users (username, email, password_hash, display_name, is_admin, is_bot, owner_id)
-                     VALUES (?1, ?2, 'x', ?1, 0, 1, NULL)",
-                    rusqlite::params![username, format!("{username}@bot.local")],
-                )
-                .unwrap();
-                let id = conn.last_insert_rowid();
-                AuthUser {
-                    id,
-                    username: username.into(),
-                    display_name: username.into(),
-                    is_admin: false,
-                }
+        } else {
+            // create_bot_user requires an owner; insert an ownerless bot directly.
+            conn.execute(
+                "INSERT INTO users (username, email, password_hash, display_name, is_admin, is_bot, owner_id)
+                 VALUES (?1, ?2, 'x', ?1, 0, 1, NULL)",
+                rusqlite::params![username, format!("{username}@bot.local")],
+            )
+            .unwrap();
+            let id = conn.last_insert_rowid();
+            AuthUser {
+                id,
+                username: username.into(),
+                display_name: username.into(),
+                is_admin: false,
             }
         }
     }

--- a/src/authz_coverage_tests.rs
+++ b/src/authz_coverage_tests.rs
@@ -298,9 +298,7 @@ fn rest_manifest() -> HashMap<(&'static str, &'static str), Classification> {
         ),
         (
             ("PUT", "/api/projects/reorder"),
-            Exempt(
-                "require_user only; instance-wide sidebar chrome, not a project edit — LIF-233",
-            ),
+            Exempt("require_user only; instance-wide sidebar chrome, not a project edit — LIF-233"),
         ),
         (("GET", "/api/projects/{id}"), Gated(Viewer)),
         (("PUT", "/api/projects/{id}"), Gated(Lead)),

--- a/src/authz_coverage_tests.rs
+++ b/src/authz_coverage_tests.rs
@@ -608,9 +608,9 @@ fn every_mcp_tool_is_classified() {
     let mut unclassified: Vec<&str> = tools
         .iter()
         .filter(|name| !manifest.contains_key(name.as_str()))
-        .map(|s| s.as_str())
+        .map(std::string::String::as_str)
         .collect();
-    unclassified.sort();
+    unclassified.sort_unstable();
     unclassified.dedup();
 
     assert!(
@@ -634,7 +634,7 @@ fn mcp_manifest_has_no_stale_entries() {
         .filter(|name| !tools.contains(**name))
         .copied()
         .collect();
-    stale.sort();
+    stale.sort_unstable();
 
     assert!(
         stale.is_empty(),

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -9,11 +9,11 @@ use crate::config::BackupConfig;
 use crate::db::DbPool;
 use crate::dump;
 
-/// Start the background backup task. Returns the JoinHandle.
+/// Start the background backup task. Returns the `JoinHandle`.
 pub fn start_backup_task(
     pool: Arc<DbPool>,
     db_path: PathBuf,
-    config: BackupConfig,
+    config: &BackupConfig,
 ) -> tokio::task::JoinHandle<()> {
     let backup_dir = if config.dir.is_absolute() {
         config.dir.clone()
@@ -166,9 +166,7 @@ fn run_backup(
 
     match dump::write_dump(pool, db_path, &backup_path) {
         Ok(manifest) => {
-            let size = std::fs::metadata(&backup_path)
-                .map(|m| m.len())
-                .unwrap_or(0);
+            let size = std::fs::metadata(&backup_path).map_or(0, |m| m.len());
             info!(
                 path = %backup_path.display(),
                 size_kb = size / 1024,
@@ -209,7 +207,7 @@ fn run_backup(
 /// default install keeps the append-only history it has always kept. Anything
 /// larger deletes rows whose `ts` predates the cutoff.
 ///
-/// The cutoff is computed by SQLite itself (`datetime('now', '-N days')`)
+/// The cutoff is computed by `SQLite` itself (`datetime('now', '-N days')`)
 /// rather than in Rust: `audit_log.ts` is written by the migration-018
 /// triggers as `datetime('now')`, so comparing against a value from the same
 /// clock and the same format is the only way the comparison is honest. The
@@ -261,7 +259,7 @@ fn sweep_stale_tmps(backup_dir: &Path, db_stem: &str) {
             return;
         }
     };
-    for entry in entries.filter_map(|e| e.ok()) {
+    for entry in entries.filter_map(std::result::Result::ok) {
         let path = entry.path();
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
@@ -307,7 +305,7 @@ fn sweep_stale_tmps(backup_dir: &Path, db_stem: &str) {
         match result {
             Ok(()) => info!(path = %path.display(), "removed stale backup staging file"),
             Err(e) => {
-                warn!(path = %path.display(), error = %e, "failed to remove stale staging file")
+                warn!(path = %path.display(), error = %e, "failed to remove stale staging file");
             }
         }
     }
@@ -324,12 +322,11 @@ fn rotate_backups(backup_dir: &Path, db_stem: &str, retain: usize) {
     let prefix = format!("{db_stem}_");
     let mut backups: Vec<PathBuf> = match std::fs::read_dir(backup_dir) {
         Ok(entries) => entries
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .map(|e| e.path())
             .filter(|p| {
-                let name = match p.file_name().and_then(|n| n.to_str()) {
-                    Some(n) => n,
-                    None => return false,
+                let Some(name) = p.file_name().and_then(|n| n.to_str()) else {
+                    return false;
                 };
                 if !name.starts_with(&prefix) {
                     return false;
@@ -407,7 +404,10 @@ mod tests {
 
         rotate_backups(dir, "lific", 3);
 
-        let remaining: Vec<_> = fs::read_dir(dir).unwrap().filter_map(|e| e.ok()).collect();
+        let remaining: Vec<_> = fs::read_dir(dir)
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .collect();
         assert_eq!(remaining.len(), 3);
 
         // Oldest two (01, 02) should be gone, newest three (03, 04, 05) kept
@@ -526,7 +526,7 @@ mod tests {
         );
         let archives = fs::read_dir(&backup_dir)
             .unwrap()
-            .filter_map(|entry| entry.ok())
+            .filter_map(std::result::Result::ok)
             .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tar.gz"))
             .count();
         assert_eq!(archives, 1, "and the backup still produced its archive");
@@ -675,7 +675,7 @@ mod tests {
         // Exactly one `.tar.gz` archive, no bare `.db` snapshot.
         let archives: Vec<_> = fs::read_dir(&backup_dir)
             .unwrap()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .map(|e| e.file_name().to_string_lossy().to_string())
             .filter(|n| n.ends_with(".tar.gz"))
             .collect();
@@ -703,7 +703,10 @@ mod tests {
                 .any(|n| n == &format!("attachments/{blob_name}"))
         );
         assert!(
-            !names.iter().any(|n| n.ends_with(".tmp")),
+            !names.iter().any(|n| {
+                n.rsplit_once('.')
+                    .is_some_and(|(_, extension)| extension.eq_ignore_ascii_case("tmp"))
+            }),
             "in-progress .tmp writes must not be archived: {names:?}"
         );
     }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -234,7 +234,11 @@ fn prune_audit_log(pool: &DbPool, audit_retention_days: Option<u32>) {
         rusqlite::params![cutoff],
     ) {
         Ok(0) => {}
-        Ok(deleted) => info!(deleted, retention_days = days, "pruned old audit log entries"),
+        Ok(deleted) => info!(
+            deleted,
+            retention_days = days,
+            "pruned old audit log entries"
+        ),
         Err(e) => warn!(error = %e, "audit log pruning failed"),
     }
 }
@@ -331,8 +335,7 @@ fn rotate_backups(backup_dir: &Path, db_stem: &str, retain: usize) {
                     return false;
                 }
                 // New archives (`.tar.gz`) or legacy snapshots (`.db`).
-                name.ends_with(".tar.gz")
-                    || p.extension().and_then(|e| e.to_str()) == Some("db")
+                name.ends_with(".tar.gz") || p.extension().and_then(|e| e.to_str()) == Some("db")
             })
             .collect(),
         Err(e) => {
@@ -553,7 +556,13 @@ mod tests {
         let other_stem = dir.join("other_20260101_120000.tar.archive.tmp");
         let real_backup = dir.join("lific_20260101_120000.tar.gz");
         let stale_dir = dir.join(".lific-dump-stale");
-        for p in [&stale_snap, &stale_arch, &fresh_arch, &other_stem, &real_backup] {
+        for p in [
+            &stale_snap,
+            &stale_arch,
+            &fresh_arch,
+            &other_stem,
+            &real_backup,
+        ] {
             fs::write(p, "x").unwrap();
         }
         fs::create_dir(&stale_dir).unwrap();
@@ -562,10 +571,7 @@ mod tests {
         backdate(&stale_arch, old);
         backdate(&other_stem, old);
         backdate(&real_backup, old);
-        backdate(
-            &stale_dir.join("activity"),
-            old,
-        );
+        backdate(&stale_dir.join("activity"), old);
 
         sweep_stale_tmps(dir, "lific");
 
@@ -573,8 +579,14 @@ mod tests {
         assert!(!stale_arch.exists(), "stale archive tmp must be swept");
         assert!(fresh_arch.exists(), "fresh staging tmp must survive");
         assert!(other_stem.exists(), "other stems are not ours to sweep");
-        assert!(real_backup.exists(), "real archives are rotation's job, not the sweep's");
-        assert!(!stale_dir.exists(), "stale dump staging directory must be swept");
+        assert!(
+            real_backup.exists(),
+            "real archives are rotation's job, not the sweep's"
+        );
+        assert!(
+            !stale_dir.exists(),
+            "stale dump staging directory must be swept"
+        );
     }
 
     #[test]
@@ -680,8 +692,16 @@ mod tests {
             .map(|e| e.unwrap().path().unwrap().to_string_lossy().to_string())
             .collect();
         assert!(names.iter().any(|n| n == crate::dump::ARCHIVE_DB_NAME));
-        assert!(names.iter().any(|n| n == crate::dump::ARCHIVE_MANIFEST_NAME));
-        assert!(names.iter().any(|n| n == &format!("attachments/{blob_name}")));
+        assert!(
+            names
+                .iter()
+                .any(|n| n == crate::dump::ARCHIVE_MANIFEST_NAME)
+        );
+        assert!(
+            names
+                .iter()
+                .any(|n| n == &format!("attachments/{blob_name}"))
+        );
         assert!(
             !names.iter().any(|n| n.ends_with(".tmp")),
             "in-progress .tmp writes must not be archived: {names:?}"

--- a/src/cli/agents_md.rs
+++ b/src/cli/agents_md.rs
@@ -100,7 +100,8 @@ pub fn write(path: &Path, project: Option<&str>) -> Result<AgentsAction, String>
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
     }
-    std::fs::write(path, contents).map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    std::fs::write(path, contents)
+        .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
     Ok(action)
 }
 
@@ -224,7 +225,10 @@ mod tests {
         std::fs::write(&path, "Top.\n").unwrap();
         write(&path, Some("OLD")).unwrap();
         // Append trailing content after the block to prove it's preserved.
-        let with_trailer = format!("{}\n\nTrailing note.\n", std::fs::read_to_string(&path).unwrap().trim_end());
+        let with_trailer = format!(
+            "{}\n\nTrailing note.\n",
+            std::fs::read_to_string(&path).unwrap().trim_end()
+        );
         std::fs::write(&path, with_trailer).unwrap();
 
         let action = write(&path, Some("NEW")).unwrap();

--- a/src/cli/connect/clients.rs
+++ b/src/cli/connect/clients.rs
@@ -251,8 +251,12 @@ impl ClientSpec {
         // token into the client's env field as LIFIC_TOKEN so the spawned
         // server resolves the caller as the bound agent. Clients that can't
         // carry an env map get the token silently dropped (i.e. write nothing).
-        if let (Transport::Stdio { token: Some(tok), .. }, Some(env_key)) =
-            (&cfg.transport, self.stdio_env_key)
+        if let (
+            Transport::Stdio {
+                token: Some(tok), ..
+            },
+            Some(env_key),
+        ) = (&cfg.transport, self.stdio_env_key)
         {
             entry.value[env_key] = serde_json::json!({ "LIFIC_TOKEN": tok });
         }
@@ -455,9 +459,7 @@ pub fn all_clients() -> Vec<ClientSpec> {
                             "claude_desktop_config.json",
                         ],
                     ),
-                    Os::Windows => {
-                        config_dir(b, &["Claude", "claude_desktop_config.json"])
-                    }
+                    Os::Windows => config_dir(b, &["Claude", "claude_desktop_config.json"]),
                     Os::Linux => config_dir(b, &["Claude", "claude_desktop_config.json"]),
                 })
             },
@@ -1037,7 +1039,10 @@ mod tests {
         assert_eq!(e.top_key, "mcp");
         assert_eq!(e.value["type"], "remote");
         assert_eq!(e.value["url"], "http://127.0.0.1:3456/mcp");
-        assert_eq!(e.value["headers"]["Authorization"], "Bearer lific_sk-live-KEY");
+        assert_eq!(
+            e.value["headers"]["Authorization"],
+            "Bearer lific_sk-live-KEY"
+        );
         assert_eq!(e.value["enabled"], true);
     }
 
@@ -1055,9 +1060,7 @@ mod tests {
 
     #[test]
     fn opencode_stdio_token_writes_into_environment_field() {
-        let e = find_client("opencode")
-            .unwrap()
-            .compile(&stdio_token_cfg());
+        let e = find_client("opencode").unwrap().compile(&stdio_token_cfg());
         assert_eq!(e.value["type"], "local");
         // Command stays unchanged.
         assert_eq!(
@@ -1065,7 +1068,10 @@ mod tests {
             serde_json::json!(["lific", "--db", "/abs/lific.db", "mcp"])
         );
         // opencode names its env field `environment`.
-        assert_eq!(e.value["environment"]["LIFIC_TOKEN"], "lific_sk-live-AGENTTOKEN");
+        assert_eq!(
+            e.value["environment"]["LIFIC_TOKEN"],
+            "lific_sk-live-AGENTTOKEN"
+        );
     }
 
     #[test]
@@ -1147,7 +1153,9 @@ mod tests {
 
     #[test]
     fn claude_desktop_remote_uses_mcp_remote_shim() {
-        let e = find_client("claude-desktop").unwrap().compile(&remote_cfg());
+        let e = find_client("claude-desktop")
+            .unwrap()
+            .compile(&remote_cfg());
         assert_eq!(e.value["command"], "npx");
         let args = e.value["args"].as_array().unwrap();
         assert!(args.iter().any(|a| a == "mcp-remote"));
@@ -1201,9 +1209,7 @@ mod tests {
                 .unwrap()
                 .path_for(&base, Scope::Global)
                 .unwrap(),
-            PathBuf::from(
-                "C:\\Users\\tester\\AppData\\Roaming/Claude/claude_desktop_config.json"
-            )
+            PathBuf::from("C:\\Users\\tester\\AppData\\Roaming/Claude/claude_desktop_config.json")
         );
     }
 

--- a/src/cli/connect/clients.rs
+++ b/src/cli/connect/clients.rs
@@ -27,7 +27,7 @@ pub enum Transport {
     },
     /// Local stdio server: the client spawns `lific --db <db> mcp` itself.
     Stdio {
-        /// Absolute path to the SQLite database the spawned server should open.
+        /// Absolute path to the `SQLite` database the spawned server should open.
         db_path: String,
         /// The agent credential carried by this stdio session (LIFIC-18). Written
         /// into the client config's env field as `LIFIC_TOKEN` so the spawned
@@ -217,7 +217,7 @@ pub struct ClientSpec {
     pub oauth: OauthSupport,
     pub format: Format,
     /// The env-field name this client uses for a stdio command's environment
-    /// (LIFIC-18): `environment` for OpenCode, `env` for Claude Code and Codex,
+    /// (LIFIC-18): `environment` for `OpenCode`, `env` for Claude Code and Codex,
     /// per those tools' config schemas. `None` when the client's stdio entry
     /// cannot carry an env map (the token is then simply not written).
     pub stdio_env_key: Option<&'static str>,
@@ -246,7 +246,7 @@ impl ClientSpec {
         let mut entry = (self.compile)(cfg);
         // The mappers don't set `name` themselves; inject the canonical server
         // name here so there's one source of truth (always `"lific"`).
-        entry.name = cfg.name.clone();
+        entry.name.clone_from(&cfg.name);
         // LIFIC-18: for a stdio transport carrying an agent token, write the
         // token into the client's env field as LIFIC_TOKEN so the spawned
         // server resolves the caller as the bound agent. Clients that can't
@@ -279,24 +279,21 @@ impl ClientSpec {
 
 /// `~/.config/<rest>` on Linux/macOS; `%APPDATA%\<rest>` on Windows.
 fn config_dir(base: &PathBase, rest: &[&str]) -> PathBuf {
-    match base.os {
-        Os::Windows => {
-            let mut p = base
-                .appdata
-                .clone()
-                .unwrap_or_else(|| base.home.join("AppData").join("Roaming"));
-            for r in rest {
-                p = p.join(r);
-            }
-            p
+    if base.os == Os::Windows {
+        let mut p = base
+            .appdata
+            .clone()
+            .unwrap_or_else(|| base.home.join("AppData").join("Roaming"));
+        for r in rest {
+            p = p.join(r);
         }
-        _ => {
-            let mut p = base.home.join(".config");
-            for r in rest {
-                p = p.join(r);
-            }
-            p
+        p
+    } else {
+        let mut p = base.home.join(".config");
+        for r in rest {
+            p = p.join(r);
         }
+        p
     }
 }
 
@@ -459,8 +456,9 @@ pub fn all_clients() -> Vec<ClientSpec> {
                             "claude_desktop_config.json",
                         ],
                     ),
-                    Os::Windows => config_dir(b, &["Claude", "claude_desktop_config.json"]),
-                    Os::Linux => config_dir(b, &["Claude", "claude_desktop_config.json"]),
+                    Os::Windows | Os::Linux => {
+                        config_dir(b, &["Claude", "claude_desktop_config.json"])
+                    }
                 })
             },
             project_path: |_| None,
@@ -569,8 +567,7 @@ pub fn all_clients() -> Vec<ClientSpec> {
                         b,
                         &["Library", "Application Support", "Code", "User", "mcp.json"],
                     ),
-                    Os::Windows => config_dir(b, &["Code", "User", "mcp.json"]),
-                    Os::Linux => config_dir(b, &["Code", "User", "mcp.json"]),
+                    Os::Windows | Os::Linux => config_dir(b, &["Code", "User", "mcp.json"]),
                 })
             },
             project_path: |b| Some(project_rel(b, &[".vscode", "mcp.json"])),
@@ -999,7 +996,7 @@ mod tests {
         for id in ["claude-desktop", "goose", "crush"] {
             match find_client(id).unwrap().oauth {
                 OauthSupport::Unsupported { reason } => {
-                    assert!(!reason.is_empty(), "{id} needs a reason")
+                    assert!(!reason.is_empty(), "{id} needs a reason");
                 }
                 OauthSupport::Capable { .. } => panic!("{id} should not be OAuth-capable"),
             }

--- a/src/cli/connect/mod.rs
+++ b/src/cli/connect/mod.rs
@@ -329,9 +329,7 @@ fn interactive_picker(detected: &[DetectedClient], target: &str) -> Result<Vec<S
     let mut prompt = cliclack::multiselect(if any_installed {
         format!("Which clients should connect to {target}?")
     } else {
-        format!(
-            "No installed clients detected in this scope — pick any to configure for {target}:"
-        )
+        format!("No installed clients detected in this scope — pick any to configure for {target}:")
     })
     .required(true);
     for c in &ordered {
@@ -742,7 +740,10 @@ fn write_all_clients(
                 id: id.clone(),
                 display: spec.display.to_string(),
                 format: spec.format.as_str().to_string(),
-                error: Some(format!("{} does not support --oauth; skipped", spec.display)),
+                error: Some(format!(
+                    "{} does not support --oauth; skipped",
+                    spec.display
+                )),
                 notes: vec![reason.to_string()],
                 ..Default::default()
             });
@@ -880,8 +881,7 @@ fn maybe_write_agents_md(
         return Ok(None);
     }
 
-    let looks_like_project =
-        args.scope == Scope::Project || base.project.join(".git").exists();
+    let looks_like_project = args.scope == Scope::Project || base.project.join(".git").exists();
     if !looks_like_project {
         return Ok(None);
     }
@@ -1171,14 +1171,8 @@ mod tests {
         let guard = tmp();
         let dir = guard.path();
         let b = base(dir);
-        let err = resolve_clients_inner(
-            &["nope".into()],
-            true,
-            &b,
-            Scope::Global,
-            no_picker,
-        )
-        .unwrap_err();
+        let err = resolve_clients_inner(&["nope".into()], true, &b, Scope::Global, no_picker)
+            .unwrap_err();
         assert!(err.contains("unknown client"));
     }
 
@@ -1197,10 +1191,9 @@ mod tests {
         let guard = tmp();
         let dir = guard.path();
         let b = base(dir);
-        let got = resolve_clients_inner(&[], true, &b, Scope::Global, |_| {
-            Ok(vec!["cursor".into()])
-        })
-        .unwrap();
+        let got =
+            resolve_clients_inner(&[], true, &b, Scope::Global, |_| Ok(vec!["cursor".into()]))
+                .unwrap();
         assert_eq!(got, vec!["cursor".to_string()]);
     }
 
@@ -1241,14 +1234,12 @@ mod tests {
 
     #[test]
     fn transport_tty_no_flag_calls_picker() {
-        let got =
-            resolve_transport_inner(false, false, true, || Ok(TransportMode::Stdio)).unwrap();
+        let got = resolve_transport_inner(false, false, true, || Ok(TransportMode::Stdio)).unwrap();
         assert_eq!(got, TransportMode::Stdio);
         let got =
             resolve_transport_inner(false, false, true, || Ok(TransportMode::Remote)).unwrap();
         assert_eq!(got, TransportMode::Remote);
-        let got =
-            resolve_transport_inner(false, false, true, || Ok(TransportMode::Oauth)).unwrap();
+        let got = resolve_transport_inner(false, false, true, || Ok(TransportMode::Oauth)).unwrap();
         assert_eq!(got, TransportMode::Oauth);
     }
 
@@ -1383,8 +1374,7 @@ mod tests {
             "stdio needs no key"
         );
 
-        let written =
-            std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
+        let written = std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(v["mcp"]["lific"]["type"], "local");
         let cmd = v["mcp"]["lific"]["command"].as_array().unwrap();
@@ -1417,8 +1407,7 @@ mod tests {
         // config MUST carry the minted agent token in the env field.
         assert!(result.outcomes.iter().all(|o| o.key.is_none()));
 
-        let written =
-            std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
+        let written = std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(v["mcp"]["lific"]["type"], "local");
         let token = v["mcp"]["lific"]["environment"]["LIFIC_TOKEN"]
@@ -1461,8 +1450,7 @@ mod tests {
         let result = run(&a, &cfg, &pool, &b).unwrap();
         assert_eq!(result.outcomes[0].action.as_deref(), Some("updated"));
 
-        let written =
-            std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
+        let written = std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
         // Unrelated entries survive.
         assert_eq!(v["mcp"]["other"]["url"], "http://other");
@@ -1506,14 +1494,20 @@ mod tests {
         let result = run(&a, &cfg, &pool, &b).unwrap();
         assert_eq!(result.outcomes[0].action.as_deref(), Some("updated"));
 
-        let v: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(b.project.join("opencode.json")).unwrap())
-                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(b.project.join("opencode.json")).unwrap(),
+        )
+        .unwrap();
         // Lific entry healed: command kept, token env added.
         assert_eq!(v["mcp"]["lific"]["type"], "local");
         assert_eq!(
             v["mcp"]["lific"]["command"],
-            serde_json::json!(["lific", "--db", dir.join("mydb.db").display().to_string(), "mcp"])
+            serde_json::json!([
+                "lific",
+                "--db",
+                dir.join("mydb.db").display().to_string(),
+                "mcp"
+            ])
         );
         let token = v["mcp"]["lific"]["environment"]["LIFIC_TOKEN"]
             .as_str()
@@ -1555,7 +1549,11 @@ mod tests {
         let _ = run(&a, &cfg, &pool, &b).unwrap();
         let conn = pool.read().unwrap();
         let bots: i64 = conn
-            .query_row("SELECT COUNT(*) FROM users WHERE username = 'opencode-solo'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM users WHERE username = 'opencode-solo'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         let keys: i64 = conn
             .query_row(
@@ -1569,9 +1567,10 @@ mod tests {
 
         // The config remains well-formed and carries a live token after run #2
         // (a re-connect may rotate the key — that is a valid fresh plaintext).
-        let second_v: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(b.project.join("opencode.json")).unwrap())
-                .unwrap();
+        let second_v: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(b.project.join("opencode.json")).unwrap(),
+        )
+        .unwrap();
         let second_token = second_v["mcp"]["lific"]["environment"]["LIFIC_TOKEN"]
             .as_str()
             .expect("token must be present after rerun");
@@ -1601,8 +1600,7 @@ mod tests {
             outcome.error
         );
 
-        let written =
-            std::fs::read_to_string(b.project.join(".codex/config.toml")).unwrap();
+        let written = std::fs::read_to_string(b.project.join(".codex/config.toml")).unwrap();
         // The stdio command and the env table with LIFIC_TOKEN both land.
         assert!(
             written.contains("command = \"lific\""),
@@ -1647,8 +1645,7 @@ mod tests {
         let result = run(&a, &cfg, &pool, &b).unwrap();
         assert_eq!(result.outcomes[0].action.as_deref(), Some("updated"));
 
-        let written =
-            std::fs::read_to_string(b.project.join(".codex/config.toml")).unwrap();
+        let written = std::fs::read_to_string(b.project.join(".codex/config.toml")).unwrap();
         // Unrelated config survives.
         assert!(
             written.contains("model = \"gpt-5\""),
@@ -1769,10 +1766,8 @@ mod tests {
             assert_eq!(uid, None, "{name} key must be unassigned");
         }
         // Each config file contains its own key.
-        let oc_body = std::fs::read_to_string(
-            b.home.join(".config/opencode/opencode.json"),
-        )
-        .unwrap();
+        let oc_body =
+            std::fs::read_to_string(b.home.join(".config/opencode/opencode.json")).unwrap();
         assert!(oc_body.contains(&ock));
         let cur_body = std::fs::read_to_string(b.home.join(".cursor/mcp.json")).unwrap();
         assert!(cur_body.contains(&curk));
@@ -2028,13 +2023,17 @@ mod tests {
 
         // Plain stdio config: command present, but NO token (no env field,
         // because no owner resolved → no LIFIC_TOKEN to bind).
-        let written =
-            std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
+        let written = std::fs::read_to_string(b.project.join("opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(v["mcp"]["lific"]["type"], "local");
         assert_eq!(
             v["mcp"]["lific"]["command"],
-            serde_json::json!(["lific", "--db", dir.join("mydb.db").display().to_string(), "mcp"])
+            serde_json::json!([
+                "lific",
+                "--db",
+                dir.join("mydb.db").display().to_string(),
+                "mcp"
+            ])
         );
         assert!(
             v["mcp"]["lific"].get("environment").is_none(),
@@ -2065,8 +2064,7 @@ mod tests {
         assert_eq!(oc.auth_hint.as_deref(), Some("opencode mcp auth lific"));
 
         // The written config has a url and NO headers key at all.
-        let body =
-            std::fs::read_to_string(b.home.join(".config/opencode/opencode.json")).unwrap();
+        let body = std::fs::read_to_string(b.home.join(".config/opencode/opencode.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["mcp"]["lific"]["url"], "http://127.0.0.1:3456/mcp");
         assert!(
@@ -2080,7 +2078,9 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM api_keys", [], |r| r.get(0))
             .unwrap();
         let bots: i64 = conn
-            .query_row("SELECT COUNT(*) FROM users WHERE is_bot = 1", [], |r| r.get(0))
+            .query_row("SELECT COUNT(*) FROM users WHERE is_bot = 1", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(keys, 0, "oauth mints no keys");
         assert_eq!(bots, 0, "oauth creates no bots");
@@ -2105,7 +2105,9 @@ mod tests {
             Some("http://127.0.0.1:3456/mcp")
         );
         assert!(
-            doc["mcp_servers"]["lific"].get("bearer_token_env_var").is_none(),
+            doc["mcp_servers"]["lific"]
+                .get("bearer_token_env_var")
+                .is_none(),
             "oauth codex must not set bearer_token_env_var: {body}"
         );
     }
@@ -2126,7 +2128,10 @@ mod tests {
             let oc = result.outcomes.iter().find(|o| o.id == id).unwrap();
             assert!(oc.action.is_none(), "{id} must be skipped, not written");
             assert!(
-                oc.error.as_ref().unwrap().contains("does not support --oauth"),
+                oc.error
+                    .as_ref()
+                    .unwrap()
+                    .contains("does not support --oauth"),
                 "{id} skip must explain why"
             );
             assert!(!oc.notes.is_empty(), "{id} must carry an explanatory note");

--- a/src/cli/connect/mod.rs
+++ b/src/cli/connect/mod.rs
@@ -34,7 +34,7 @@
 //! **Per-tool identities (LIF-259).** `connect` mints ONE bot + key PER SELECTED
 //! CLIENT, named after the tool the way the web UI's Connected Tools page does
 //! (`{tool}-{owner.username}`, e.g. `opencode-blake`). This means the audit log
-//! attributes each change to the specific harness ("OpenCode changed status"),
+//! attributes each change to the specific harness ("`OpenCode` changed status"),
 //! and CLI-connected tools show up on that page indistinguishable from
 //! web-connected ones. On a fresh install (zero human users) it mints one plain
 //! unassigned key per tool named just `{tool}` — still per-tool attribution in
@@ -471,7 +471,7 @@ fn resolve_key_source(args: &ConnectArgs, pool: &DbPool) -> Result<KeySource, St
 ///   the tool's display name, mint-or-rotate a key named after the bot, and
 ///   assign the key to the bot. The bot's `owner_id` points at the human, so
 ///   authz resolves bot → owner (src/authz.rs).
-/// - **FreshInstall:** mint-or-rotate a plain unassigned key named just `{tool}`.
+/// - **`FreshInstall`:** mint-or-rotate a plain unassigned key named just `{tool}`.
 /// - **Provided:** the verbatim `--key` (no DB writes).
 ///
 /// Returns the plaintext key for that tool.
@@ -669,7 +669,7 @@ pub fn run(
     } else {
         None
     };
-    let key_origin = key_source.as_ref().map(|s| s.origin());
+    let key_origin = key_source.as_ref().map(KeySource::origin);
 
     let manager = if needs_minting {
         Some(
@@ -1291,7 +1291,10 @@ mod tests {
 
     fn args(clients: &[&str], scope: Scope) -> ConnectArgs {
         ConnectArgs {
-            clients: clients.iter().map(|s| s.to_string()).collect(),
+            clients: clients
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
             scope,
             stdio: false,
             oauth: false,

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -184,9 +184,7 @@ fn sync_parent_dir(_dir: &Path) -> Result<(), WriteError> {
     {
         std::fs::File::open(_dir)
             .and_then(|dir| dir.sync_all())
-            .map_err(|e| {
-                WriteError::new(format!("failed to sync {}: {e}", _dir.display()))
-            })?;
+            .map_err(|e| WriteError::new(format!("failed to sync {}: {e}", _dir.display())))?;
     }
     Ok(())
 }

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -96,7 +96,7 @@ fn render_from(
     } else {
         Action::Created
     };
-    let existing_str = existing.map(|e| e.contents.as_str()).unwrap_or("");
+    let existing_str = existing.map_or("", |e| e.contents.as_str());
     let contents = match format {
         Format::Json => render_json(existing_str, entry)?,
         Format::Toml => render_toml(existing_str, entry)?,
@@ -110,7 +110,7 @@ fn render_from(
 pub fn write(path: &Path, format: Format, entry: &CompiledEntry) -> Result<Action, WriteError> {
     let existing = read_existing(path)?;
     let rendered = render_from(existing.as_ref(), format, entry)?;
-    let parent_existed = path.parent().map(|parent| parent.exists()).unwrap_or(true);
+    let parent_existed = path.parent().is_none_or(std::path::Path::exists);
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
@@ -179,39 +179,47 @@ pub fn write(path: &Path, format: Format, entry: &CompiledEntry) -> Result<Actio
 /// `connect` cannot leave the config missing even though the write reported
 /// success. Unix only: Windows exposes no directory handle to sync, and
 /// `fsync` on a directory has no meaning there.
-fn sync_parent_dir(_dir: &Path) -> Result<(), WriteError> {
+fn sync_parent_dir(dir: &Path) -> Result<(), WriteError> {
+    #[cfg(not(unix))]
+    let _ = dir;
+
     #[cfg(unix)]
     {
-        std::fs::File::open(_dir)
-            .and_then(|dir| dir.sync_all())
-            .map_err(|e| WriteError::new(format!("failed to sync {}: {e}", _dir.display())))?;
+        std::fs::File::open(dir)
+            .and_then(|file| file.sync_all())
+            .map_err(|e| WriteError::new(format!("failed to sync {}: {e}", dir.display())))?;
     }
     Ok(())
 }
 
-fn set_private_file(_file: &std::fs::File) -> Result<(), WriteError> {
+fn set_private_file(file: &std::fs::File) -> Result<(), WriteError> {
+    #[cfg(not(unix))]
+    let _ = file;
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        _file
-            .set_permissions(std::fs::Permissions::from_mode(0o600))
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
             .map_err(|e| WriteError::new(format!("failed to tighten config staging file: {e}")))?;
     }
     Ok(())
 }
 
-fn set_private_dir(_path: &Path) -> Result<(), WriteError> {
+fn set_private_dir(path: &Path) -> Result<(), WriteError> {
+    #[cfg(not(unix))]
+    let _ = path;
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
-        let mode = std::fs::metadata(_path)
-            .map_err(|e| WriteError::new(format!("failed to inspect {}: {e}", _path.display())))?
+        let mode = std::fs::metadata(path)
+            .map_err(|e| WriteError::new(format!("failed to inspect {}: {e}", path.display())))?
             .mode()
             & 0o777;
         if mode & 0o022 != 0 {
             return Err(WriteError::new(format!(
                 "config directory {} is writable by group/others; remove group/other write permissions before writing embedded credentials",
-                _path.display()
+                path.display()
             )));
         }
     }
@@ -414,7 +422,7 @@ fn render_toml(existing: &str, entry: &CompiledEntry) -> Result<String, WriteErr
 }
 
 /// Convert a JSON scalar/array/object (the compiled entry's shape) into a
-/// toml_edit value. Codex entries carry strings, string arrays, and — for the
+/// `toml_edit` value. Codex entries carry strings, string arrays, and — for the
 /// stdio agent token (LIFIC-18) — a nested `env` object of strings.
 fn json_to_toml_value(v: &serde_json::Value) -> Result<toml_edit::Item, WriteError> {
     use toml_edit::{Array, InlineTable, Item, Value, value};
@@ -458,7 +466,7 @@ fn json_to_toml_value(v: &serde_json::Value) -> Result<toml_edit::Item, WriteErr
             }
             Ok(Item::Value(Value::InlineTable(inline)))
         }
-        other => Err(WriteError::new(format!("unsupported TOML value: {other}"))),
+        serde_json::Value::Null => Err(WriteError::new("unsupported TOML null value")),
     }
 }
 

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -415,7 +415,11 @@ mod tests {
     fn file_store_creates_missing_parent_dir() {
         let tmp = tempfile::tempdir().unwrap();
         // Path two levels deep, neither of which exists yet.
-        let path = tmp.path().join("deep").join("nested").join("credentials.json");
+        let path = tmp
+            .path()
+            .join("deep")
+            .join("nested")
+            .join("credentials.json");
         let store = FileStore::new(path.clone());
         store.store("http://a", "tok").unwrap();
         assert!(path.exists());
@@ -431,7 +435,10 @@ mod tests {
 
     #[test]
     fn origin_of_makes_default_ports_explicit() {
-        assert_eq!(origin_of("https://h.example").unwrap(), "https://h.example:443");
+        assert_eq!(
+            origin_of("https://h.example").unwrap(),
+            "https://h.example:443"
+        );
         assert_eq!(
             origin_of("https://h.example:443").unwrap(),
             origin_of("https://h.example").unwrap()
@@ -451,7 +458,10 @@ mod tests {
     fn origin_of_ignores_case_path_and_trailing_slash() {
         let base = origin_of("https://Lific.Example:3998").unwrap();
         assert_eq!(origin_of("https://lific.example:3998/").unwrap(), base);
-        assert_eq!(origin_of("HTTPS://LIFIC.EXAMPLE:3998/a/b?q=1#f").unwrap(), base);
+        assert_eq!(
+            origin_of("HTTPS://LIFIC.EXAMPLE:3998/a/b?q=1#f").unwrap(),
+            base
+        );
         assert_eq!(origin_of("  https://lific.example:3998  ").unwrap(), base);
     }
 
@@ -466,7 +476,11 @@ mod tests {
     #[test]
     fn env_token_attaches_when_target_origin_matches_env_url() {
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("https://ci.example"), "https://ci.example"),
+            env_token_for(
+                Some("env-tok"),
+                Some("https://ci.example"),
+                "https://ci.example"
+            ),
             EnvToken::Bound("env-tok".into())
         );
         // Same origin spelled differently on either side still binds.
@@ -479,7 +493,11 @@ mod tests {
             EnvToken::Bound("env-tok".into())
         );
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("http://127.0.0.1:3998"), "http://127.0.0.1:3998/"),
+            env_token_for(
+                Some("env-tok"),
+                Some("http://127.0.0.1:3998"),
+                "http://127.0.0.1:3998/"
+            ),
             EnvToken::Bound("env-tok".into())
         );
     }
@@ -488,22 +506,38 @@ mod tests {
     fn env_token_is_dropped_when_target_origin_differs() {
         // The attack: a cwd config (or --url) points somewhere else.
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("https://ci.example"), "https://hostile.example"),
+            env_token_for(
+                Some("env-tok"),
+                Some("https://ci.example"),
+                "https://hostile.example"
+            ),
             EnvToken::Unbound
         );
         // Different port, same host.
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("http://127.0.0.1:3998"), "http://127.0.0.1:4000"),
+            env_token_for(
+                Some("env-tok"),
+                Some("http://127.0.0.1:3998"),
+                "http://127.0.0.1:4000"
+            ),
             EnvToken::Unbound
         );
         // Different scheme, same host: an http downgrade must not carry it.
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("https://ci.example"), "http://ci.example"),
+            env_token_for(
+                Some("env-tok"),
+                Some("https://ci.example"),
+                "http://ci.example"
+            ),
             EnvToken::Unbound
         );
         // Subdomain is a different origin.
         assert_eq!(
-            env_token_for(Some("env-tok"), Some("https://ci.example"), "https://evil.ci.example"),
+            env_token_for(
+                Some("env-tok"),
+                Some("https://ci.example"),
+                "https://evil.ci.example"
+            ),
             EnvToken::Unbound
         );
         // Unparseable/non-http on either side never binds.
@@ -538,11 +572,18 @@ mod tests {
             EnvToken::Absent
         );
         assert_eq!(
-            env_token_for(Some("   "), Some("https://ci.example"), "https://ci.example"),
+            env_token_for(
+                Some("   "),
+                Some("https://ci.example"),
+                "https://ci.example"
+            ),
             EnvToken::Absent
         );
         // Absent, not Unbound, even with no LIFIC_URL: nothing to warn about.
-        assert_eq!(env_token_for(None, None, "https://ci.example"), EnvToken::Absent);
+        assert_eq!(
+            env_token_for(None, None, "https://ci.example"),
+            EnvToken::Absent
+        );
     }
 
     // The remaining tests mutate the process env, so they serialize on the

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -299,9 +299,7 @@ pub fn load_with_source(base_url: &str) -> Option<(String, TokenSource)> {
 pub fn delete(base_url: &str) -> bool {
     let key = normalize_base_url(base_url);
     let kr = keyring_delete(&key);
-    let file = default_file_path()
-        .map(|p| FileStore::new(p).delete(&key).unwrap_or(false))
-        .unwrap_or(false);
+    let file = default_file_path().is_some_and(|p| FileStore::new(p).delete(&key).unwrap_or(false));
     kr || file
 }
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -161,10 +161,7 @@ pub async fn run(
     let report = build_report_with_config_path(cfg, explicit_config, key.as_deref()).await;
     print_report(&report, json);
     if report.fail_count() > 0 {
-        Err(format!(
-            "doctor: {} check(s) failed",
-            report.fail_count()
-        ))
+        Err(format!("doctor: {} check(s) failed", report.fail_count()))
     } else {
         Ok(())
     }
@@ -201,14 +198,16 @@ pub async fn build_report_with_config_path(
     // credential store keyed by the server's public_url when set, else the
     // loopback base, since that's how `lific login` would have keyed it.
     let cred_base = cfg.server.public_url.as_deref().unwrap_or(&base);
-    let (effective_key, key_source): (Option<String>, Option<crate::cli::credentials::TokenSource>) =
-        match key {
-            Some(k) => (Some(k.to_string()), None),
-            None => match crate::cli::credentials::load_with_source(cred_base) {
-                Some((tok, src)) => (Some(tok), Some(src)),
-                None => (None, None),
-            },
-        };
+    let (effective_key, key_source): (
+        Option<String>,
+        Option<crate::cli::credentials::TokenSource>,
+    ) = match key {
+        Some(k) => (Some(k.to_string()), None),
+        None => match crate::cli::credentials::load_with_source(cred_base) {
+            Some((tok, src)) => (Some(tok), Some(src)),
+            None => (None, None),
+        },
+    };
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(3))
@@ -382,10 +381,7 @@ fn check_database(cfg: &Config) -> Check {
             Some(v) => Check::new(
                 "database",
                 Status::Pass,
-                format!(
-                    "{} opens; migrations applied (schema v{v})",
-                    path.display()
-                ),
+                format!("{} opens; migrations applied (schema v{v})", path.display()),
             ),
             None => Check::new(
                 "database",
@@ -653,7 +649,9 @@ pub async fn check_mcp(client: &reqwest::Client, base: &str, key: Option<&str>) 
     };
 
     let status = resp.status();
-    let has_www_auth = resp.headers().contains_key(reqwest::header::WWW_AUTHENTICATE);
+    let has_www_auth = resp
+        .headers()
+        .contains_key(reqwest::header::WWW_AUTHENTICATE);
 
     match key {
         None => {
@@ -721,11 +719,7 @@ pub async fn check_mcp(client: &reqwest::Client, base: &str, key: Option<&str>) 
                             format!("initialize returned a JSON-RPC error: {}", body["error"]),
                         )
                     } else {
-                        Check::new(
-                            "mcp",
-                            Status::Fail,
-                            "200 but result had no serverInfo",
-                        )
+                        Check::new("mcp", Status::Fail, "200 but result had no serverInfo")
                     }
                 }
                 Err(e) => Check::new(
@@ -974,8 +968,7 @@ mod tests {
     fn database_check_fails_when_parent_unwritable() {
         let mut cfg = Config::default();
         // A path under a directory that does not exist → parent not writable.
-        cfg.database.path =
-            std::path::PathBuf::from("/nonexistent-lific-doctor-xyz/deep/lific.db");
+        cfg.database.path = std::path::PathBuf::from("/nonexistent-lific-doctor-xyz/deep/lific.db");
         let c = check_database(&cfg);
         assert_eq!(c.status, Status::Fail, "detail: {}", c.detail);
     }
@@ -1167,9 +1160,7 @@ mod tests {
         let app = build_test_app(pool, "http://127.0.0.1");
         let base = serve_ephemeral(app).await;
 
-        let probe = http_server_reachable(&test_client(), &base)
-            .await
-            .unwrap();
+        let probe = http_server_reachable(&test_client(), &base).await.unwrap();
         assert!(probe.reachable);
         assert_eq!(probe.status, Some(200));
     }
@@ -1195,11 +1186,7 @@ mod tests {
 
         let c = check_mcp(&test_client(), &base, None).await;
         assert_eq!(c.status, Status::Pass, "detail: {}", c.detail);
-        assert!(
-            c.detail.contains("auth enforced"),
-            "detail: {}",
-            c.detail
-        );
+        assert!(c.detail.contains("auth enforced"), "detail: {}", c.detail);
     }
 
     #[tokio::test]
@@ -1251,13 +1238,7 @@ mod tests {
         assert!(report.ok);
 
         // server = warn, oauth_discovery + mcp = skipped
-        let by = |n: &str| {
-            report
-                .checks
-                .iter()
-                .find(|c| c.name == n)
-                .map(|c| c.status)
-        };
+        let by = |n: &str| report.checks.iter().find(|c| c.name == n).map(|c| c.status);
         assert_eq!(by("server"), Some(Status::Warn));
         assert_eq!(by("oauth_discovery"), Some(Status::Skipped));
         assert_eq!(by("mcp"), Some(Status::Skipped));

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -26,13 +26,13 @@
 //!    with the most-recent backup age vs the configured interval.
 //! 4. **server** — HTTP reachability of `http://{host}:{port}/api/health`
 //!    (0.0.0.0 → 127.0.0.1). Not running = warn (doctor must work offline).
-//! 5. **oauth_discovery** — `GET {base}/.well-known/oauth-protected-resource/mcp`
+//! 5. **`oauth_discovery`** — `GET {base}/.well-known/oauth-protected-resource/mcp`
 //!    → 200 + JSON containing `resource`. Skipped when the server is unreachable.
 //! 6. **mcp** — `POST {base}/mcp` JSON-RPC `initialize`. No key → expect 401 with
 //!    a `WWW-Authenticate` header (auth enforced, discovery advertised) = pass.
 //!    With a key → expect 200 + a `serverInfo` result = pass; wrong key = fail.
 //!    Skipped when the server is unreachable.
-//! 7. **public_url** — only when `server.public_url` is set. `GET
+//! 7. **`public_url`** — only when `server.public_url` is set. `GET
 //!    {public_url}/.well-known/oauth-protected-resource/mcp` reachable = pass;
 //!    unreachable = warn (may be firewalled from this vantage point).
 
@@ -219,41 +219,38 @@ pub async fn build_report_with_config_path(
         None => None,
     };
 
-    match (&client, &server_up) {
-        (Some(c), Some(reachable)) => {
-            checks.push(server_check_result(reachable));
-            if reachable.reachable {
-                checks.push(check_oauth_discovery(c, &base).await);
-                let mut mcp_check = check_mcp(c, &base, effective_key.as_deref()).await;
-                // Note where the credential came from when it was a stored
-                // login token rather than an explicit --key/LIFIC_API_KEY.
-                if let Some(src) = key_source {
-                    mcp_check.detail = format!("{} (using {})", mcp_check.detail, src.label());
-                }
-                checks.push(mcp_check);
-            } else {
-                checks.push(Check::new(
-                    "oauth_discovery",
-                    Status::Skipped,
-                    "server not reachable — skipped",
-                ));
-                checks.push(Check::new(
-                    "mcp",
-                    Status::Skipped,
-                    "server not reachable — skipped",
-                ));
+    if let (Some(c), Some(reachable)) = (&client, &server_up) {
+        checks.push(server_check_result(reachable));
+        if reachable.reachable {
+            checks.push(check_oauth_discovery(c, &base).await);
+            let mut mcp_check = check_mcp(c, &base, effective_key.as_deref()).await;
+            // Note where the credential came from when it was a stored
+            // login token rather than an explicit --key/LIFIC_API_KEY.
+            if let Some(src) = key_source {
+                mcp_check.detail = format!("{} (using {})", mcp_check.detail, src.label());
             }
-        }
-        _ => {
-            // Could not even build a client; report all HTTP checks as skipped.
+            checks.push(mcp_check);
+        } else {
             checks.push(Check::new(
-                "server",
-                Status::Warn,
-                "could not build HTTP client — skipped",
+                "oauth_discovery",
+                Status::Skipped,
+                "server not reachable — skipped",
             ));
-            checks.push(Check::new("oauth_discovery", Status::Skipped, "skipped"));
-            checks.push(Check::new("mcp", Status::Skipped, "skipped"));
+            checks.push(Check::new(
+                "mcp",
+                Status::Skipped,
+                "server not reachable — skipped",
+            ));
         }
+    } else {
+        // Could not even build a client; report all HTTP checks as skipped.
+        checks.push(Check::new(
+            "server",
+            Status::Warn,
+            "could not build HTTP client — skipped",
+        ));
+        checks.push(Check::new("oauth_discovery", Status::Skipped, "skipped"));
+        checks.push(Check::new("mcp", Status::Skipped, "skipped"));
     }
 
     // public_url check only when configured.
@@ -653,81 +650,78 @@ pub async fn check_mcp(client: &reqwest::Client, base: &str, key: Option<&str>) 
         .headers()
         .contains_key(reqwest::header::WWW_AUTHENTICATE);
 
-    match key {
-        None => {
-            // No key: the correct, healthy behavior is a 401 that advertises
-            // where to discover auth.
-            if status == reqwest::StatusCode::UNAUTHORIZED && has_www_auth {
-                Check::new(
-                    "mcp",
-                    Status::Pass,
-                    "auth enforced (401 + WWW-Authenticate); discovery advertised",
-                )
-            } else if status == reqwest::StatusCode::UNAUTHORIZED {
-                Check::new(
-                    "mcp",
-                    Status::Warn,
-                    "401 but no WWW-Authenticate header — discovery not advertised",
-                )
-            } else {
-                Check::new(
-                    "mcp",
-                    Status::Fail,
-                    format!(
-                        "expected 401 without a key, got HTTP {} (auth may be disabled)",
-                        status.as_u16()
-                    ),
-                )
-            }
-        }
-        Some(_) => {
-            if status == reqwest::StatusCode::UNAUTHORIZED {
-                return Check::new(
-                    "mcp",
-                    Status::Fail,
-                    "provided key was rejected (401) — wrong or revoked key",
-                );
-            }
-            if !status.is_success() {
-                return Check::new(
-                    "mcp",
-                    Status::Fail,
-                    format!("initialize returned HTTP {}", status.as_u16()),
-                );
-            }
-            // json_response mode: the body is a plain JSON-RPC envelope.
-            match resp.json::<serde_json::Value>().await {
-                Ok(body) => {
-                    if body
-                        .get("result")
-                        .and_then(|r| r.get("serverInfo"))
-                        .is_some()
-                    {
-                        let name = body
-                            .pointer("/result/serverInfo/name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("lific");
-                        Check::new(
-                            "mcp",
-                            Status::Pass,
-                            format!("authorized initialize succeeded (serverInfo: {name})"),
-                        )
-                    } else if body.get("error").is_some() {
-                        Check::new(
-                            "mcp",
-                            Status::Fail,
-                            format!("initialize returned a JSON-RPC error: {}", body["error"]),
-                        )
-                    } else {
-                        Check::new("mcp", Status::Fail, "200 but result had no serverInfo")
-                    }
-                }
-                Err(e) => Check::new(
-                    "mcp",
-                    Status::Fail,
-                    format!("200 but body was not JSON: {e}"),
+    if key.is_none() {
+        // No key: the correct, healthy behavior is a 401 that advertises
+        // where to discover auth.
+        if status == reqwest::StatusCode::UNAUTHORIZED && has_www_auth {
+            Check::new(
+                "mcp",
+                Status::Pass,
+                "auth enforced (401 + WWW-Authenticate); discovery advertised",
+            )
+        } else if status == reqwest::StatusCode::UNAUTHORIZED {
+            Check::new(
+                "mcp",
+                Status::Warn,
+                "401 but no WWW-Authenticate header — discovery not advertised",
+            )
+        } else {
+            Check::new(
+                "mcp",
+                Status::Fail,
+                format!(
+                    "expected 401 without a key, got HTTP {} (auth may be disabled)",
+                    status.as_u16()
                 ),
+            )
+        }
+    } else {
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Check::new(
+                "mcp",
+                Status::Fail,
+                "provided key was rejected (401) — wrong or revoked key",
+            );
+        }
+        if !status.is_success() {
+            return Check::new(
+                "mcp",
+                Status::Fail,
+                format!("initialize returned HTTP {}", status.as_u16()),
+            );
+        }
+        // json_response mode: the body is a plain JSON-RPC envelope.
+        match resp.json::<serde_json::Value>().await {
+            Ok(body) => {
+                if body
+                    .get("result")
+                    .and_then(|r| r.get("serverInfo"))
+                    .is_some()
+                {
+                    let name = body
+                        .pointer("/result/serverInfo/name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("lific");
+                    Check::new(
+                        "mcp",
+                        Status::Pass,
+                        format!("authorized initialize succeeded (serverInfo: {name})"),
+                    )
+                } else if body.get("error").is_some() {
+                    Check::new(
+                        "mcp",
+                        Status::Fail,
+                        format!("initialize returned a JSON-RPC error: {}", body["error"]),
+                    )
+                } else {
+                    Check::new("mcp", Status::Fail, "200 but result had no serverInfo")
+                }
             }
+            Err(e) => Check::new(
+                "mcp",
+                Status::Fail,
+                format!("200 but body was not JSON: {e}"),
+            ),
         }
     }
 }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1145,7 +1145,10 @@ mod tests {
             .unwrap();
             conn.execute(
                 "UPDATE comments SET created_at = ?1 WHERE id = ?2",
-                rusqlite::params![format!("2026-01-01 00:{:02}:{:02}", i / 60, i % 60), comment.id],
+                rusqlite::params![
+                    format!("2026-01-01 00:{:02}:{:02}", i / 60, i % 60),
+                    comment.id
+                ],
             )
             .unwrap();
         }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,10 +1,17 @@
 use crate::db::DbPool;
-use crate::db::models::*;
+use crate::db::models::{
+    Comment, CreateFolder, CreateIssue, CreateLabel, CreateModule, CreatePage, CreateProject,
+    ListIssuesQuery, Priority, SearchQuery, Status, UpdateFolder, UpdateIssue, UpdateLabel,
+    UpdateModule, UpdatePage, UpdateProject,
+};
 use crate::db::queries;
 use crate::error::LificError;
 
 use super::render;
-use super::*;
+use super::{
+    Command, CommentAction, ExportAction, FolderAction, IssueAction, LabelAction, ModuleAction,
+    PageAction, ProjectAction, owned_labels,
+};
 
 /// Run a CLI CRUD command against the database.
 /// Returns Ok(()) on success, printing output to stdout.
@@ -823,6 +830,9 @@ fn folder(
 
 #[cfg(test)]
 mod tests {
+    #[allow(clippy::wildcard_imports)]
+    use crate::db::models::*;
+
     use crate::db;
     use crate::db::queries;
 

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -100,7 +100,11 @@ impl HttpBackend {
                 parsed.host_str().unwrap_or_default()
             );
         }
-        if parsed.scheme() == "http" && parsed.host_str().is_some_and(|host| !is_loopback_host(host)) {
+        if parsed.scheme() == "http"
+            && parsed
+                .host_str()
+                .is_some_and(|host| !is_loopback_host(host))
+        {
             eprintln!(
                 "warning: connecting over unencrypted http to {}",
                 parsed.host_str().unwrap_or_default()
@@ -1473,24 +1477,24 @@ mod tests {
             display_name: "Test Admin".into(),
             is_admin: true,
         })))
-            .layer(Extension(Some(crate::resolve_caller::ResolvedIdentity {
-                user: AuthUser {
-                    id: admin_id,
-                    username: "test-admin".into(),
-                    display_name: "Test Admin".into(),
-                    is_admin: true,
-                },
-                transport: crate::actor::Transport::Web,
-            })))
-            .layer(Extension(Some(crate::resolve_caller::ResolvedIdentity {
-                user: AuthUser {
-                    id: admin_id,
-                    username: "test-admin".into(),
-                    display_name: "Test Admin".into(),
-                    is_admin: true,
-                },
-                transport: crate::actor::Transport::Web,
-            })));
+        .layer(Extension(Some(crate::resolve_caller::ResolvedIdentity {
+            user: AuthUser {
+                id: admin_id,
+                username: "test-admin".into(),
+                display_name: "Test Admin".into(),
+                is_admin: true,
+            },
+            transport: crate::actor::Transport::Web,
+        })))
+        .layer(Extension(Some(crate::resolve_caller::ResolvedIdentity {
+            user: AuthUser {
+                id: admin_id,
+                username: "test-admin".into(),
+                display_name: "Test Admin".into(),
+                is_admin: true,
+            },
+            transport: crate::actor::Transport::Web,
+        })));
         let (project_id, _) = seed_project(&app).await;
         let project_page = parse_json(
             json_post(
@@ -3192,7 +3196,10 @@ mod tests {
             .await
             .unwrap();
 
-        let value = backend.execute(&command, IssueLinkOutput::Url).await.unwrap();
+        let value = backend
+            .execute(&command, IssueLinkOutput::Url)
+            .await
+            .unwrap();
         let remote = backend.human(&command, &value).await;
 
         let pool = crate::db::open_memory().expect("test db");

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -1959,7 +1959,10 @@ mod tests {
         );
         assert!(!remote.is_empty(), "the {label} export wrote nothing");
         assert!(
-            remote.iter().all(|(path, _)| path.ends_with(".md")),
+            remote.iter().all(|(path, _)| {
+                path.rsplit_once('.')
+                    .is_some_and(|(_, extension)| extension.eq_ignore_ascii_case("md"))
+            }),
             "the {label} export left something other than markdown: {remote:?}"
         );
 

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -7,10 +7,10 @@
 
 use crate::config::Config;
 use crate::db::{self, DbPool};
-use crate::import::{self, ImportSummary};
 use crate::import::github::{self, StateFilter};
 use crate::import::jira::{self, JiraStatusMap};
 use crate::import::linear::{self, LinearStatusMap};
+use crate::import::{self, ImportSummary};
 
 /// Dispatch an `ImportAction` to the right source runner.
 pub fn run(
@@ -35,8 +35,15 @@ pub fn run(
             user,
             dry_run,
         } => run_github(
-            &pool, repo, project, state, token.as_deref(), map_open, map_closed,
-            user.as_deref(), *dry_run,
+            &pool,
+            repo,
+            project,
+            state,
+            token.as_deref(),
+            map_open,
+            map_closed,
+            user.as_deref(),
+            *dry_run,
         )?,
         ImportAction::Linear {
             team,
@@ -44,7 +51,14 @@ pub fn run(
             token,
             user,
             dry_run,
-        } => run_linear(&pool, team, project, token.as_deref(), user.as_deref(), *dry_run)?,
+        } => run_linear(
+            &pool,
+            team,
+            project,
+            token.as_deref(),
+            user.as_deref(),
+            *dry_run,
+        )?,
         ImportAction::Jira {
             site,
             jira_project,
@@ -54,8 +68,14 @@ pub fn run(
             user,
             dry_run,
         } => run_jira(
-            &pool, site, jira_project, project, email.as_deref(), token.as_deref(),
-            user.as_deref(), *dry_run,
+            &pool,
+            site,
+            jira_project,
+            project,
+            email.as_deref(),
+            token.as_deref(),
+            user.as_deref(),
+            *dry_run,
         )?,
     };
 
@@ -80,7 +100,12 @@ fn resolve_bot(
     user: Option<&str>,
 ) -> Result<Option<i64>, Box<dyn std::error::Error>> {
     match import::resolve_owner(pool, user)? {
-        Some(owner) => Ok(Some(import::ensure_import_bot(pool, owner, source_slug, display)?)),
+        Some(owner) => Ok(Some(import::ensure_import_bot(
+            pool,
+            owner,
+            source_slug,
+            display,
+        )?)),
         None => Ok(None),
     }
 }
@@ -208,11 +233,7 @@ pub fn print_summary(summary: &ImportSummary, json: bool) {
         }
     }
     // What didn't come across.
-    if summary.skipped_non_issues
-        + summary.skipped_assignees
-        + summary.skipped_other
-        > 0
-    {
+    if summary.skipped_non_issues + summary.skipped_assignees + summary.skipped_other > 0 {
         println!();
         println!("  Not imported (by design):");
         if summary.skipped_non_issues > 0 {

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -139,10 +139,11 @@ fn run_github(
         resolve_bot(pool, "github", "GitHub Import", user)?
     };
 
-    let fetcher = github::LiveGithub::new(&owner, &name, token.map(|s| s.to_string()))?;
+    let fetcher =
+        github::LiveGithub::new(&owner, &name, token.map(std::string::ToString::to_string))?;
     let slug = format!("{owner}/{name}");
-    let fetched = github::collect(&fetcher, &slug, state, &status_map)?;
-    let summary = import::run_import(pool, project_id, bot, &fetched, dry_run)?;
+    let issues = github::collect(&fetcher, &slug, state, &status_map)?;
+    let summary = import::run_import(pool, project_id, bot, &issues, dry_run)?;
     Ok(summary)
 }
 
@@ -167,8 +168,8 @@ fn run_linear(
     };
 
     let fetcher = linear::LiveLinear::new(team, token)?;
-    let fetched = linear::collect(&fetcher, &map)?;
-    let summary = import::run_import(pool, project_id, bot, &fetched, dry_run)?;
+    let issues = linear::collect(&fetcher, &map)?;
+    let summary = import::run_import(pool, project_id, bot, &issues, dry_run)?;
     Ok(summary)
 }
 
@@ -195,8 +196,8 @@ fn run_jira(
     };
 
     let fetcher = jira::LiveJira::new(site, jira_project, email, token)?;
-    let fetched = jira::collect(&fetcher, fetcher.site_slug(), &map)?;
-    let summary = import::run_import(pool, project_id, bot, &fetched, dry_run)?;
+    let issues = jira::collect(&fetcher, fetcher.site_slug(), &map)?;
+    let summary = import::run_import(pool, project_id, bot, &issues, dry_run)?;
     Ok(summary)
 }
 

--- a/src/cli/instance.rs
+++ b/src/cli/instance.rs
@@ -91,15 +91,31 @@ pub fn run(
         println!("{}", serde_json::to_string_pretty(&out)?);
     } else {
         println!("Instance");
-        println!("  name:          {}", settings.instance_name.as_deref().unwrap_or("(unnamed)"));
+        println!(
+            "  name:          {}",
+            settings.instance_name.as_deref().unwrap_or("(unnamed)")
+        );
         println!("  version:       {version}");
         println!("  database:      {}", cfg.database.path.display());
         println!("  bind:          {}:{}", cfg.server.host, cfg.server.port);
-        println!("  public url:    {}", cfg.server.public_url.as_deref().unwrap_or("(not set)"));
-        println!("  signups:       {}", if settings.allow_signup { "open" } else { "closed" });
+        println!(
+            "  public url:    {}",
+            cfg.server.public_url.as_deref().unwrap_or("(not set)")
+        );
+        println!(
+            "  signups:       {}",
+            if settings.allow_signup {
+                "open"
+            } else {
+                "closed"
+            }
+        );
         println!("  signup domains:{domains}");
         println!("  session days:  {}", settings.session_lifetime_days);
-        println!("  login message: {}", settings.login_message.as_deref().unwrap_or("(none)"));
+        println!(
+            "  login message: {}",
+            settings.login_message.as_deref().unwrap_or("(none)")
+        );
         println!("  users:         {total} ({admins} admin)");
     }
     Ok(())

--- a/src/cli/key.rs
+++ b/src/cli/key.rs
@@ -12,7 +12,8 @@ pub fn run(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let json = term::wants_json(json_flag);
     let pool = db::open(&cfg.database.path)?;
-    let manager = auth::create_key_manager().map_err(|e| format!("key manager init failed: {e}"))?;
+    let manager =
+        auth::create_key_manager().map_err(|e| format!("key manager init failed: {e}"))?;
 
     match action {
         KeyAction::Create {
@@ -46,7 +47,9 @@ pub fn run(
                 println!("{}", serde_json::to_string_pretty(&out)?);
             } else {
                 let title = if let Some(ref username) = assigned {
-                    format!("API key '{name}' created (assigned to {username}) — save it now, it will not be shown again")
+                    format!(
+                        "API key '{name}' created (assigned to {username}) — save it now, it will not be shown again"
+                    )
                 } else {
                     format!("API key '{name}' created — save it now, it will not be shown again")
                 };

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -202,7 +202,9 @@ impl DeviceFlow for HttpDeviceFlow {
                 .get("access_token")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| "token response missing access_token".to_string())?;
-            return Ok(PollSignal::Terminal(PollOutcome::Approved(token.to_string())));
+            return Ok(PollSignal::Terminal(PollOutcome::Approved(
+                token.to_string(),
+            )));
         }
         let err = body.get("error").and_then(|v| v.as_str()).unwrap_or("");
         Ok(classify_poll_error(err))
@@ -277,7 +279,10 @@ pub fn run_login_with_flow<F: DeviceFlow>(
     // polling — a second `--complete` call finishes the login.
     if args.non_interactive || !stdin_tty {
         let payload = non_interactive_json(&resp, base);
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload).unwrap_or_default()
+        );
         return Ok(());
     }
 
@@ -405,7 +410,10 @@ mod tests {
 
     #[test]
     fn classify_maps_rfc8628_errors() {
-        assert_eq!(classify_poll_error("authorization_pending"), PollSignal::Pending);
+        assert_eq!(
+            classify_poll_error("authorization_pending"),
+            PollSignal::Pending
+        );
         assert_eq!(classify_poll_error("slow_down"), PollSignal::SlowDown);
         assert_eq!(
             classify_poll_error("access_denied"),
@@ -427,10 +435,7 @@ mod tests {
         let mut cfg = Config::default();
         cfg.server.port = 3999;
         // Explicit --url wins, trailing slash trimmed.
-        assert_eq!(
-            resolve_base_url(Some("http://h:1/"), &cfg),
-            "http://h:1"
-        );
+        assert_eq!(resolve_base_url(Some("http://h:1/"), &cfg), "http://h:1");
         // Else public_url.
         cfg.server.public_url = Some("https://lific.example/".into());
         assert_eq!(resolve_base_url(None, &cfg), "https://lific.example");
@@ -482,7 +487,9 @@ mod tests {
                     device_code: "DEV".into(),
                     user_code: "BCDF-GHJK".into(),
                     verification_uri: "http://h/oauth/device".into(),
-                    verification_uri_complete: Some("http://h/oauth/device?user_code=BCDF-GHJK".into()),
+                    verification_uri_complete: Some(
+                        "http://h/oauth/device?user_code=BCDF-GHJK".into(),
+                    ),
                     expires_in: 900,
                     interval: 5,
                 },
@@ -573,7 +580,11 @@ mod tests {
         };
         // stdin_tty=true but --non-interactive set → still non-interactive.
         run_login_with_flow(&args, "http://h", &flow, true, true).unwrap();
-        assert_eq!(*flow.polls.borrow(), 0, "must not poll in non-interactive mode");
+        assert_eq!(
+            *flow.polls.borrow(),
+            0,
+            "must not poll in non-interactive mode"
+        );
     }
 
     #[test]

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -90,7 +90,7 @@ pub trait DeviceFlow {
 /// consecutive `slow_down` signals we've seen. RFC 8628 says to increase the
 /// interval by 5 seconds on each `slow_down`.
 pub fn poll_backoff(base_interval: u64, slow_downs: u32) -> u64 {
-    base_interval + 5 * (slow_downs as u64)
+    base_interval + 5 * u64::from(slow_downs)
 }
 
 /// Run the polling loop to a terminal outcome, sleeping `sleep` between polls.

--- a/src/cli/member.rs
+++ b/src/cli/member.rs
@@ -85,7 +85,11 @@ pub fn run(
                         if skipped.is_empty() {
                             String::new()
                         } else {
-                            format!(" ({} already a member: {})", skipped.len(), skipped.join(", "))
+                            format!(
+                                " ({} already a member: {})",
+                                skipped.len(),
+                                skipped.join(", ")
+                            )
                         }
                     ));
                 }
@@ -104,8 +108,7 @@ pub fn run(
                 } else {
                     ui::step(format!(
                         "Added '{}' to {ident} as {}",
-                        u.username,
-                        member.role
+                        u.username, member.role
                     ));
                 }
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1277,7 +1277,10 @@ mod tests {
             resolve_http_credential(None, || Some(" stored ".into())),
             Ok(Some("stored".into()))
         );
-        assert_eq!(resolve_http_credential(None, || Some("  ".into())), Ok(None));
+        assert_eq!(
+            resolve_http_credential(None, || Some("  ".into())),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -1342,22 +1345,13 @@ mod tests {
 
     #[test]
     fn rejects_unknown_backend_values() {
-        assert!(
-            Cli::try_parse_from(["lific", "--backend", "remote", "project", "list"]).is_err()
-        );
+        assert!(Cli::try_parse_from(["lific", "--backend", "remote", "project", "list"]).is_err());
     }
 
     #[test]
     fn parses_json_output_alongside_http_backend() {
-        let cli = Cli::try_parse_from([
-            "lific",
-            "--backend",
-            "http",
-            "--json",
-            "project",
-            "list",
-        ])
-        .expect("JSON output should be transport independent");
+        let cli = Cli::try_parse_from(["lific", "--backend", "http", "--json", "project", "list"])
+            .expect("JSON output should be transport independent");
 
         assert_eq!(cli.backend, BackendKind::Http);
         assert!(cli.json);
@@ -1512,8 +1506,7 @@ mod tests {
 
     #[test]
     fn parse_restore_force() {
-        let cli =
-            Cli::try_parse_from(["lific", "restore", "/tmp/b.tar.gz", "--force"]).unwrap();
+        let cli = Cli::try_parse_from(["lific", "restore", "/tmp/b.tar.gz", "--force"]).unwrap();
         match cli.command {
             Command::Restore {
                 archive,
@@ -1530,8 +1523,8 @@ mod tests {
 
     #[test]
     fn parse_restore_allow_large() {
-        let cli = Cli::try_parse_from(["lific", "restore", "/tmp/b.tar.gz", "--allow-large"])
-            .unwrap();
+        let cli =
+            Cli::try_parse_from(["lific", "restore", "/tmp/b.tar.gz", "--allow-large"]).unwrap();
         match cli.command {
             Command::Restore {
                 force, allow_large, ..
@@ -1617,13 +1610,16 @@ mod tests {
     #[test]
     fn parse_login_complete() {
         let cli = Cli::try_parse_from([
-            "lific", "login", "--complete", "abc123def", "--url", "http://h:1",
+            "lific",
+            "login",
+            "--complete",
+            "abc123def",
+            "--url",
+            "http://h:1",
         ])
         .unwrap();
         match cli.command {
-            Command::Login {
-                complete, url, ..
-            } => {
+            Command::Login { complete, url, .. } => {
                 assert_eq!(complete, Some("abc123def".into()));
                 assert_eq!(url, Some("http://h:1".into()));
             }
@@ -1642,7 +1638,8 @@ mod tests {
 
     #[test]
     fn parse_logout_with_url() {
-        let cli = Cli::try_parse_from(["lific", "logout", "--url", "https://lific.example"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["lific", "logout", "--url", "https://lific.example"]).unwrap();
         match cli.command {
             Command::Logout { url } => assert_eq!(url, Some("https://lific.example".into())),
             _ => panic!("expected Logout"),
@@ -1717,14 +1714,21 @@ mod tests {
     #[test]
     fn parse_connect_repeatable_client_and_flags() {
         let cli = Cli::try_parse_from([
-            "lific", "connect",
-            "--client", "opencode",
-            "--client", "codex",
-            "--scope", "project",
+            "lific",
+            "connect",
+            "--client",
+            "opencode",
+            "--client",
+            "codex",
+            "--scope",
+            "project",
             "--stdio",
-            "--url", "http://127.0.0.1:9000/mcp",
-            "--key", "lific_sk-live-K",
-            "--user", "blake",
+            "--url",
+            "http://127.0.0.1:9000/mcp",
+            "--key",
+            "lific_sk-live-K",
+            "--user",
+            "blake",
             "--yes",
             "--dry-run",
             "--skip-agents",
@@ -1773,7 +1777,12 @@ mod tests {
     #[test]
     fn parse_agents_md_with_path_and_project() {
         let cli = Cli::try_parse_from([
-            "lific", "agents-md", "--path", "docs/AGENTS.md", "--project", "LIF",
+            "lific",
+            "agents-md",
+            "--path",
+            "docs/AGENTS.md",
+            "--project",
+            "LIF",
         ])
         .unwrap();
         match cli.command {
@@ -1826,14 +1835,23 @@ mod tests {
     #[test]
     fn parse_instance_set() {
         let cli = Cli::try_parse_from([
-            "lific", "instance", "set",
-            "--name", "Acme Eng",
-            "--signups", "false",
-            "--signup-domains", "acme.com,sub.acme.com",
-            "--session-days", "14",
-            "--login-message", "Ask #it for access",
-            "--auto-login", "true",
-            "--authz-enforced", "true",
+            "lific",
+            "instance",
+            "set",
+            "--name",
+            "Acme Eng",
+            "--signups",
+            "false",
+            "--signup-domains",
+            "acme.com,sub.acme.com",
+            "--session-days",
+            "14",
+            "--login-message",
+            "Ask #it for access",
+            "--auto-login",
+            "true",
+            "--authz-enforced",
+            "true",
         ])
         .unwrap();
         match cli.command {
@@ -1866,11 +1884,12 @@ mod tests {
         let cli = Cli::try_parse_from(["lific", "key", "create", "--name", "test-key"]).unwrap();
         match cli.command {
             Command::Key {
-                action: KeyAction::Create {
-                    name,
-                    user,
-                    expires,
-                },
+                action:
+                    KeyAction::Create {
+                        name,
+                        user,
+                        expires,
+                    },
             } => {
                 assert_eq!(name, "test-key");
                 assert!(user.is_none());
@@ -1888,11 +1907,12 @@ mod tests {
         .unwrap();
         match cli.command {
             Command::Key {
-                action: KeyAction::Create {
-                    name,
-                    user,
-                    expires,
-                },
+                action:
+                    KeyAction::Create {
+                        name,
+                        user,
+                        expires,
+                    },
             } => {
                 assert_eq!(name, "my-key");
                 assert_eq!(user, Some("blake".into()));
@@ -1916,11 +1936,12 @@ mod tests {
         .unwrap();
         match cli.command {
             Command::Key {
-                action: KeyAction::Create {
-                    name,
-                    user,
-                    expires,
-                },
+                action:
+                    KeyAction::Create {
+                        name,
+                        user,
+                        expires,
+                    },
             } => {
                 assert_eq!(name, "temp-key");
                 assert!(user.is_none());
@@ -2009,10 +2030,8 @@ mod tests {
 
     #[test]
     fn parse_user_set_password() {
-        let cli = Cli::try_parse_from([
-            "lific", "user", "set-password", "--username", "blake",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["lific", "user", "set-password", "--username", "blake"]).unwrap();
         match cli.command {
             Command::User {
                 action: UserAction::SetPassword { username, password },
@@ -2027,7 +2046,13 @@ mod tests {
     #[test]
     fn parse_user_set_password_with_password_flag() {
         let cli = Cli::try_parse_from([
-            "lific", "user", "set-password", "-u", "blake", "-p", "newpass123",
+            "lific",
+            "user",
+            "set-password",
+            "-u",
+            "blake",
+            "-p",
+            "newpass123",
         ])
         .unwrap();
         match cli.command {
@@ -2046,12 +2071,24 @@ mod tests {
     #[test]
     fn parse_member_add_defaults_to_viewer() {
         let cli = Cli::try_parse_from([
-            "lific", "member", "add", "--project", "LIF", "--user", "bob",
+            "lific",
+            "member",
+            "add",
+            "--project",
+            "LIF",
+            "--user",
+            "bob",
         ])
         .unwrap();
         match cli.command {
             Command::Member {
-                action: MemberAction::Add { project, user, role, all },
+                action:
+                    MemberAction::Add {
+                        project,
+                        user,
+                        role,
+                        all,
+                    },
             } => {
                 assert_eq!(project, Some("LIF".into()));
                 assert_eq!(user, "bob");
@@ -2065,12 +2102,25 @@ mod tests {
     #[test]
     fn parse_member_add_all_projects() {
         let cli = Cli::try_parse_from([
-            "lific", "member", "add", "--all", "--user", "bob", "--role", "maintainer",
+            "lific",
+            "member",
+            "add",
+            "--all",
+            "--user",
+            "bob",
+            "--role",
+            "maintainer",
         ])
         .unwrap();
         match cli.command {
             Command::Member {
-                action: MemberAction::Add { project, user, role, all },
+                action:
+                    MemberAction::Add {
+                        project,
+                        user,
+                        role,
+                        all,
+                    },
             } => {
                 assert!(project.is_none());
                 assert_eq!(user, "bob");
@@ -2089,7 +2139,14 @@ mod tests {
         );
         assert!(
             Cli::try_parse_from([
-                "lific", "member", "add", "--project", "LIF", "--all", "--user", "bob",
+                "lific",
+                "member",
+                "add",
+                "--project",
+                "LIF",
+                "--all",
+                "--user",
+                "bob",
             ])
             .is_err(),
             "--project conflicts with --all"
@@ -2102,7 +2159,9 @@ mod tests {
             Cli::try_parse_from(["lific", "member", "list", "--project", "LIF"])
                 .unwrap()
                 .command,
-            Command::Member { action: MemberAction::List { .. } }
+            Command::Member {
+                action: MemberAction::List { .. }
+            }
         ));
         match Cli::try_parse_from([
             "lific", "member", "role", "-p", "LIF", "-u", "bob", "-r", "lead",
@@ -2111,9 +2170,17 @@ mod tests {
         .command
         {
             Command::Member {
-                action: MemberAction::Role { project, user, role },
+                action:
+                    MemberAction::Role {
+                        project,
+                        user,
+                        role,
+                    },
             } => {
-                assert_eq!((project.as_str(), user.as_str(), role.as_str()), ("LIF", "bob", "lead"));
+                assert_eq!(
+                    (project.as_str(), user.as_str(), role.as_str()),
+                    ("LIF", "bob", "lead")
+                );
             }
             _ => panic!("expected Member Role"),
         }
@@ -2121,7 +2188,9 @@ mod tests {
             Cli::try_parse_from(["lific", "member", "remove", "-p", "LIF", "-u", "bob"])
                 .unwrap()
                 .command,
-            Command::Member { action: MemberAction::Remove { .. } }
+            Command::Member {
+                action: MemberAction::Remove { .. }
+            }
         ));
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -61,7 +61,7 @@ pub(super) fn resolve_http_credential(
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum BackendKind {
-    /// Execute commands against the configured SQLite database.
+    /// Execute commands against the configured `SQLite` database.
     Sql,
     /// Execute commands against a Lific HTTP server.
     Http,
@@ -78,7 +78,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub config: Option<PathBuf>,
 
-    /// Path to the SQLite database file (overrides config)
+    /// Path to the `SQLite` database file (overrides config)
     #[arg(long, global = true)]
     pub db: Option<PathBuf>,
 
@@ -86,15 +86,15 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
-    /// Backend for data commands (defaults to the local SQLite database).
+    /// Backend for data commands (defaults to the local `SQLite` database).
     #[arg(long, global = true, value_enum, default_value_t = BackendKind::Sql)]
     pub backend: BackendKind,
 
-    /// Base URL for the HTTP backend (also read from LIFIC_URL).
+    /// Base URL for the HTTP backend (also read from `LIFIC_URL`).
     #[arg(long, global = true, env = "LIFIC_URL")]
     pub url: Option<String>,
 
-    /// API key for the HTTP backend (also read from LIFIC_API_KEY; login
+    /// API key for the HTTP backend (also read from `LIFIC_API_KEY`; login
     /// credentials are used when this is omitted).
     #[arg(long = "api-key", global = true, env = "LIFIC_API_KEY")]
     pub api_key: Option<String>,
@@ -126,12 +126,12 @@ pub enum Command {
     /// OAuth token is stored in your OS keyring (or a 0600 file fallback) so
     /// later commands can reuse it.
     ///
-    /// Agent/CI friendly: `--non-interactive` prints the code + device_code as
+    /// Agent/CI friendly: `--non-interactive` prints the code + `device_code` as
     /// JSON and exits immediately; complete the login later (after a human
     /// approves) with `lific login --complete <device_code>`.
     Login {
-        /// Base URL of the server (default: server.public_url, else
-        /// http://127.0.0.1:<port>).
+        /// Base URL of the server (default: `server.public_url`, else
+        /// <http://127.0.0.1>:<port>).
         #[arg(long)]
         url: Option<String>,
 
@@ -140,7 +140,7 @@ pub enum Command {
         #[arg(long = "non-interactive")]
         non_interactive: bool,
 
-        /// Resume a previously started login by polling for this device_code
+        /// Resume a previously started login by polling for this `device_code`
         /// until it is approved/denied/expired, then store the token.
         #[arg(long)]
         complete: Option<String>,
@@ -158,8 +158,8 @@ pub enum Command {
     /// Sign out: delete the stored credential for a server and best-effort
     /// revoke it server-side.
     Logout {
-        /// Base URL of the server (default: server.public_url, else
-        /// http://127.0.0.1:<port>).
+        /// Base URL of the server (default: `server.public_url`, else
+        /// <http://127.0.0.1>:<port>).
         #[arg(long)]
         url: Option<String>,
     },
@@ -173,7 +173,7 @@ pub enum Command {
     /// (not failed) when nothing is listening.
     Doctor {
         /// API key to test an authorized MCP round-trip. Falls back to the
-        /// LIFIC_API_KEY environment variable. Without a key, doctor still
+        /// `LIFIC_API_KEY` environment variable. Without a key, doctor still
         /// verifies that auth is enforced and discovery is advertised.
         #[arg(long, env = "LIFIC_API_KEY")]
         key: Option<String>,
@@ -183,7 +183,7 @@ pub enum Command {
     ///
     /// One command, whole story: writes lific.toml (kept if already present),
     /// creates the database, prints your initial API key, installs a
-    /// background service (systemd user unit on Linux, LaunchAgent on macOS)
+    /// background service (systemd user unit on Linux, `LaunchAgent` on macOS)
     /// and starts it, then waits until the server answers. Re-running is safe
     /// and repairs whatever is missing. Use `--no-service` if you'd rather run
     /// `lific start` in the foreground yourself.
@@ -237,7 +237,7 @@ pub enum Command {
     /// Produces `lific_YYYYMMDD_HHMMSS.tar.gz` (gitea-dump style) containing a
     /// consistent snapshot of the database, every attachment blob, and a
     /// `manifest.json`. Safe to run while the server is running (the DB is
-    /// snapshotted via SQLite's online backup, no writer lock is held). The archive is
+    /// snapshotted via `SQLite`'s online backup, no writer lock is held). The archive is
     /// chmod 0600. Point external harnesses (restic/borg/cron) at the output,
     /// or call this as a pre-backup hook.
     Dump {
@@ -310,8 +310,8 @@ pub enum Command {
         #[arg(long)]
         oauth: bool,
 
-        /// Override the MCP URL (default: server.public_url, else
-        /// http://127.0.0.1:<port>/mcp).
+        /// Override the MCP URL (default: `server.public_url`, else
+        /// <http://127.0.0.1>:<port>/mcp).
         #[arg(long)]
         url: Option<String>,
 
@@ -503,7 +503,7 @@ pub enum ImportAction {
         #[arg(long, default_value = "all")]
         state: String,
 
-        /// GitHub token (falls back to GITHUB_TOKEN). Optional for public
+        /// GitHub token (falls back to `GITHUB_TOKEN`). Optional for public
         /// repos, but strongly recommended to avoid the 60 req/hr anon limit.
         #[arg(long, env = "GITHUB_TOKEN")]
         token: Option<String>,
@@ -536,7 +536,7 @@ pub enum ImportAction {
         #[arg(long)]
         project: String,
 
-        /// Linear personal API key (falls back to LINEAR_API_KEY).
+        /// Linear personal API key (falls back to `LINEAR_API_KEY`).
         #[arg(long, env = "LINEAR_API_KEY")]
         token: Option<String>,
 
@@ -563,11 +563,11 @@ pub enum ImportAction {
         #[arg(long)]
         project: String,
 
-        /// Jira account email (falls back to JIRA_EMAIL).
+        /// Jira account email (falls back to `JIRA_EMAIL`).
         #[arg(long, env = "JIRA_EMAIL")]
         email: Option<String>,
 
-        /// Jira API token (falls back to JIRA_API_TOKEN).
+        /// Jira API token (falls back to `JIRA_API_TOKEN`).
         #[arg(long, env = "JIRA_API_TOKEN")]
         token: Option<String>,
 

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -392,7 +392,12 @@ pub fn comment_list(
 
 pub fn comment_added(comment: &Comment, identifier: &str) -> String {
     let mut out = String::new();
-    w!(out, "Added comment to {} by {}:", identifier, comment.author);
+    w!(
+        out,
+        "Added comment to {} by {}:",
+        identifier,
+        comment.author
+    );
     w!(out, "  {}", comment.content);
     out
 }
@@ -498,7 +503,12 @@ pub fn folder_created(folder: &Folder) -> String {
 
 pub fn folder_updated(previous_name: &str, folder: &Folder) -> String {
     let mut out = String::new();
-    w!(out, "Renamed folder '{}' -> '{}'", previous_name, folder.name);
+    w!(
+        out,
+        "Renamed folder '{}' -> '{}'",
+        previous_name,
+        folder.name
+    );
     out
 }
 
@@ -594,7 +604,10 @@ mod tests {
             ),
             "got: {unknown}"
         );
-        assert!(!unknown.contains("More comments available"), "got: {unknown}");
+        assert!(
+            !unknown.contains("More comments available"),
+            "got: {unknown}"
+        );
     }
 
     #[test]

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -11,7 +11,7 @@
 //! - **systemd (user unit)** on Linux: `~/.config/systemd/user/lific.service`,
 //!   enabled via `systemctl --user enable --now`. `loginctl enable-linger` is
 //!   attempted (best-effort) so the unit keeps running after logout.
-//! - **launchd (LaunchAgent)** on macOS: `~/Library/LaunchAgents/dev.lific.plist`,
+//! - **launchd (`LaunchAgent`)** on macOS: `~/Library/LaunchAgents/dev.lific.plist`,
 //!   loaded via `launchctl bootstrap gui/<uid>` (falling back to the legacy
 //!   `launchctl load -w` on older systems).
 //!
@@ -118,8 +118,7 @@ pub fn detect() -> Option<Manager> {
         let ok = Command::new("systemctl")
             .args(["--user", "show", "--property=Version"])
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
+            .is_ok_and(|o| o.status.success());
         if ok {
             return Some(Manager::SystemdUser);
         }
@@ -152,7 +151,7 @@ pub fn definition_path(manager: Manager) -> Result<PathBuf, String> {
 /// Render the systemd user unit. Paths are systemd-quoted so spaces survive.
 pub fn systemd_unit(plan: &ServicePlan) -> String {
     format!(
-        r#"# Managed by `lific init` / `lific service install`.
+        r"# Managed by `lific init` / `lific service install`.
 [Unit]
 Description=Lific issue tracker
 After=network.target
@@ -166,14 +165,14 @@ RestartSec=2
 
 [Install]
 WantedBy=default.target
-"#,
+",
         exe = systemd_quote(&plan.exe, true),
         config = systemd_quote(&plan.config, true),
         workdir = systemd_quote(&plan.workdir, false),
     )
 }
 
-/// Quote a path for a systemd ExecStart line (double quotes, escape embedded
+/// Quote a path for a systemd `ExecStart` line (double quotes, escape embedded
 /// quotes/backslashes). systemd's quoting rules accept this for paths.
 fn systemd_quote(p: &Path, escape_dollar: bool) -> String {
     let s = p.display().to_string();
@@ -191,7 +190,7 @@ fn systemd_quote(p: &Path, escape_dollar: bool) -> String {
     }
 }
 
-/// Render the launchd LaunchAgent plist.
+/// Render the launchd `LaunchAgent` plist.
 pub fn launchd_plist(plan: &ServicePlan) -> String {
     let log = plan.workdir.join("lific.log");
     format!(
@@ -262,7 +261,7 @@ fn launchd_domain() -> Result<String, String> {
     Err("launchd services are only available on macOS".to_string())
 }
 
-/// Load (or reload) the LaunchAgent at `path` into the user's GUI domain.
+/// Load (or reload) the `LaunchAgent` at `path` into the user's GUI domain.
 ///
 /// Shared by [`install`] and [`restart`], which perform an identical dance:
 /// boot out any already-loaded copy, bootstrap the new one, and fall back to
@@ -315,8 +314,7 @@ pub fn install(manager: Manager, plan: &ServicePlan) -> Result<InstallReport, St
             let linger = Command::new("loginctl")
                 .arg("enable-linger")
                 .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
+                .is_ok_and(|s| s.success());
             Ok(InstallReport {
                 manager: manager.label().into(),
                 definition: path.display().to_string(),
@@ -385,13 +383,11 @@ pub fn status(manager: Manager) -> Result<StatusReport, String> {
         Manager::SystemdUser => Command::new("systemctl")
             .args(["--user", "is-active", "--quiet", SYSTEMD_UNIT_NAME])
             .status()
-            .map(|s| s.success())
-            .unwrap_or(false),
+            .is_ok_and(|s| s.success()),
         Manager::Launchd => Command::new("launchctl")
             .args(["print", &format!("{}/{LAUNCHD_LABEL}", launchd_domain()?)])
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false),
+            .is_ok_and(|o| o.status.success()),
     };
     Ok(StatusReport {
         manager: manager.label().into(),

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -157,7 +157,10 @@ mod tests {
             err.contains("--yes"),
             "error should name the bypass flag, got: {err}"
         );
-        assert!(err.contains("interactive"), "error should explain why: {err}");
+        assert!(
+            err.contains("interactive"),
+            "error should explain why: {err}"
+        );
     }
 
     #[test]
@@ -188,30 +191,49 @@ mod tests {
     #[test]
     fn prompt_text_refuses_without_tty_and_names_bypass_flag() {
         let mut input: &[u8] = b"";
-        let err = prompt_text_inner("What's your name?", "--name", false, &mut input, &mut Vec::new())
-            .expect_err("must refuse when stdin is not a TTY");
+        let err = prompt_text_inner(
+            "What's your name?",
+            "--name",
+            false,
+            &mut input,
+            &mut Vec::new(),
+        )
+        .expect_err("must refuse when stdin is not a TTY");
         assert!(
             err.contains("--name"),
             "error should name the bypass flag, got: {err}"
         );
-        assert!(err.contains("interactive"), "error should explain why: {err}");
+        assert!(
+            err.contains("interactive"),
+            "error should explain why: {err}"
+        );
     }
 
     #[test]
     fn prompt_text_trims_response_on_tty() {
         let mut input: &[u8] = b"  Blake Alston  \n";
-        let value =
-            prompt_text_inner("What's your name?", "--name", true, &mut input, &mut Vec::new())
-                .unwrap();
+        let value = prompt_text_inner(
+            "What's your name?",
+            "--name",
+            true,
+            &mut input,
+            &mut Vec::new(),
+        )
+        .unwrap();
         assert_eq!(value, "Blake Alston");
     }
 
     #[test]
     fn prompt_text_rejects_empty_input() {
         let mut input: &[u8] = b"\n";
-        let err =
-            prompt_text_inner("What's your name?", "--name", true, &mut input, &mut Vec::new())
-                .expect_err("empty input must fail");
+        let err = prompt_text_inner(
+            "What's your name?",
+            "--name",
+            true,
+            &mut input,
+            &mut Vec::new(),
+        )
+        .expect_err("empty input must fail");
         assert!(err.contains("empty"), "error should explain why: {err}");
     }
 }

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -18,7 +18,12 @@
 
 /// Begin a command session: prints the `┌ <title>` header.
 pub fn intro(title: &str) {
-    let _ = cliclack::intro(console::style(format!(" {title} ")).on_cyan().black().to_string());
+    let _ = cliclack::intro(
+        console::style(format!(" {title} "))
+            .on_cyan()
+            .black()
+            .to_string(),
+    );
 }
 
 /// A completed step: `◇ <msg>`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -347,7 +347,7 @@ impl Default for BackupConfig {
             enabled: true,
             dir: PathBuf::from("backups"),
             interval_minutes: 60,
-            retain: 24, // keep 24 hourly backups = 1 day of history
+            retain: 24,                 // keep 24 hourly backups = 1 day of history
             audit_retention_days: None, // keep audit history forever
         }
     }
@@ -570,10 +570,7 @@ mod tests {
         let config = Config::default();
         assert_eq!(config.server.host, "0.0.0.0");
         assert_eq!(config.server.port, 3456);
-        assert_eq!(
-            config.server.trusted_proxies,
-            Vec::<String>::new()
-        );
+        assert_eq!(config.server.trusted_proxies, Vec::<String>::new());
         assert_eq!(config.database.path, PathBuf::from("lific.db"));
         assert!(config.backup.enabled);
         assert_eq!(config.backup.retain, 24);
@@ -622,7 +619,10 @@ enabled = false
 
         Config::load(Some(&path)).unwrap();
 
-        assert_eq!(std::fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 
     #[cfg(unix)]
@@ -755,7 +755,11 @@ enabled = false
     fn absolute_db_path_is_untouched_by_anchoring() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("lific.toml");
-        std::fs::write(&path, format!("[database]\npath = \"{ABSOLUTE_DB_PATH}\"\n")).unwrap();
+        std::fs::write(
+            &path,
+            format!("[database]\npath = \"{ABSOLUTE_DB_PATH}\"\n"),
+        )
+        .unwrap();
 
         let config = Config::load(Some(&path)).unwrap();
         assert_eq!(config.database.path, PathBuf::from(ABSOLUTE_DB_PATH));
@@ -1032,17 +1036,14 @@ enabled = false
     // LIFIC-24: the startup guard's bind-host check.
     #[test]
     fn is_localhost_host_accepts_only_loopback() {
-        for host in [
-            "127.0.0.1",
-            "127.5.5.5",
-            "::1",
-            "localhost",
-            "LOCALHOST",
-        ] {
+        for host in ["127.0.0.1", "127.5.5.5", "::1", "localhost", "LOCALHOST"] {
             assert!(is_localhost_host(host), "{host} should count as loopback");
         }
         for host in ["0.0.0.0", "::", "[::]", "192.168.1.10", "lific.example", ""] {
-            assert!(!is_localhost_host(host), "{host} must NOT count as loopback");
+            assert!(
+                !is_localhost_host(host),
+                "{host} must NOT count as loopback"
+            );
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,13 +22,16 @@ struct ConfigFile {
 /// was read from. Fails closed on symlinks: [`read_config_file`] opens with
 /// `O_NOFOLLOW`, so a symlinked config never produces a [`ConfigFile`] to
 /// tighten in the first place.
-fn tighten_config_permissions(_config: &ConfigFile) -> std::io::Result<()> {
+fn tighten_config_permissions(config: &ConfigFile) -> std::io::Result<()> {
+    #[cfg(not(unix))]
+    let _ = config;
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        let metadata = _config.file.metadata()?;
+        let metadata = config.file.metadata()?;
         if metadata.mode() & 0o077 != 0 {
-            _config
+            config
                 .file
                 .set_permissions(std::fs::Permissions::from_mode(0o600))?;
         }
@@ -85,7 +88,7 @@ pub enum ConfigError {
         path: PathBuf,
         /// Boxed to keep `ConfigError` small. `toml::de::Error` is over 100
         /// bytes on its own, which makes every `Result<Config, _>` in the
-        /// program pay for the failure path (clippy::result_large_err).
+        /// program pay for the failure path (`clippy::result_large_err`).
         #[source]
         source: Box<toml::de::Error>,
     },
@@ -147,7 +150,7 @@ impl Default for AuthConfig {
 
 impl AuthConfig {
     /// Build the runtime auth config, deriving `secure_cookies` from the
-    /// server's public URL scheme. Only an explicit `http://` public_url turns
+    /// server's public URL scheme. Only an explicit `http://` `public_url` turns
     /// `Secure` off; everything else (https, or unset) stays secure-by-default.
     pub fn from_server(file: &AuthConfig, public_url: Option<&str>) -> Self {
         let secure_cookies = match public_url {
@@ -253,15 +256,15 @@ pub struct ServerConfig {
     pub host: String,
     /// Port to listen on
     pub port: u16,
-    /// Public URL for OAuth discovery (e.g. https://your-server.example.com/lific)
+    /// Public URL for OAuth discovery (e.g. <https://your-server.example.com/lific>)
     pub public_url: Option<String>,
     /// Allowed CORS origins. If empty, allows all origins (not recommended for production).
-    /// Example: ["https://your-app.example.com"]
+    /// Example: `["https://your-app.example.com"]`
     pub cors_origins: Vec<String>,
     /// IP addresses or CIDR ranges allowed to supply client-IP proxy headers.
     /// Plain IPs are allowed; defaults to no trusted peers. Configure only
     /// isolated reverse-proxy addresses that cannot be reached directly.
-    /// Example: ["10.0.0.0/8"]
+    /// Example: `["10.0.0.0/8"]`
     pub trusted_proxies: Vec<String>,
     /// If set, exposes an authless MCP endpoint at `/mcp/<token>` that skips the
     /// OAuth flow entirely — the path secret itself is the credential. This is an
@@ -279,7 +282,7 @@ pub struct ServerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct DatabaseConfig {
-    /// Path to the SQLite database file
+    /// Path to the `SQLite` database file
     pub path: PathBuf,
 }
 
@@ -424,12 +427,13 @@ impl Config {
                         });
                     }
                 },
-                Err(source) if source.kind() == std::io::ErrorKind::NotFound => continue,
                 Err(source) => {
-                    return Err(ConfigError::Read {
-                        path: path.clone(),
-                        source,
-                    });
+                    if source.kind() != std::io::ErrorKind::NotFound {
+                        return Err(ConfigError::Read {
+                            path: path.clone(),
+                            source,
+                        });
+                    }
                 }
             }
         }
@@ -505,7 +509,7 @@ impl Config {
     /// LIFIC-23: sets `[auth] required` and, when `host` is supplied,
     /// `[server] host`. When `existing` is empty/absent the function builds a
     /// fresh default config carrying the chosen values; otherwise it edits the
-    /// existing TOML in place (formatting and comments survive via toml_edit).
+    /// existing TOML in place (formatting and comments survive via `toml_edit`).
     /// Pure — no filesystem side effects. This is what the `lific init`
     /// auth-mode menu (LIFIC-25) uses to persist the operator's choice.
     ///

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -220,7 +220,7 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
 
 /// Migrations that rebuild a table other tables reference by foreign key.
 ///
-/// SQLite cannot change a column's collating sequence in place, so those
+/// `SQLite` cannot change a column's collating sequence in place, so those
 /// migrations drop and recreate the table. Two connection pragmas have to be
 /// set around the rebuild, and neither can be set from inside the migration
 /// file itself:
@@ -231,11 +231,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
 ///   takes every child row with it.
 /// * `legacy_alter_table = ON` — otherwise `ALTER TABLE x RENAME TO parent`
 ///   reparses every trigger in the schema and fails with "error in trigger
-///   audit_issues_insert: no such table: main.projects", since the old table
+///   `audit_issues_insert`: no such table: main.projects", since the old table
 ///   is already gone by then. Legacy mode also leaves child `REFERENCES`
 ///   clauses alone, which is what we want: ids are preserved verbatim.
 ///
-/// This is the standard SQLite table-rebuild procedure. Both pragmas are
+/// This is the standard `SQLite` table-rebuild procedure. Both pragmas are
 /// silent no-ops inside a transaction, and `run` serializes the whole batch
 /// under one `BEGIN IMMEDIATE` (see below), so when a rebuild migration is
 /// pending the pragmas are set on the connection *before* that transaction
@@ -899,7 +899,7 @@ mod tests {
         rows.collect::<Result<Vec<String>, _>>().unwrap()
     }
 
-    /// The whole point of the index is that SQLite reaches for it instead of
+    /// The whole point of the index is that `SQLite` reaches for it instead of
     /// scanning, so assert against the query planner rather than merely that
     /// a name exists in `sqlite_master`.
     fn query_plan(conn: &Connection, sql: &str) -> String {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -669,7 +669,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(has_column, 0, "fixture must start on the pre-checksum shape");
+        assert_eq!(
+            has_column, 0,
+            "fixture must start on the pre-checksum shape"
+        );
 
         run(&conn).expect("a legacy database must upgrade cleanly");
 
@@ -988,7 +991,9 @@ mod tests {
             .unwrap();
         assert_eq!(counts, (3, 2), "no rows may be lost or deduplicated");
         assert!(index_names(&conn, "oauth_codes").contains(&"idx_oauth_codes_client".to_string()));
-        assert!(index_names(&conn, "oauth_tokens").contains(&"idx_oauth_tokens_client".to_string()));
+        assert!(
+            index_names(&conn, "oauth_tokens").contains(&"idx_oauth_tokens_client".to_string())
+        );
 
         // Non-unique: another code for a client that already has two.
         conn.execute(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -283,9 +283,8 @@ fn ensure_private_file(path: &Path) -> Result<(), LificError> {
     match options.open(path) {
         Ok(_) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            let metadata = std::fs::symlink_metadata(path).map_err(|error| {
-                LificError::Internal(format!("inspect database file: {error}"))
-            })?;
+            let metadata = std::fs::symlink_metadata(path)
+                .map_err(|error| LificError::Internal(format!("inspect database file: {error}")))?;
             if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
                 return Err(LificError::Internal(
                     "database path must be a regular file, not a link".into(),
@@ -316,10 +315,9 @@ fn secure_parent(path: &Path) -> Result<(), LificError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        let metadata = parent
-            .symlink_metadata()
-            .map_err(|error| LificError::Internal(format!("inspect database directory: {error}")))?
-            ;
+        let metadata = parent.symlink_metadata().map_err(|error| {
+            LificError::Internal(format!("inspect database directory: {error}"))
+        })?;
         if metadata.file_type().is_symlink() {
             return Err(LificError::Internal(
                 "database directory must not be a symlink".into(),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -11,12 +11,12 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use crate::error::LificError;
 
 /// Number of read connections in the pool.
-/// SQLite WAL mode supports unlimited concurrent readers.
+/// `SQLite` WAL mode supports unlimited concurrent readers.
 const READ_POOL_SIZE: usize = 8;
 
 /// Database pool with read/write splitting.
 ///
-/// SQLite allows concurrent reads but only one writer at a time.
+/// `SQLite` allows concurrent reads but only one writer at a time.
 /// - Writes go through a single Mutex-protected connection.
 /// - Reads pull from a lock-free pool of read-only connections.
 /// - Readers never block each other. Readers never block writers.
@@ -70,19 +70,18 @@ impl DbPool {
 
     /// Acquire a read-only connection from the pool.
     pub fn read(&self) -> Result<ReadConn, LificError> {
-        match self.readers.pop() {
-            Some(conn) => Ok(ReadConn {
+        if let Some(conn) = self.readers.pop() {
+            Ok(ReadConn {
                 conn: Some(conn),
                 pool: Arc::clone(&self.readers),
-            }),
-            None => {
-                // Pool exhausted — open a fresh read connection
-                let conn = open_read_connection(&self.path)?;
-                Ok(ReadConn {
-                    conn: Some(conn),
-                    pool: Arc::clone(&self.readers),
-                })
-            }
+            })
+        } else {
+            // Pool exhausted — open a fresh read connection
+            let conn = open_read_connection(&self.path)?;
+            Ok(ReadConn {
+                conn: Some(conn),
+                pool: Arc::clone(&self.readers),
+            })
         }
     }
 
@@ -105,7 +104,7 @@ impl DbPool {
         Ok(connection)
     }
 
-    /// Run a write operation in an immediate SQLite transaction.
+    /// Run a write operation in an immediate `SQLite` transaction.
     ///
     /// The immediate lock serializes the caller's reads and writes with
     /// writers in other processes. Errors roll back on drop.
@@ -138,13 +137,13 @@ fn apply_pragmas(conn: &Connection) -> Result<(), LificError> {
     Ok(())
 }
 
-/// Disable SQLite's memory-usage statistics before the first connection is
+/// Disable `SQLite`'s memory-usage statistics before the first connection is
 /// created. When memstatus is on (the default), every sqlite3 malloc/free in
 /// the entire process serializes on one global mutex (`mem0`) — with many
 /// threads (e.g. the parallel test runner) this becomes a futex storm that
 /// burns more CPU in the kernel than the actual queries. We never read
-/// sqlite3_memory_used(), so the stats are pure overhead. Must run before
-/// SQLite initializes; once it has, the call returns SQLITE_MISUSE and is a
+/// `sqlite3_memory_used()`, so the stats are pure overhead. Must run before
+/// `SQLite` initializes; once it has, the call returns `SQLITE_MISUSE` and is a
 /// harmless no-op.
 fn disable_sqlite_memstatus() {
     static ONCE: std::sync::Once = std::sync::Once::new();
@@ -233,7 +232,7 @@ pub fn open_memory() -> Result<DbPool, LificError> {
     })
 }
 
-/// Open (or create) the SQLite database, run migrations, and return a pool.
+/// Open (or create) the `SQLite` database, run migrations, and return a pool.
 pub fn open(path: &Path) -> Result<DbPool, LificError> {
     disable_sqlite_memstatus();
     secure_parent(path)?;
@@ -339,11 +338,14 @@ fn secure_parent(path: &Path) -> Result<(), LificError> {
     Ok(())
 }
 
-fn secure_file(_path: &Path) -> Result<(), LificError> {
+fn secure_file(path: &Path) -> Result<(), LificError> {
+    #[cfg(not(unix))]
+    let _ = path;
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(_path, std::fs::Permissions::from_mode(0o600))
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
             .map_err(|error| LificError::Internal(format!("secure database file: {error}")))?;
     }
     Ok(())

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -9,7 +9,7 @@ pub struct Project {
     pub emoji: Option<String>,
     pub lead_user_id: Option<i64>,
     /// LIF-233: sidebar ordering rank. Reindexed 0..N on every reorder; new
-    /// projects append at the end. list_projects orders by this then name.
+    /// projects append at the end. `list_projects` orders by this then name.
     pub sort_order: i64,
     pub created_at: String,
     pub updated_at: String,
@@ -273,7 +273,7 @@ pub struct Issue {
     /// Labels attached to this issue (populated on read)
     #[serde(default)]
     pub labels: Vec<String>,
-    /// Relations (populated on read for get_issue)
+    /// Relations (populated on read for `get_issue`)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub blocks: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -302,7 +302,7 @@ pub struct ProjectRelation {
     pub target_id: i64,
     /// Computed "{project.identifier}-{sequence}" for the target issue.
     pub target_identifier: String,
-    /// blocks | relates_to | duplicate (directional: source→target).
+    /// blocks | `relates_to` | duplicate (directional: source→target).
     pub relation_type: String,
 }
 
@@ -377,7 +377,7 @@ pub struct ListIssuesQuery {
     pub updated_since: Option<String>,
     /// Exclusive upper bound on `updated_at`.
     pub updated_until: Option<String>,
-    /// Sort column: sort_order (default), sequence, created, updated, priority.
+    /// Sort column: `sort_order` (default), sequence, created, updated, priority.
     /// Whitelisted in `list_issues` — never interpolated raw.
     pub order_by: Option<String>,
     /// Sort direction: asc (default) or desc.
@@ -517,7 +517,7 @@ pub struct CreatePage {
     #[serde(default = "default_page_status")]
     pub status: String,
     /// Label names to attach. Silently ignored for workspace pages (no
-    /// project_id), since labels are project-scoped (LIF-105).
+    /// `project_id`), since labels are project-scoped (LIF-105).
     #[serde(default)]
     pub labels: Vec<String>,
 }
@@ -1000,7 +1000,7 @@ pub struct Plan {
     pub status: String,
     pub created_at: String,
     pub updated_at: String,
-    /// Nested step tree (populated on read for get_plan). Empty in list views.
+    /// Nested step tree (populated on read for `get_plan`). Empty in list views.
     #[serde(default)]
     pub steps: Vec<PlanStepNode>,
     /// Step counts (populated for list views and headers).
@@ -1050,7 +1050,7 @@ pub struct CreatePlan {
     pub steps: Vec<CreatePlanStep>,
 }
 
-/// A step in a create_plan tree. Recursive via `steps`.
+/// A step in a `create_plan` tree. Recursive via `steps`.
 #[derive(Debug, Deserialize)]
 pub struct CreatePlanStep {
     pub title: String,
@@ -1268,9 +1268,9 @@ pub struct ProjectAttachmentQuery {
     /// Restrict to attachments linked via this kind of entity: issue | page |
     /// comment.
     pub entity_type: Option<String>,
-    /// created_at (default) | size | filename
+    /// `created_at` (default) | size | filename
     pub sort: Option<String>,
-    /// asc | desc. Defaults to desc for created_at/size and asc for filename.
+    /// asc | desc. Defaults to desc for `created_at/size` and asc for filename.
     pub order: Option<String>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,

--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -642,7 +642,8 @@ mod tests {
             },
         );
         let issue = queries::create_issue(&conn, &new_issue(pid, "Orphan")).unwrap();
-        conn.execute("DELETE FROM users WHERE id = ?1", [uid]).unwrap();
+        conn.execute("DELETE FROM users WHERE id = ?1", [uid])
+            .unwrap();
         drop(conn);
 
         let feed = issue_feed(&pool, issue.id);
@@ -729,14 +730,20 @@ mod tests {
 
         crate::actor::stamp(
             &conn,
-            &ActorCtx { user_id: Some(alice), transport: Transport::Web },
+            &ActorCtx {
+                user_id: Some(alice),
+                transport: Transport::Web,
+            },
         );
         queries::create_issue(&conn, &new_issue(pid, "a1")).unwrap();
         queries::create_issue(&conn, &new_issue(pid, "a2")).unwrap();
 
         crate::actor::stamp(
             &conn,
-            &ActorCtx { user_id: Some(bot), transport: Transport::Mcp },
+            &ActorCtx {
+                user_id: Some(bot),
+                transport: Transport::Mcp,
+            },
         );
         queries::create_issue(&conn, &new_issue(pid, "b1")).unwrap();
         queries::create_issue(&conn, &new_issue(pid, "b2")).unwrap();

--- a/src/db/queries/activity.rs
+++ b/src/db/queries/activity.rs
@@ -139,7 +139,8 @@ pub fn list_activity(
         n + 2,
     );
 
-    let refs: Vec<&dyn rusqlite::types::ToSql> = sp.iter().map(|p| p.as_ref()).collect();
+    let refs: Vec<&dyn rusqlite::types::ToSql> =
+        sp.iter().map(std::convert::AsRef::as_ref).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(refs.as_slice(), row_to_activity)?;
     let items: Vec<Activity> = rows.collect::<Result<Vec<_>, _>>()?;
@@ -217,7 +218,7 @@ mod tests {
     use crate::db::models::*;
     use crate::db::queries;
 
-    /// Seed a project and return (pool, project_id).
+    /// Seed a project and return (pool, `project_id`).
     fn seeded() -> (crate::db::DbPool, i64) {
         let pool = crate::db::open_memory().expect("test db");
         let project = {

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -118,7 +118,11 @@ pub fn update_alt_text(
 /// screenshot into two projects produces two rows over one blob, and this is
 /// how `GET /api/attachments/{id}/links` finds the twin so a caller can see
 /// the file is already in the tracker before uploading a third copy.
-pub fn duplicates_of(conn: &Connection, id: i64, sha256: &str) -> Result<Vec<Attachment>, LificError> {
+pub fn duplicates_of(
+    conn: &Connection,
+    id: i64,
+    sha256: &str,
+) -> Result<Vec<Attachment>, LificError> {
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT {ATTACHMENT_COLUMNS} FROM attachments
          WHERE sha256 = ?1 AND id != ?2 ORDER BY id"
@@ -151,10 +155,7 @@ pub fn delete_attachment(conn: &Connection, id: i64) -> Result<bool, LificError>
 /// Delete an unlinked attachment only if it is still unlinked on this writer
 /// connection. The returned hash is safe for the caller to garbage-collect
 /// after checking whether another row still shares it.
-pub fn delete_orphan_attachment(
-    conn: &Connection,
-    id: i64,
-) -> Result<Option<String>, LificError> {
+pub fn delete_orphan_attachment(conn: &Connection, id: i64) -> Result<Option<String>, LificError> {
     conn.query_row(
         "DELETE FROM attachments
          WHERE id = ?1
@@ -470,9 +471,7 @@ pub fn find_orphans(
         format!("+{} seconds", -grace_seconds)
     };
     let rows = stmt.query_map(params![modifier], |row| {
-        Ok(OrphanAttachment {
-            id: row.get(0)?,
-        })
+        Ok(OrphanAttachment { id: row.get(0)? })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
@@ -658,11 +657,10 @@ pub fn list_project_attachments(
          WHERE {where_clause}"
     );
     let totals_params = base_params();
-    let (total_count, total_bytes): (i64, i64) = conn.query_row(
-        &totals_sql,
-        bind(&totals_params).as_slice(),
-        |row| Ok((row.get(0)?, row.get(1)?)),
-    )?;
+    let (total_count, total_bytes): (i64, i64) =
+        conn.query_row(&totals_sql, bind(&totals_params).as_slice(), |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?;
 
     let ids: Vec<i64> = items.iter().map(|item| item.id).collect();
     let mut entities = linked_entities_in_project(conn, project_id, &ids)?;
@@ -1607,7 +1605,10 @@ mod tests {
             create_attachment(&conn, &test_sha("race"), "a.png", "image/png", 1, None).unwrap();
         link_attachment(&conn, attachment.id, AttachmentEntity::Issue, issue).unwrap();
 
-        assert_eq!(delete_orphan_attachment(&conn, attachment.id).unwrap(), None);
+        assert_eq!(
+            delete_orphan_attachment(&conn, attachment.id).unwrap(),
+            None
+        );
         assert!(get_attachment(&conn, attachment.id).is_ok());
     }
 

--- a/src/db/queries/attachments.rs
+++ b/src/db/queries/attachments.rs
@@ -693,7 +693,7 @@ pub fn linked_entities_in_project(
     // database, never caller-supplied text.
     let id_list = attachment_ids
         .iter()
-        .map(|id| id.to_string())
+        .map(std::string::ToString::to_string)
         .collect::<Vec<_>>()
         .join(",");
 
@@ -1367,9 +1367,9 @@ mod tests {
             .into_iter()
             .map(|x| x.id)
             .collect();
-        ids.sort();
+        ids.sort_unstable();
         let mut want = vec![b.id, c.id];
-        want.sort();
+        want.sort_unstable();
         assert_eq!(ids, want);
     }
 

--- a/src/db/queries/comments.rs
+++ b/src/db/queries/comments.rs
@@ -21,7 +21,7 @@ pub fn validate_comment_content(content: &str) -> Result<(), LificError> {
 
 /// What a comment is attached to.
 ///
-/// The `comments` table allows exactly one of (issue_id, page_id) to be set
+/// The `comments` table allows exactly one of (`issue_id`, `page_id`) to be set
 /// (enforced by a CHECK constraint added in migration 012). This enum mirrors
 /// that invariant in Rust so callers can't accidentally construct an
 /// orphan or dual-parent comment.
@@ -358,8 +358,10 @@ pub fn list_comments_keyset(
         param_values.push(Box::new(offset));
     }
 
-    let params_refs: Vec<&dyn rusqlite::types::ToSql> =
-        param_values.iter().map(|p| p.as_ref()).collect();
+    let params_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(std::convert::AsRef::as_ref)
+        .collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_refs.as_slice(), row_to_comment)?;
     let rows: Vec<Comment> = rows.collect::<Result<Vec<_>, _>>()?;
@@ -624,7 +626,7 @@ mod tests {
     use crate::db::models::*;
     use crate::db::queries;
 
-    /// Seed a user, a project, an issue, and a page. Returns (pool, issue_id, page_id, user_id).
+    /// Seed a user, a project, an issue, and a page. Returns (pool, `issue_id`, `page_id`, `user_id`).
     fn setup() -> (db::DbPool, i64, i64, i64) {
         let pool = db::open_memory().expect("test db");
         let conn = pool.write().unwrap();
@@ -1396,7 +1398,7 @@ mod tests {
         assert!(!tail.has_more);
     }
 
-    /// Read an issue's raw updated_at timestamp directly from the table.
+    /// Read an issue's raw `updated_at` timestamp directly from the table.
     fn issue_updated_at(conn: &Connection, issue_id: i64) -> String {
         conn.query_row(
             "SELECT updated_at FROM issues WHERE id = ?1",

--- a/src/db/queries/insights.rs
+++ b/src/db/queries/insights.rs
@@ -39,7 +39,9 @@ use std::collections::HashMap;
 use chrono::{Datelike, Duration, NaiveDate, Utc};
 use rusqlite::{Connection, params};
 
-use crate::db::models::*;
+use crate::db::models::{
+    ActorStat, InsightsPayload, ModuleCount, Priority, PriorityCounts, WeekPoint,
+};
 use crate::error::LificError;
 
 pub const DEFAULT_WEEKS: i64 = 12;
@@ -56,7 +58,7 @@ pub fn clamp_weeks(weeks: Option<i64>) -> i64 {
 /// `count` entries long.
 fn week_starts(count: i64) -> Vec<NaiveDate> {
     let today = Utc::now().date_naive();
-    let this_monday = today - Duration::days(today.weekday().num_days_from_monday() as i64);
+    let this_monday = today - Duration::days(i64::from(today.weekday().num_days_from_monday()));
     (0..count)
         .rev()
         .map(|k| this_monday - Duration::days(7 * k))
@@ -255,6 +257,9 @@ pub fn get_insights(
 
 #[cfg(test)]
 mod tests {
+    #[allow(clippy::wildcard_imports)]
+    use crate::db::models::*;
+
     use super::*;
     use crate::db::queries;
 

--- a/src/db/queries/insights.rs
+++ b/src/db/queries/insights.rs
@@ -91,7 +91,10 @@ fn bucket_weekly(
         .map(|d| {
             let key = d.format("%Y-%m-%d").to_string();
             let count = counts.get(&key).copied().unwrap_or(0);
-            WeekPoint { week_start: key, count }
+            WeekPoint {
+                week_start: key,
+                count,
+            }
         })
         .collect())
 }
@@ -225,7 +228,8 @@ fn top_actors(
             top_transport: row.get(6)?,
         })
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(LificError::Database)
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(LificError::Database)
 }
 
 /// Compute the full Insights payload for a project. `weeks` should already
@@ -331,7 +335,11 @@ mod tests {
         let conn = pool.read().unwrap();
         let payload = get_insights(&conn, pid, 4).unwrap();
         assert_eq!(payload.weeks, 4);
-        assert_eq!(payload.created_per_week.len(), 4, "dense — one point per week");
+        assert_eq!(
+            payload.created_per_week.len(),
+            4,
+            "dense — one point per week"
+        );
         // Every bucket is Monday-aligned.
         for pt in &payload.created_per_week {
             let d = NaiveDate::parse_from_str(&pt.week_start, "%Y-%m-%d").unwrap();
@@ -355,7 +363,10 @@ mod tests {
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Done), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
         )
         .unwrap();
         drop(conn);
@@ -374,14 +385,20 @@ mod tests {
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Done), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
         )
         .unwrap();
         // Reopen: latest status transition is no longer terminal.
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Todo), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Todo),
+                ..Default::default()
+            },
         )
         .unwrap();
         drop(conn);
@@ -389,7 +406,10 @@ mod tests {
         let conn = pool.read().unwrap();
         let payload = get_insights(&conn, pid, 4).unwrap();
         let total: i64 = payload.closed_per_week.iter().map(|p| p.count).sum();
-        assert_eq!(total, 0, "currently-open issue must not appear in closed_per_week");
+        assert_eq!(
+            total, 0,
+            "currently-open issue must not appear in closed_per_week"
+        );
     }
 
     #[test]
@@ -400,19 +420,28 @@ mod tests {
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Done), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
         )
         .unwrap();
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Todo), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Todo),
+                ..Default::default()
+            },
         )
         .unwrap();
         queries::update_issue(
             &conn,
             issue.id,
-            &UpdateIssue { status: Some(Status::Cancelled), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Cancelled),
+                ..Default::default()
+            },
         )
         .unwrap();
         drop(conn);
@@ -438,7 +467,10 @@ mod tests {
         queries::update_issue(
             &conn,
             c.id,
-            &UpdateIssue { status: Some(Status::Done), ..Default::default() },
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
         )
         .unwrap();
         drop(conn);
@@ -473,7 +505,10 @@ mod tests {
         queries::update_issue(
             &conn,
             a.id,
-            &UpdateIssue { module_id: Some(Some(module.id)), ..Default::default() },
+            &UpdateIssue {
+                module_id: Some(Some(module.id)),
+                ..Default::default()
+            },
         )
         .unwrap();
         quick_issue(&conn, pid, "B", Priority::None);
@@ -489,7 +524,11 @@ mod tests {
             .unwrap();
         assert_eq!(backend.name, "Backend");
         assert_eq!(backend.count, 1);
-        let unassigned = payload.module_counts.iter().find(|m| m.module_id.is_none()).unwrap();
+        let unassigned = payload
+            .module_counts
+            .iter()
+            .find(|m| m.module_id.is_none())
+            .unwrap();
         assert_eq!(unassigned.name, "No module");
         assert_eq!(unassigned.count, 1);
     }
@@ -511,7 +550,10 @@ mod tests {
         };
         crate::actor::stamp(
             &conn,
-            &crate::actor::ActorCtx { user_id: Some(alice), transport: crate::actor::Transport::Web },
+            &crate::actor::ActorCtx {
+                user_id: Some(alice),
+                transport: crate::actor::Transport::Web,
+            },
         );
         quick_issue(&conn, pid, "A1", Priority::None);
         quick_issue(&conn, pid, "A2", Priority::None);

--- a/src/db/queries/issues.rs
+++ b/src/db/queries/issues.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -928,15 +928,17 @@ mod tests {
                     "module {module_id} does not belong to project {issue_project_id}"
                 )
         ));
-        assert!(list_issues(
-            &conn,
-            &ListIssuesQuery {
-                project_id: Some(issue_project_id),
-                ..Default::default()
-            }
-        )
-        .unwrap()
-        .is_empty());
+        assert!(
+            list_issues(
+                &conn,
+                &ListIssuesQuery {
+                    project_id: Some(issue_project_id),
+                    ..Default::default()
+                }
+            )
+            .unwrap()
+            .is_empty()
+        );
     }
 
     // LIF-130: the issue INSERT and its label attaches are one atomic unit.

--- a/src/db/queries/issues.rs
+++ b/src/db/queries/issues.rs
@@ -1,6 +1,8 @@
 use rusqlite::{Connection, params};
 
-use crate::db::models::*;
+use crate::db::models::{
+    CreateIssue, Issue, IssueStatusCounts, ListIssuesQuery, ProjectRelation, Status, UpdateIssue,
+};
 use crate::error::LificError;
 
 use super::unescape_text;
@@ -332,8 +334,8 @@ pub fn list_issues_page(
     let order_clause = match q.order_by.as_deref() {
         None | Some("sort_order") => format!("i.sort_order {dir}, i.sequence {dir}"),
         Some("sequence") => format!("i.sequence {dir}"),
-        Some("created") | Some("created_at") => format!("i.created_at {dir}, i.sequence {dir}"),
-        Some("updated") | Some("updated_at") => format!("i.updated_at {dir}, i.sequence {dir}"),
+        Some("created" | "created_at") => format!("i.created_at {dir}, i.sequence {dir}"),
+        Some("updated" | "updated_at") => format!("i.updated_at {dir}, i.sequence {dir}"),
         Some("priority") => format!(
             "CASE i.priority WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 ELSE 4 END {dir}, i.sequence {dir}"
         ),
@@ -354,8 +356,10 @@ pub fn list_issues_page(
     param_values.push(Box::new(super::over_fetch(limit)));
     param_values.push(Box::new(offset));
 
-    let params_refs: Vec<&dyn rusqlite::types::ToSql> =
-        param_values.iter().map(|p| p.as_ref()).collect();
+    let params_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(std::convert::AsRef::as_ref)
+        .collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_refs.as_slice(), |row| {
         let project_ident: String = row.get(3)?;
@@ -419,7 +423,7 @@ pub fn list_issues_page(
             .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
             .collect();
         let params_refs: Vec<&dyn rusqlite::types::ToSql> =
-            params.iter().map(|p| p.as_ref()).collect();
+            params.iter().map(std::convert::AsRef::as_ref).collect();
         let mut stmt = conn.prepare(&sql)?;
         let label_rows = stmt.query_map(params_refs.as_slice(), |row| {
             Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
@@ -734,6 +738,9 @@ pub fn unlink_issues(conn: &Connection, source_id: i64, target_id: i64) -> Resul
 
 #[cfg(test)]
 mod tests {
+    #[allow(clippy::wildcard_imports)]
+    use crate::db::models::*;
+
     use super::*;
     use crate::db;
     use crate::db::queries::{projects, resources};
@@ -1619,7 +1626,7 @@ mod tests {
         assert_eq!(limited.len(), 3);
     }
 
-    /// Read an issue's raw updated_at timestamp directly from the table.
+    /// Read an issue's raw `updated_at` timestamp directly from the table.
     fn issue_updated_at(conn: &rusqlite::Connection, issue_id: i64) -> String {
         conn.query_row(
             "SELECT updated_at FROM issues WHERE id = ?1",
@@ -1687,9 +1694,9 @@ mod tests {
 
     // ── Date-window filters + sort control ───────────────────
 
-    /// Pin an issue's created_at/updated_at to explicit values so date
+    /// Pin an issue's `created_at/updated_at` to explicit values so date
     /// filter and ordering tests don't depend on wall-clock timing. The
-    /// `issues_updated` trigger rewrites updated_at to now on every UPDATE,
+    /// `issues_updated` trigger rewrites `updated_at` to now on every UPDATE,
     /// which would silently overwrite the pin — drop it first.
     fn pin_timestamps(conn: &rusqlite::Connection, issue_id: i64, created: &str, updated: &str) {
         conn.execute_batch("DROP TRIGGER IF EXISTS issues_updated;")

--- a/src/db/queries/members.rs
+++ b/src/db/queries/members.rs
@@ -7,7 +7,7 @@
 //! paths that set it (`queries::projects::create_project` /
 //! `update_project`) call [`upsert_member`] to keep both in sync.
 
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::{MemberWithUser, ProjectMember, Role};
 use crate::error::LificError;
@@ -64,12 +64,10 @@ pub fn get_member_role(
     project_id: i64,
     user_id: i64,
 ) -> Result<Option<Role>, LificError> {
-    conn.prepare_cached(
-        "SELECT role FROM project_members WHERE project_id = ?1 AND user_id = ?2",
-    )?
-    .query_row(params![project_id, user_id], |row| row.get(0))
-    .optional()
-    .map_err(Into::into)
+    conn.prepare_cached("SELECT role FROM project_members WHERE project_id = ?1 AND user_id = ?2")?
+        .query_row(params![project_id, user_id], |row| row.get(0))
+        .optional()
+        .map_err(Into::into)
 }
 
 /// Insert or update a member's role. Idempotent — re-running with the same
@@ -124,9 +122,8 @@ pub fn remove_member(conn: &Connection, project_id: i64, user_id: i64) -> Result
 /// Powers `authz::visible_project_ids` (LIF-196) — the cross-project read
 /// filter for search / project listing once enforcement is wired in.
 pub fn list_project_ids_for_user(conn: &Connection, user_id: i64) -> Result<Vec<i64>, LificError> {
-    let mut stmt = conn.prepare_cached(
-        "SELECT project_id FROM project_members WHERE user_id = ?1",
-    )?;
+    let mut stmt =
+        conn.prepare_cached("SELECT project_id FROM project_members WHERE user_id = ?1")?;
     let rows = stmt.query_map(params![user_id], |row| row.get(0))?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
@@ -215,7 +212,9 @@ pub fn change_role(
     let new_role: Role = new_role.parse().map_err(LificError::BadRequest)?;
 
     let current = get_member_role(conn, project_id, user_id)?.ok_or_else(|| {
-        LificError::NotFound(format!("user {user_id} is not a member of project {project_id}"))
+        LificError::NotFound(format!(
+            "user {user_id} is not a member of project {project_id}"
+        ))
     })?;
 
     if current == Role::Lead && new_role != Role::Lead && count_leads(conn, project_id)? <= 1 {
@@ -245,7 +244,9 @@ pub fn remove_member_guarded(
     user_id: i64,
 ) -> Result<(), LificError> {
     let current = get_member_role(conn, project_id, user_id)?.ok_or_else(|| {
-        LificError::NotFound(format!("user {user_id} is not a member of project {project_id}"))
+        LificError::NotFound(format!(
+            "user {user_id} is not a member of project {project_id}"
+        ))
     })?;
 
     if current == Role::Lead && count_leads(conn, project_id)? <= 1 {
@@ -275,8 +276,8 @@ pub fn remove_member_guarded(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{self, queries::projects};
     use crate::db::models::{CreateProject, UpdateProject};
+    use crate::db::{self, queries::projects};
 
     fn test_db() -> db::DbPool {
         db::open_memory().expect("test db")
@@ -622,7 +623,10 @@ mod tests {
         let err = add_member(&conn, project_id, alice, "maintainer").unwrap_err();
         assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
         // The conflicting call must not have overwritten the role.
-        assert_eq!(get_member_role(&conn, project_id, alice).unwrap(), Some(Role::Viewer));
+        assert_eq!(
+            get_member_role(&conn, project_id, alice).unwrap(),
+            Some(Role::Viewer)
+        );
     }
 
     #[test]
@@ -680,7 +684,10 @@ mod tests {
 
         let err = change_role(&conn, project_id, alice, "maintainer").unwrap_err();
         assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
-        assert_eq!(get_member_role(&conn, project_id, alice).unwrap(), Some(Role::Lead));
+        assert_eq!(
+            get_member_role(&conn, project_id, alice).unwrap(),
+            Some(Role::Lead)
+        );
 
         // Re-affirming the same role is not a demotion — always fine.
         assert!(change_role(&conn, project_id, alice, "lead").is_ok());
@@ -697,7 +704,10 @@ mod tests {
         upsert_member(&conn, project_id, bob, Role::Lead).unwrap();
 
         change_role(&conn, project_id, alice, "maintainer").unwrap();
-        assert_eq!(get_member_role(&conn, project_id, alice).unwrap(), Some(Role::Maintainer));
+        assert_eq!(
+            get_member_role(&conn, project_id, alice).unwrap(),
+            Some(Role::Maintainer)
+        );
     }
 
     #[test]
@@ -710,7 +720,10 @@ mod tests {
 
         let err = remove_member_guarded(&conn, project_id, alice).unwrap_err();
         assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
-        assert_eq!(get_member_role(&conn, project_id, alice).unwrap(), Some(Role::Lead));
+        assert_eq!(
+            get_member_role(&conn, project_id, alice).unwrap(),
+            Some(Role::Lead)
+        );
     }
 
     #[test]
@@ -811,6 +824,10 @@ mod tests {
         remove_member_guarded(&conn, project.id, bob).unwrap();
 
         let updated = projects::get_project(&conn, project.id).unwrap();
-        assert_eq!(updated.lead_user_id, Some(alice), "unrelated removal must not touch the pointer");
+        assert_eq!(
+            updated.lead_user_id,
+            Some(alice),
+            "unrelated removal must not touch the pointer"
+        );
     }
 }

--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -35,13 +35,13 @@ pub const DEFAULT_PAGE_LIMIT: i64 = 50;
 /// documents a deliberately lower cap of its own (see `activity::list_activity`).
 pub const MAX_PAGE_LIMIT: i64 = 500;
 
-/// SQLite's "no limit" sentinel: `LIMIT -1` returns every row. Only reachable
+/// `SQLite`'s "no limit" sentinel: `LIMIT -1` returns every row. Only reachable
 /// through `page_unbounded`, where an absent limit means "no limit" by design.
 pub const NO_LIMIT: i64 = -1;
 
 /// Clamp caller-supplied pagination into `(limit, offset)` ready for SQL.
 ///
-/// LIF-141 class: SQLite treats `LIMIT -1` as "no limit", so an unclamped
+/// LIF-141 class: `SQLite` treats `LIMIT -1` as "no limit", so an unclamped
 /// `?limit=-1` would dump the whole table. Floor at 1 so a 0/negative value
 /// still paginates, cap at [`MAX_PAGE_LIMIT`], and floor the offset at 0.
 pub fn page(limit: Option<i64>, offset: Option<i64>) -> (i64, i64) {
@@ -143,7 +143,7 @@ pub(crate) fn project_visibility_sql(
     }
 }
 
-/// Run a closure inside a SQLite SAVEPOINT so that multi-statement writes are atomic.
+/// Run a closure inside a `SQLite` SAVEPOINT so that multi-statement writes are atomic.
 /// On success the savepoint is released; on error it is rolled back.
 pub(crate) fn savepoint<F, T>(
     conn: &rusqlite::Connection,

--- a/src/db/queries/pages.rs
+++ b/src/db/queries/pages.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -314,7 +314,9 @@ fn validate_page_folder(
         Some(folder_project_id) => Err(LificError::BadRequest(format!(
             "folder {folder_id} belongs to project {folder_project_id}, not page project {project_id}"
         ))),
-        None => Err(LificError::BadRequest(format!("folder {folder_id} not found"))),
+        None => Err(LificError::BadRequest(format!(
+            "folder {folder_id} not found"
+        ))),
     }
 }
 
@@ -1301,18 +1303,20 @@ mod tests {
             .is_err(),
             "unknown order_by must error, not be interpolated"
         );
-        assert!(list_pages(
-            &conn,
-            Some(pid),
-            None,
-            None,
-            None,
-            None,
-            Some("up"),
-            None,
-            None
-        )
-        .is_err());
+        assert!(
+            list_pages(
+                &conn,
+                Some(pid),
+                None,
+                None,
+                None,
+                None,
+                Some("up"),
+                None,
+                None
+            )
+            .is_err()
+        );
     }
 
     // ── LIF-183: page pinning ────────────────────────────────

--- a/src/db/queries/pages.rs
+++ b/src/db/queries/pages.rs
@@ -1,6 +1,6 @@
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::db::models::*;
+use crate::db::models::{CreatePage, Page, UpdatePage};
 use crate::error::LificError;
 
 use super::unescape_text;
@@ -70,7 +70,8 @@ fn populate_page_labels(conn: &Connection, pages: &mut [Page]) -> Result<(), Lif
         .iter()
         .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
         .collect();
-    let params_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+    let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+        params.iter().map(std::convert::AsRef::as_ref).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_refs.as_slice(), |row| {
         Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
@@ -185,8 +186,8 @@ pub fn list_pages_page(
         None | Some("sort_order") => "pg.sort_order",
         Some("title") => "pg.title COLLATE NOCASE",
         Some("status") => "pg.status",
-        Some("created") | Some("created_at") => "pg.created_at",
-        Some("updated") | Some("updated_at") => "pg.updated_at",
+        Some("created" | "created_at") => "pg.created_at",
+        Some("updated" | "updated_at") => "pg.updated_at",
         Some(other) => {
             return Err(LificError::BadRequest(format!(
                 "invalid order_by '{other}'. Use sort_order, title, status, created, or updated."
@@ -212,8 +213,10 @@ pub fn list_pages_page(
         param_values.push(Box::new(offset));
     }
 
-    let params_refs: Vec<&dyn rusqlite::types::ToSql> =
-        param_values.iter().map(|p| p.as_ref()).collect();
+    let params_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(std::convert::AsRef::as_ref)
+        .collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_refs.as_slice(), page_from_row)?;
     let rows: Vec<Page> = rows.collect::<Result<Vec<_>, _>>()?;
@@ -444,6 +447,9 @@ pub fn delete_page(conn: &Connection, id: i64) -> Result<(), LificError> {
 
 #[cfg(test)]
 mod tests {
+    #[allow(clippy::wildcard_imports)]
+    use crate::db::models::*;
+
     use super::*;
     use crate::db;
     use crate::db::queries::{projects, resources};
@@ -1187,7 +1193,7 @@ mod tests {
     // ── Sort control (order_by / order) ───────────────────────
 
     /// Pin a page's timestamps so ordering tests don't race the clock.
-    /// The `pages_updated` trigger rewrites updated_at to now on every
+    /// The `pages_updated` trigger rewrites `updated_at` to now on every
     /// UPDATE, which would silently overwrite the pin — drop it first.
     fn pin_page_timestamps(
         conn: &rusqlite::Connection,

--- a/src/db/queries/plans.rs
+++ b/src/db/queries/plans.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -21,9 +21,9 @@ pub struct StepDoneEffect {
 
 /// Resolve "PROJ-PLAN-7" to a plan id.
 pub fn resolve_plan_identifier(conn: &Connection, identifier: &str) -> Result<i64, LificError> {
-    let idx = identifier.rfind("-PLAN-").ok_or_else(|| {
-        LificError::BadRequest(format!("invalid plan identifier: {identifier}"))
-    })?;
+    let idx = identifier
+        .rfind("-PLAN-")
+        .ok_or_else(|| LificError::BadRequest(format!("invalid plan identifier: {identifier}")))?;
     let project_ident = &identifier[..idx];
     let sequence: i64 = identifier[idx + 6..]
         .parse()
@@ -79,7 +79,9 @@ fn read_plan_row(conn: &Connection, id: i64) -> Result<Plan, LificError> {
         },
     )
     .map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => LificError::NotFound(format!("plan {id} not found")),
+        rusqlite::Error::QueryReturnedNoRows => {
+            LificError::NotFound(format!("plan {id} not found"))
+        }
         _ => e.into(),
     })
 }
@@ -134,7 +136,10 @@ fn assemble_tree(flat: Vec<PlanStepNode>) -> Vec<PlanStepNode> {
     use std::collections::HashMap;
     let mut children_of: HashMap<Option<i64>, Vec<PlanStepNode>> = HashMap::new();
     for node in flat {
-        children_of.entry(node.parent_step_id).or_default().push(node);
+        children_of
+            .entry(node.parent_step_id)
+            .or_default()
+            .push(node);
     }
     fn build(
         parent: Option<i64>,
@@ -206,7 +211,11 @@ pub fn list_plans(conn: &Connection, q: &ListPlansQuery) -> Result<Vec<Plan>, Li
         inner.push_str(&format!(" LIMIT ?{}", pv.len() + 1));
         pv.push(Box::new(limit));
     } else {
-        inner.push_str(&format!(" LIMIT ?{} OFFSET ?{}", pv.len() + 1, pv.len() + 2));
+        inner.push_str(&format!(
+            " LIMIT ?{} OFFSET ?{}",
+            pv.len() + 1,
+            pv.len() + 2
+        ));
         pv.push(Box::new(limit));
         pv.push(Box::new(offset));
     }
@@ -307,7 +316,10 @@ pub fn update_plan(conn: &Connection, id: i64, input: &UpdatePlan) -> Result<Pla
     read_plan_row(conn, id)?;
     savepoint(conn, "update_plan", || {
         if let Some(ref title) = input.title {
-            conn.execute("UPDATE plans SET title = ?1 WHERE id = ?2", params![title, id])?;
+            conn.execute(
+                "UPDATE plans SET title = ?1 WHERE id = ?2",
+                params![title, id],
+            )?;
         }
         if let Some(ref status) = input.status {
             if !["active", "done", "archived"].contains(&status.as_str()) {
@@ -374,7 +386,9 @@ pub fn set_step_title(conn: &Connection, step_id: i64, title: &str) -> Result<()
         params![title, step_id],
     )?;
     if changed == 0 {
-        return Err(LificError::NotFound(format!("plan step {step_id} not found")));
+        return Err(LificError::NotFound(format!(
+            "plan step {step_id} not found"
+        )));
     }
     Ok(())
 }
@@ -390,7 +404,9 @@ pub fn set_step_description(
         params![unescape_text(description), step_id],
     )?;
     if changed == 0 {
-        return Err(LificError::NotFound(format!("plan step {step_id} not found")));
+        return Err(LificError::NotFound(format!(
+            "plan step {step_id} not found"
+        )));
     }
     Ok(())
 }
@@ -461,7 +477,7 @@ pub fn edit_step_text(
         other => {
             return Err(LificError::BadRequest(format!(
                 "invalid field '{other}'. Use title or description."
-            )))
+            )));
         }
     };
     let current: String = conn
@@ -589,7 +605,9 @@ pub fn set_step_issue(
         params![issue_id, step_id],
     )?;
     if changed == 0 {
-        return Err(LificError::NotFound(format!("plan step {step_id} not found")));
+        return Err(LificError::NotFound(format!(
+            "plan step {step_id} not found"
+        )));
     }
     Ok(())
 }
@@ -606,7 +624,9 @@ pub fn move_step(
 
     if let Some(parent) = new_parent {
         if parent == step_id {
-            return Err(LificError::BadRequest("a step cannot be its own parent".into()));
+            return Err(LificError::BadRequest(
+                "a step cannot be its own parent".into(),
+            ));
         }
         // Walk up from the proposed parent; if we reach step_id, the parent is
         // a descendant of the step → cycle.
@@ -659,7 +679,9 @@ pub fn move_step(
 pub fn delete_step(conn: &Connection, step_id: i64) -> Result<(), LificError> {
     let changed = conn.execute("DELETE FROM plan_steps WHERE id = ?1", params![step_id])?;
     if changed == 0 {
-        return Err(LificError::NotFound(format!("plan step {step_id} not found")));
+        return Err(LificError::NotFound(format!(
+            "plan step {step_id} not found"
+        )));
     }
     Ok(())
 }
@@ -752,8 +774,26 @@ mod tests {
         let conn = pool.write().unwrap();
         let a = seed_project(&conn, "AAA");
         let b = seed_project(&conn, "BBB");
-        let p1 = create_plan(&conn, &CreatePlan { project_id: a, title: "a".into(), issue_id: None, steps: vec![] }).unwrap();
-        let p2 = create_plan(&conn, &CreatePlan { project_id: b, title: "b".into(), issue_id: None, steps: vec![] }).unwrap();
+        let p1 = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: a,
+                title: "a".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        let p2 = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: b,
+                title: "b".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
         assert_eq!(p1.identifier, "AAA-PLAN-1");
         assert_eq!(p2.identifier, "BBB-PLAN-1");
         assert_eq!(resolve_plan_identifier(&conn, "AAA-PLAN-1").unwrap(), p1.id);
@@ -813,7 +853,10 @@ mod tests {
         .unwrap();
 
         let refreshed = get_plan(&conn, plan.id).unwrap();
-        assert!(refreshed.steps[0].done, "issue close should complete the step");
+        assert!(
+            refreshed.steps[0].done,
+            "issue close should complete the step"
+        );
         let _ = step_id;
     }
 
@@ -852,7 +895,10 @@ mod tests {
         .unwrap();
 
         let refreshed = get_plan(&conn, plan.id).unwrap();
-        assert!(!refreshed.steps[0].done, "reopen should un-complete the step");
+        assert!(
+            !refreshed.steps[0].done,
+            "reopen should un-complete the step"
+        );
         assert!(
             refreshed.steps[0].reopened_via_issue_at.is_some(),
             "reopen should stamp the reason"
@@ -876,7 +922,15 @@ mod tests {
         )
         .unwrap();
         // Archive the plan → frozen.
-        update_plan(&conn, plan.id, &UpdatePlan { status: Some("archived".into()), ..Default::default() }).unwrap();
+        update_plan(
+            &conn,
+            plan.id,
+            &UpdatePlan {
+                status: Some("archived".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         issues::update_issue(
             &conn,
@@ -889,7 +943,10 @@ mod tests {
         .unwrap();
 
         let refreshed = get_plan(&conn, plan.id).unwrap();
-        assert!(!refreshed.steps[0].done, "archived plan steps must not cascade");
+        assert!(
+            !refreshed.steps[0].done,
+            "archived plan steps must not cascade"
+        );
     }
 
     #[test]
@@ -930,12 +987,33 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         let anchor = seed_issue(&conn, pid, "Epic", Status::Active);
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: Some(anchor.id), steps: vec![] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: Some(anchor.id),
+                steps: vec![],
+            },
+        )
+        .unwrap();
 
-        update_plan(&conn, plan.id, &UpdatePlan { status: Some("done".into()), ..Default::default() }).unwrap();
+        update_plan(
+            &conn,
+            plan.id,
+            &UpdatePlan {
+                status: Some("done".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let got = issues::get_issue(&conn, anchor.id).unwrap();
-        assert_eq!(got.status, Status::Active, "plan completion must not close the anchor issue");
+        assert_eq!(
+            got.status,
+            Status::Active,
+            "plan completion must not close the anchor issue"
+        );
     }
 
     #[test]
@@ -943,7 +1021,16 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("root", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("root", None)],
+            },
+        )
+        .unwrap();
         let root_id = plan.steps[0].id;
 
         let child = add_step(&conn, plan.id, Some(root_id), "child", "desc", None).unwrap();
@@ -966,10 +1053,25 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("s", None)],
+            },
+        )
+        .unwrap();
         delete_plan(&conn, plan.id).unwrap();
         assert!(get_plan(&conn, plan.id).is_err());
-        let count: i64 = conn.query_row("SELECT COUNT(*) FROM plan_steps WHERE plan_id = ?1", params![plan.id], |r| r.get(0)).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM plan_steps WHERE plan_id = ?1",
+                params![plan.id],
+                |r| r.get(0),
+            )
+            .unwrap();
         assert_eq!(count, 0);
     }
 
@@ -978,12 +1080,46 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let p = create_plan(&conn, &CreatePlan { project_id: pid, title: "Active".into(), issue_id: None, steps: vec![simple_step("a", None), simple_step("b", None)] }).unwrap();
+        let p = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Active".into(),
+                issue_id: None,
+                steps: vec![simple_step("a", None), simple_step("b", None)],
+            },
+        )
+        .unwrap();
         set_step_done(&conn, p.steps[0].id, true).unwrap();
-        let archived = create_plan(&conn, &CreatePlan { project_id: pid, title: "Old".into(), issue_id: None, steps: vec![] }).unwrap();
-        update_plan(&conn, archived.id, &UpdatePlan { status: Some("archived".into()), ..Default::default() }).unwrap();
+        let archived = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Old".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        update_plan(
+            &conn,
+            archived.id,
+            &UpdatePlan {
+                status: Some("archived".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
-        let active = list_plans(&conn, &ListPlansQuery { project_id: Some(pid), status: Some("active".into()), ..Default::default() }).unwrap();
+        let active = list_plans(
+            &conn,
+            &ListPlansQuery {
+                project_id: Some(pid),
+                status: Some("active".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].title, "Active");
         assert_eq!(active[0].step_count, 2);
@@ -999,9 +1135,25 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        create_plan(&conn, &CreatePlan { project_id: pid, title: "Empty".into(), issue_id: None, steps: vec![] }).unwrap();
+        create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Empty".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
 
-        let plans = list_plans(&conn, &ListPlansQuery { project_id: Some(pid), ..Default::default() }).unwrap();
+        let plans = list_plans(
+            &conn,
+            &ListPlansQuery {
+                project_id: Some(pid),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].step_count, 0, "stepless plan must count 0, not 1");
         assert_eq!(plans[0].done_count, 0);
@@ -1015,16 +1167,45 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         for i in 0..5 {
-            create_plan(&conn, &CreatePlan { project_id: pid, title: format!("Plan {i}"), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+            create_plan(
+                &conn,
+                &CreatePlan {
+                    project_id: pid,
+                    title: format!("Plan {i}"),
+                    issue_id: None,
+                    steps: vec![simple_step("s", None)],
+                },
+            )
+            .unwrap();
         }
-        let page = list_plans(&conn, &ListPlansQuery { project_id: Some(pid), status: None, limit: Some(2), offset: Some(0), ..Default::default() }).unwrap();
+        let page = list_plans(
+            &conn,
+            &ListPlansQuery {
+                project_id: Some(pid),
+                status: None,
+                limit: Some(2),
+                offset: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(page.len(), 2);
         // Newest (highest id / latest updated_at) first.
         assert_eq!(page[0].title, "Plan 4");
         assert_eq!(page[1].title, "Plan 3");
         assert_eq!(page[0].step_count, 1);
 
-        let next = list_plans(&conn, &ListPlansQuery { project_id: Some(pid), status: None, limit: Some(2), offset: Some(2), ..Default::default() }).unwrap();
+        let next = list_plans(
+            &conn,
+            &ListPlansQuery {
+                project_id: Some(pid),
+                status: None,
+                limit: Some(2),
+                offset: Some(2),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(next.len(), 2);
         assert_eq!(next[0].title, "Plan 2");
     }
@@ -1034,10 +1215,46 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let first_created = create_plan(&conn, &CreatePlan { project_id: pid, title: "First".into(), issue_id: None, steps: vec![] }).unwrap();
-        let second_created = create_plan(&conn, &CreatePlan { project_id: pid, title: "Second".into(), issue_id: None, steps: vec![] }).unwrap();
-        let third_created = create_plan(&conn, &CreatePlan { project_id: pid, title: "Third".into(), issue_id: None, steps: vec![] }).unwrap();
-        let fourth_created = create_plan(&conn, &CreatePlan { project_id: pid, title: "Fourth".into(), issue_id: None, steps: vec![] }).unwrap();
+        let first_created = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "First".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        let second_created = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Second".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        let third_created = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Third".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
+        let fourth_created = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "Fourth".into(),
+                issue_id: None,
+                steps: vec![],
+            },
+        )
+        .unwrap();
         conn.execute("DROP TRIGGER plans_updated", []).unwrap();
         conn.execute(
             "UPDATE plans SET updated_at = '2020-01-01 00:00:00' WHERE project_id = ?1",
@@ -1055,7 +1272,10 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(first.iter().map(|plan| plan.id).collect::<Vec<_>>(), vec![fourth_created.id, third_created.id]);
+        assert_eq!(
+            first.iter().map(|plan| plan.id).collect::<Vec<_>>(),
+            vec![fourth_created.id, third_created.id]
+        );
 
         // An unseen row can move in updated-at order between requests without
         // crossing an immutable id cursor boundary.
@@ -1077,14 +1297,23 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(second.iter().map(|plan| plan.id).collect::<Vec<_>>(), vec![second_created.id, first_created.id]);
+        assert_eq!(
+            second.iter().map(|plan| plan.id).collect::<Vec<_>>(),
+            vec![second_created.id, first_created.id]
+        );
 
         let default_order = list_plans(
             &conn,
-            &ListPlansQuery { project_id: Some(pid), ..Default::default() },
+            &ListPlansQuery {
+                project_id: Some(pid),
+                ..Default::default()
+            },
         )
         .unwrap();
-        assert_eq!(default_order[0].id, second_created.id, "default ordering remains updated_at DESC, id DESC");
+        assert_eq!(
+            default_order[0].id, second_created.id,
+            "default ordering remains updated_at DESC, id DESC"
+        );
     }
 
     #[test]
@@ -1129,12 +1358,21 @@ mod tests {
 
     // ── Audit coverage (LIF-176) ──
 
-    fn audit_rows(conn: &Connection, entity_type: &str) -> Vec<(String, Option<String>, Option<String>)> {
+    fn audit_rows(
+        conn: &Connection,
+        entity_type: &str,
+    ) -> Vec<(String, Option<String>, Option<String>)> {
         let mut stmt = conn
-            .prepare("SELECT action, field, new_value FROM audit_log WHERE entity_type = ?1 ORDER BY id")
+            .prepare(
+                "SELECT action, field, new_value FROM audit_log WHERE entity_type = ?1 ORDER BY id",
+            )
             .unwrap();
         stmt.query_map(params![entity_type], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, Option<String>>(1)?, r.get::<_, Option<String>>(2)?))
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, Option<String>>(1)?,
+                r.get::<_, Option<String>>(2)?,
+            ))
         })
         .unwrap()
         .collect::<Result<Vec<_>, _>>()
@@ -1146,17 +1384,35 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("s", None)],
+            },
+        )
+        .unwrap();
         let step_id = plan.steps[0].id;
         set_step_done(&conn, step_id, true).unwrap();
 
-        let plan_actions: Vec<String> = audit_rows(&conn, "plan").into_iter().map(|r| r.0).collect();
-        assert!(plan_actions.contains(&"create".to_string()), "plan create must be audited: {plan_actions:?}");
+        let plan_actions: Vec<String> =
+            audit_rows(&conn, "plan").into_iter().map(|r| r.0).collect();
+        assert!(
+            plan_actions.contains(&"create".to_string()),
+            "plan create must be audited: {plan_actions:?}"
+        );
 
         let step_audit = audit_rows(&conn, "plan_step");
-        assert!(step_audit.iter().any(|(a, _, _)| a == "create"), "step create audited");
         assert!(
-            step_audit.iter().any(|(a, f, _)| a == "update" && f.as_deref() == Some("done")),
+            step_audit.iter().any(|(a, _, _)| a == "create"),
+            "step create audited"
+        );
+        assert!(
+            step_audit
+                .iter()
+                .any(|(a, f, _)| a == "update" && f.as_deref() == Some("done")),
             "step done audited: {step_audit:?}"
         );
     }
@@ -1167,12 +1423,26 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         let issue = seed_issue(&conn, pid, "Work", Status::Todo);
-        create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("mirror", Some(issue.id))] }).unwrap();
+        create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("mirror", Some(issue.id))],
+            },
+        )
+        .unwrap();
 
-        issues::update_issue(&conn, issue.id, &UpdateIssue {
-            status: Some(Status::Done),
-            ..Default::default()
-        }).unwrap();
+        issues::update_issue(
+            &conn,
+            issue.id,
+            &UpdateIssue {
+                status: Some(Status::Done),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let step_audit = audit_rows(&conn, "plan_step");
         assert!(
@@ -1191,15 +1461,36 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan_a = create_plan(&conn, &CreatePlan { project_id: pid, title: "A".into(), issue_id: None, steps: vec![simple_step("a-step", None)] }).unwrap();
-        let plan_b = create_plan(&conn, &CreatePlan { project_id: pid, title: "B".into(), issue_id: None, steps: vec![simple_step("b-step", None)] }).unwrap();
+        let plan_a = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "A".into(),
+                issue_id: None,
+                steps: vec![simple_step("a-step", None)],
+            },
+        )
+        .unwrap();
+        let plan_b = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "B".into(),
+                issue_id: None,
+                steps: vec![simple_step("b-step", None)],
+            },
+        )
+        .unwrap();
         let a_step = plan_a.steps[0].id;
         let b_step = plan_b.steps[0].id;
 
         assert!(assert_step_in_plan(&conn, plan_a.id, a_step).is_ok());
         // a_step belongs to plan_a, not plan_b → BadRequest.
         let err = assert_step_in_plan(&conn, plan_b.id, a_step).unwrap_err();
-        assert!(matches!(err, LificError::BadRequest(_)), "foreign step must be rejected, got {err:?}");
+        assert!(
+            matches!(err, LificError::BadRequest(_)),
+            "foreign step must be rejected, got {err:?}"
+        );
         assert!(assert_step_in_plan(&conn, plan_b.id, b_step).is_ok());
     }
 
@@ -1208,7 +1499,16 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("old title", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("old title", None)],
+            },
+        )
+        .unwrap();
         let step_id = plan.steps[0].id;
 
         set_step_title(&conn, step_id, "new title").unwrap();
@@ -1216,7 +1516,10 @@ mod tests {
         assert_eq!(reread.steps[0].title, "new title");
 
         let err = set_step_title(&conn, 999_999, "ghost").unwrap_err();
-        assert!(matches!(err, LificError::NotFound(_)), "missing step must 404, got {err:?}");
+        assert!(
+            matches!(err, LificError::NotFound(_)),
+            "missing step must 404, got {err:?}"
+        );
     }
 
     // set_step_description runs unescape_text (LIF-177): literal \n from JSON
@@ -1226,12 +1529,24 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("s", None)],
+            },
+        )
+        .unwrap();
         let step_id = plan.steps[0].id;
 
         set_step_description(&conn, step_id, "line one\\nline two").unwrap();
         let reread = get_plan(&conn, plan.id).unwrap();
-        assert_eq!(reread.steps[0].description, "line one\nline two", "\\n must be unescaped to a newline");
+        assert_eq!(
+            reread.steps[0].description, "line one\nline two",
+            "\\n must be unescaped to a newline"
+        );
 
         let err = set_step_description(&conn, 999_999, "x").unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)));
@@ -1243,11 +1558,23 @@ mod tests {
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn, "TST");
         let issue = seed_issue(&conn, pid, "Linkable", Status::Todo);
-        let plan = create_plan(&conn, &CreatePlan { project_id: pid, title: "P".into(), issue_id: None, steps: vec![simple_step("s", None)] }).unwrap();
+        let plan = create_plan(
+            &conn,
+            &CreatePlan {
+                project_id: pid,
+                title: "P".into(),
+                issue_id: None,
+                steps: vec![simple_step("s", None)],
+            },
+        )
+        .unwrap();
         let step_id = plan.steps[0].id;
 
         set_step_issue(&conn, step_id, Some(issue.id)).unwrap();
-        assert_eq!(get_plan(&conn, plan.id).unwrap().steps[0].issue_id, Some(issue.id));
+        assert_eq!(
+            get_plan(&conn, plan.id).unwrap().steps[0].issue_id,
+            Some(issue.id)
+        );
 
         // Passing None must clear the link back to NULL.
         set_step_issue(&conn, step_id, None).unwrap();
@@ -1281,7 +1608,11 @@ mod tests {
         let parent_id = plan.steps[0].id;
         let child_id = plan.steps[0].children[0].id;
 
-        assert_eq!(step_parent(&conn, parent_id).unwrap(), None, "root step has no parent");
+        assert_eq!(
+            step_parent(&conn, parent_id).unwrap(),
+            None,
+            "root step has no parent"
+        );
         assert_eq!(step_parent(&conn, child_id).unwrap(), Some(parent_id));
 
         let err = step_parent(&conn, 999_999).unwrap_err();

--- a/src/db/queries/plans.rs
+++ b/src/db/queries/plans.rs
@@ -1,6 +1,8 @@
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::db::models::*;
+use crate::db::models::{
+    CreatePlan, CreatePlanStep, ListPlansQuery, Plan, PlanStepNode, UpdatePlan,
+};
 use crate::error::LificError;
 
 use super::{savepoint, unescape_text};
@@ -146,7 +148,7 @@ fn assemble_tree(flat: Vec<PlanStepNode>) -> Vec<PlanStepNode> {
         children_of: &mut std::collections::HashMap<Option<i64>, Vec<PlanStepNode>>,
     ) -> Vec<PlanStepNode> {
         let mut nodes = children_of.remove(&parent).unwrap_or_default();
-        for node in nodes.iter_mut() {
+        for node in &mut nodes {
             node.children = build(Some(node.id), children_of);
         }
         nodes
@@ -235,7 +237,8 @@ pub fn list_plans(conn: &Connection, q: &ListPlansQuery) -> Result<Vec<Plan>, Li
           ORDER BY {order_by}"
     );
 
-    let refs: Vec<&dyn rusqlite::types::ToSql> = pv.iter().map(|p| p.as_ref()).collect();
+    let refs: Vec<&dyn rusqlite::types::ToSql> =
+        pv.iter().map(std::convert::AsRef::as_ref).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(refs.as_slice(), |row| {
         let proj: String = row.get(3)?;
@@ -301,7 +304,7 @@ fn insert_step_tree(
                 step.title,
                 unescape_text(&step.description),
                 step.issue_id,
-                step.done as i64,
+                i64::from(step.done),
             ],
         )?;
         let child_id = conn.last_insert_rowid();
@@ -379,7 +382,7 @@ pub fn assert_step_in_plan(
     Ok(())
 }
 
-/// Directly set a step's title (full rename, vs the find/replace edit_step_text).
+/// Directly set a step's title (full rename, vs the find/replace `edit_step_text`).
 pub fn set_step_title(conn: &Connection, step_id: i64, title: &str) -> Result<(), LificError> {
     let changed = conn.execute(
         "UPDATE plan_steps SET title = ?1, edited_at = datetime('now') WHERE id = ?2",
@@ -462,7 +465,7 @@ pub fn add_step(
     Ok(conn.last_insert_rowid())
 }
 
-/// Find/replace on a step's title or description (mirrors edit_issue/edit_page).
+/// Find/replace on a step's title or description (mirrors `edit_issue/edit_page`).
 pub fn edit_step_text(
     conn: &Connection,
     step_id: i64,
@@ -688,6 +691,9 @@ pub fn delete_step(conn: &Connection, step_id: i64) -> Result<(), LificError> {
 
 #[cfg(test)]
 mod tests {
+    #[allow(clippy::wildcard_imports)]
+    use crate::db::models::*;
+
     use super::*;
     use crate::db;
     use crate::db::queries::{issues, projects};
@@ -1453,7 +1459,7 @@ mod tests {
 
     // ── Coverage backfill: previously-untested step mutators & guards ──
 
-    /// assert_step_in_plan is an integrity guard: it must accept a step that
+    /// `assert_step_in_plan` is an integrity guard: it must accept a step that
     /// belongs to the plan and reject one that doesn't, so a caller can't
     /// mutate a step via the wrong plan's identifier.
     #[test]

--- a/src/db/queries/project_groups.rs
+++ b/src/db/queries/project_groups.rs
@@ -214,8 +214,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
 
-        let created =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let created = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
         assert_eq!(created.name, "Work");
         assert!(created.project_ids.is_empty());
 
@@ -231,14 +237,33 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
 
-        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
-        let err =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap_err();
+        let err = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap_err();
         assert!(matches!(err, LificError::Conflict(_)), "got {err:?}");
 
-        create_group(&conn, bob, &CreateProjectGroup { name: "Work".into() })
-            .expect("a different user may reuse the name");
+        create_group(
+            &conn,
+            bob,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .expect("a different user may reuse the name");
     }
 
     #[test]
@@ -248,7 +273,14 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
 
-        create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+        create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Personal".into(),
+            },
+        )
+        .unwrap();
 
         assert!(list_groups(&conn, bob).unwrap().is_empty());
     }
@@ -272,10 +304,22 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
-        let personal =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
+        let personal = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Personal".into(),
+            },
+        )
+        .unwrap();
 
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
         assign_project(&conn, alice, project, Some(personal.id)).unwrap();
@@ -296,8 +340,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
         assign_project(&conn, alice, project, None).unwrap();
@@ -313,10 +363,22 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
         let project = seed_project(&conn, "APP");
-        let alice_work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
-        let bob_side =
-            create_group(&conn, bob, &CreateProjectGroup { name: "Side".into() }).unwrap();
+        let alice_work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
+        let bob_side = create_group(
+            &conn,
+            bob,
+            &CreateProjectGroup {
+                name: "Side".into(),
+            },
+        )
+        .unwrap();
 
         assign_project(&conn, alice, project, Some(alice_work.id)).unwrap();
         assign_project(&conn, bob, project, Some(bob_side.id)).unwrap();
@@ -338,8 +400,14 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
         let project = seed_project(&conn, "APP");
-        let alice_work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let alice_work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
         let err = assign_project(&conn, bob, project, Some(alice_work.id)).unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
@@ -353,8 +421,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
 
         assert!(delete_group(&conn, work.id, alice).unwrap());
@@ -369,8 +443,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
         let err = delete_group(&conn, work.id, bob).unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
@@ -382,8 +462,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
 
         queries::delete_project(&conn, project).unwrap();
@@ -396,7 +482,14 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
-        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
 
         conn.execute("DELETE FROM users WHERE id = ?1", params![alice])
             .unwrap();
@@ -414,9 +507,22 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
-        create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
-        let personal =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Personal".into() }).unwrap();
+        create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
+        let personal = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Personal".into(),
+            },
+        )
+        .unwrap();
 
         let err = update_group(
             &conn,
@@ -436,8 +542,14 @@ mod tests {
         let conn = pool.write().unwrap();
         let alice = seed_user(&conn, "alice");
         let project = seed_project(&conn, "APP");
-        let work =
-            create_group(&conn, alice, &CreateProjectGroup { name: "Work".into() }).unwrap();
+        let work = create_group(
+            &conn,
+            alice,
+            &CreateProjectGroup {
+                name: "Work".into(),
+            },
+        )
+        .unwrap();
         assign_project(&conn, alice, project, Some(work.id)).unwrap();
 
         let renamed = update_group(
@@ -450,6 +562,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(renamed.name, "Day job");
-        assert_eq!(list_groups(&conn, alice).unwrap()[0].project_ids, vec![project]);
+        assert_eq!(
+            list_groups(&conn, alice).unwrap()[0].project_ids,
+            vec![project]
+        );
     }
 }

--- a/src/db/queries/projects.rs
+++ b/src/db/queries/projects.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use rusqlite::{Connection, params};
 
-use crate::db::models::*;
+use crate::db::models::{CreateProject, Project, Role, UpdateProject};
 use crate::error::LificError;
 
 use super::unescape_text;
@@ -208,7 +208,7 @@ pub fn create_project(conn: &Connection, input: &CreateProject) -> Result<Projec
 /// dense and deterministic, avoiding the float-midpoint exhaustion and
 /// all-equal-rank collisions a per-item PATCH scheme would hit.
 ///
-/// Rejects duplicate ids and any id that doesn't exist (BadRequest). Projects
+/// Rejects duplicate ids and any id that doesn't exist (`BadRequest`). Projects
 /// not present in `ids` keep their current rank — callers should send the full
 /// list to guarantee a total order.
 pub fn reorder_projects(conn: &Connection, ids: &[i64]) -> Result<Vec<Project>, LificError> {
@@ -224,9 +224,11 @@ pub fn reorder_projects(conn: &Connection, ids: &[i64]) -> Result<Vec<Project>, 
     }
     super::savepoint(conn, "reorder_projects", || {
         for (position, id) in ids.iter().enumerate() {
+            let position = i64::try_from(position)
+                .map_err(|_| LificError::BadRequest("too many projects to reorder".into()))?;
             let changed = conn.execute(
                 "UPDATE projects SET sort_order = ?1 WHERE id = ?2",
-                params![position as i64, id],
+                params![position, id],
             )?;
             if changed == 0 {
                 return Err(LificError::BadRequest(format!("project {id} not found")));
@@ -341,11 +343,11 @@ fn project_viewer_ids(conn: &Connection, project: &Project) -> Result<Vec<i64>, 
     let admins = stmt
         .query_map([], |row| row.get::<_, i64>(0))?
         .collect::<Result<Vec<_>, _>>()?;
-    admins.into_iter().for_each(|id| {
+    for id in admins {
         if !ids.contains(&id) {
             ids.push(id);
         }
-    });
+    }
     Ok(ids)
 }
 
@@ -652,14 +654,14 @@ mod tests {
             .unwrap();
             conn.last_insert_rowid()
         };
-        let blocker = insert_issue(1, "Blocker", "active", "2026-01-01 00:00:00");
+        let blocking_issue = insert_issue(1, "Blocker", "active", "2026-01-01 00:00:00");
         insert_issue(2, "Unblocked", "todo", "2026-01-02 00:00:00");
-        let blocked = insert_issue(3, "Blocked", "todo", "2026-01-03 00:00:00");
+        let blocked_issue = insert_issue(3, "Blocked", "todo", "2026-01-03 00:00:00");
         insert_issue(4, "Done", "done", "2026-01-04 00:00:00");
         conn.execute(
             "INSERT INTO issue_relations (source_id, target_id, relation_type)
              VALUES (?1, ?2, 'blocks')",
-            params![blocker, blocked],
+            params![blocking_issue, blocked_issue],
         )
         .unwrap();
 
@@ -807,7 +809,7 @@ mod tests {
 
     // ── LIF-103: tristate clear-to-NULL semantics for emoji + lead_user_id ──
 
-    /// Seed a real user so projects with lead_user_id pass the FK constraint.
+    /// Seed a real user so projects with `lead_user_id` pass the FK constraint.
     fn seed_user(conn: &Connection, username: &str) -> i64 {
         conn.execute(
             "INSERT INTO users (username, email, password_hash, display_name, is_admin, is_bot)

--- a/src/db/queries/projects.rs
+++ b/src/db/queries/projects.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -152,7 +152,9 @@ pub fn get_project(conn: &Connection, id: i64) -> Result<Project, LificError> {
 ///   workspace pages
 fn validate_identifier(identifier: &str) -> Result<(), LificError> {
     if identifier.is_empty() {
-        return Err(LificError::BadRequest("identifier must not be empty".into()));
+        return Err(LificError::BadRequest(
+            "identifier must not be empty".into(),
+        ));
     }
     if identifier.chars().count() > 5 {
         return Err(LificError::BadRequest(
@@ -275,19 +277,16 @@ pub fn update_project(
             // return a 400 with a clear message instead of letting the FK
             // constraint surface as a generic 500.
             if let Some(uid) = lead {
-                let exists = match conn.query_row(
-                    "SELECT 1 FROM users WHERE id = ?1",
-                    params![uid],
-                    |_| Ok(true),
-                ) {
-                    Ok(_) => true,
-                    Err(rusqlite::Error::QueryReturnedNoRows) => false,
-                    Err(e) => return Err(e.into()),
-                };
+                let exists =
+                    match conn.query_row("SELECT 1 FROM users WHERE id = ?1", params![uid], |_| {
+                        Ok(true)
+                    }) {
+                        Ok(_) => true,
+                        Err(rusqlite::Error::QueryReturnedNoRows) => false,
+                        Err(e) => return Err(e.into()),
+                    };
                 if !exists {
-                    return Err(LificError::BadRequest(format!(
-                        "user {uid} not found"
-                    )));
+                    return Err(LificError::BadRequest(format!("user {uid} not found")));
                 }
             }
             conn.execute(
@@ -716,7 +715,8 @@ mod tests {
         seed_named(&conn, "Gamma", "G");
         seed_named(&conn, "Alpha", "A");
         seed_named(&conn, "Beta", "B");
-        conn.execute("UPDATE projects SET sort_order = 0", []).unwrap();
+        conn.execute("UPDATE projects SET sort_order = 0", [])
+            .unwrap();
 
         let names: Vec<String> = list_projects(&conn)
             .unwrap()

--- a/src/db/queries/resources.rs
+++ b/src/db/queries/resources.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -137,16 +137,18 @@ pub fn get_module(conn: &Connection, id: i64) -> Result<Module, LificError> {
         "SELECT id, project_id, name, description, status, emoji, created_at, updated_at
          FROM modules WHERE id = ?1",
         params![id],
-        |row| Ok(Module {
-            id: row.get(0)?,
-            project_id: row.get(1)?,
-            name: row.get(2)?,
-            description: row.get(3)?,
-            status: row.get(4)?,
-            emoji: row.get(5)?,
-            created_at: row.get(6)?,
-            updated_at: row.get(7)?,
-        }),
+        |row| {
+            Ok(Module {
+                id: row.get(0)?,
+                project_id: row.get(1)?,
+                name: row.get(2)?,
+                description: row.get(3)?,
+                status: row.get(4)?,
+                emoji: row.get(5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        },
     )
     .map_err(|e| match e {
         rusqlite::Error::QueryReturnedNoRows => {
@@ -182,7 +184,14 @@ pub fn list_modules(conn: &Connection, project_id: i64) -> Result<Vec<Module>, L
 /// CLI all get the same contract (mirrors how issue status became a real
 /// type in 286d4ac; modules keep the lighter String representation because
 /// nothing branches on module status server-side).
-const MODULE_STATUSES: [&str; 6] = ["backlog", "planned", "active", "paused", "done", "cancelled"];
+const MODULE_STATUSES: [&str; 6] = [
+    "backlog",
+    "planned",
+    "active",
+    "paused",
+    "done",
+    "cancelled",
+];
 
 fn validate_module_status(status: &str) -> Result<(), LificError> {
     if MODULE_STATUSES.contains(&status) {
@@ -573,7 +582,10 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got: {err:?}");
-        assert!(err.to_string().contains("paused"), "error must list the six: {err}");
+        assert!(
+            err.to_string().contains("paused"),
+            "error must list the six: {err}"
+        );
 
         let module = create_module(
             &conn,
@@ -586,7 +598,14 @@ mod tests {
             },
         )
         .unwrap();
-        for status in ["backlog", "planned", "active", "paused", "done", "cancelled"] {
+        for status in [
+            "backlog",
+            "planned",
+            "active",
+            "paused",
+            "done",
+            "cancelled",
+        ] {
             update_module(
                 &conn,
                 module.id,
@@ -771,12 +790,20 @@ mod tests {
         let pid = seed_project(&conn);
         let bug = create_label(
             &conn,
-            &CreateLabel { project_id: pid, name: "bug".into(), color: "#EF4444".into() },
+            &CreateLabel {
+                project_id: pid,
+                name: "bug".into(),
+                color: "#EF4444".into(),
+            },
         )
         .unwrap();
         let defect = create_label(
             &conn,
-            &CreateLabel { project_id: pid, name: "defect".into(), color: "#F97316".into() },
+            &CreateLabel {
+                project_id: pid,
+                name: "defect".into(),
+                color: "#F97316".into(),
+            },
         )
         .unwrap();
 
@@ -825,7 +852,11 @@ mod tests {
         let pid = seed_project(&conn);
         let l = create_label(
             &conn,
-            &CreateLabel { project_id: pid, name: "bug".into(), color: "#EF4444".into() },
+            &CreateLabel {
+                project_id: pid,
+                name: "bug".into(),
+                color: "#EF4444".into(),
+            },
         )
         .unwrap();
         let err = merge_label(&conn, l.id, l.id).unwrap_err();
@@ -1062,24 +1093,56 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn);
-        let module = create_module(&conn, &CreateModule {
-            project_id: pid, name: "M".into(), description: String::new(),
-            status: "active".into(), emoji: None,
-        }).unwrap();
-        let label = create_label(&conn, &CreateLabel {
-            project_id: pid, name: "bug".into(), color: "#EF4444".into(),
-        }).unwrap();
-        let folder = create_folder(&conn, &CreateFolder {
-            project_id: pid, parent_id: None, name: "Docs".into(),
-        }).unwrap();
+        let module = create_module(
+            &conn,
+            &CreateModule {
+                project_id: pid,
+                name: "M".into(),
+                description: String::new(),
+                status: "active".into(),
+                emoji: None,
+            },
+        )
+        .unwrap();
+        let label = create_label(
+            &conn,
+            &CreateLabel {
+                project_id: pid,
+                name: "bug".into(),
+                color: "#EF4444".into(),
+            },
+        )
+        .unwrap();
+        let folder = create_folder(
+            &conn,
+            &CreateFolder {
+                project_id: pid,
+                parent_id: None,
+                name: "Docs".into(),
+            },
+        )
+        .unwrap();
 
-        assert_eq!(get_resource_project_id(&conn, ResourceTable::Modules, module.id).unwrap(), pid);
-        assert_eq!(get_resource_project_id(&conn, ResourceTable::Labels, label.id).unwrap(), pid);
-        assert_eq!(get_resource_project_id(&conn, ResourceTable::Folders, folder.id).unwrap(), pid);
+        assert_eq!(
+            get_resource_project_id(&conn, ResourceTable::Modules, module.id).unwrap(),
+            pid
+        );
+        assert_eq!(
+            get_resource_project_id(&conn, ResourceTable::Labels, label.id).unwrap(),
+            pid
+        );
+        assert_eq!(
+            get_resource_project_id(&conn, ResourceTable::Folders, folder.id).unwrap(),
+            pid
+        );
 
         // The only table names reachable from the enum are these three bare
         // identifiers, so no call site can smuggle SQL in through the name.
-        for table in [ResourceTable::Modules, ResourceTable::Labels, ResourceTable::Folders] {
+        for table in [
+            ResourceTable::Modules,
+            ResourceTable::Labels,
+            ResourceTable::Folders,
+        ] {
             let name = table.as_table();
             assert!(
                 ["modules", "labels", "folders"].contains(&name),
@@ -1101,9 +1164,15 @@ mod tests {
         let pool = test_db();
         let conn = pool.write().unwrap();
         let pid = seed_project(&conn);
-        let folder = create_folder(&conn, &CreateFolder {
-            project_id: pid, parent_id: None, name: "Design".into(),
-        }).unwrap();
+        let folder = create_folder(
+            &conn,
+            &CreateFolder {
+                project_id: pid,
+                parent_id: None,
+                name: "Design".into(),
+            },
+        )
+        .unwrap();
 
         assert_eq!(get_folder_name(&conn, folder.id).unwrap(), "Design");
         let err = get_folder_name(&conn, 999_999).unwrap_err();

--- a/src/db/queries/resources.rs
+++ b/src/db/queries/resources.rs
@@ -1,13 +1,16 @@
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::db::models::*;
+use crate::db::models::{
+    CreateFolder, CreateLabel, CreateModule, Folder, Label, Module, UpdateFolder, UpdateLabel,
+    UpdateModule,
+};
 use crate::error::LificError;
 
 use super::unescape_text;
 
 /// A table [`get_resource_project_id`] can resolve a row in.
 ///
-/// LIF-386: the table name is interpolated into the SQL, because SQLite has
+/// LIF-386: the table name is interpolated into the SQL, because `SQLite` has
 /// no bind parameter for an identifier. The set of legal names is therefore
 /// an enum rather than a string: a caller cannot express an injection in the
 /// first place, so there is nothing to validate at runtime.
@@ -30,7 +33,7 @@ impl ResourceTable {
     }
 }
 
-/// Look up the project_id for a module, label, or folder by its id.
+/// Look up the `project_id` for a module, label, or folder by its id.
 pub fn get_resource_project_id(
     conn: &Connection,
     table: ResourceTable,
@@ -129,8 +132,8 @@ pub fn get_folder_name(conn: &Connection, id: i64) -> Result<String, LificError>
 }
 
 /// Fetch a single module by id. Used by the web detail route and any
-/// client that already knows the id but not the project — list_modules
-/// requires the project_id up front, which makes URL→data resolution
+/// client that already knows the id but not the project — `list_modules`
+/// requires the `project_id` up front, which makes URL→data resolution
 /// awkward when you don't have it in hand.
 pub fn get_module(conn: &Connection, id: i64) -> Result<Module, LificError> {
     conn.query_row(
@@ -498,6 +501,9 @@ pub fn delete_folder(conn: &Connection, id: i64) -> Result<(), LificError> {
 
 #[cfg(test)]
 mod tests {
+    #[allow(clippy::wildcard_imports)]
+    use crate::db::models::*;
+
     use super::*;
     use crate::db;
     use crate::db::queries::projects;
@@ -561,7 +567,7 @@ mod tests {
 
     /// LIF-397: docs and the MCP schema promise six module statuses, but the
     /// column is TEXT and used to take anything ("bananas" included). The six
-    /// documented values round-trip; everything else is a BadRequest naming
+    /// documented values round-trip; everything else is a `BadRequest` naming
     /// them, on both create and update, and a rejected update leaves the row
     /// untouched.
     #[test]

--- a/src/db/queries/search.rs
+++ b/src/db/queries/search.rs
@@ -408,7 +408,7 @@ fn search_literal(
     visible_project_ids: Option<&HashSet<i64>>,
 ) -> Result<Vec<SearchResult>, LificError> {
     match q.sort.as_deref() {
-        None | Some("relevance") | Some("recent") => {}
+        None | Some("relevance" | "recent") => {}
         Some(other) => {
             return Err(LificError::BadRequest(format!(
                 "invalid sort '{other}'. Use relevance or recent."

--- a/src/db/queries/settings.rs
+++ b/src/db/queries/settings.rs
@@ -124,7 +124,10 @@ pub fn update(
     patch: InstanceSettingsPatch,
 ) -> Result<InstanceSettings, LificError> {
     // Guarantee the single row exists before we UPDATE it (write conn).
-    conn.execute("INSERT OR IGNORE INTO instance_settings (id) VALUES (1)", [])?;
+    conn.execute(
+        "INSERT OR IGNORE INTO instance_settings (id) VALUES (1)",
+        [],
+    )?;
     let cur = get(conn)?;
 
     let allow_signup = patch.allow_signup.unwrap_or(cur.allow_signup);
@@ -237,7 +240,8 @@ fn is_plausible_domain(d: &str) -> bool {
     if d.contains("..") {
         return false;
     }
-    d.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+    d.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
 }
 
 #[cfg(test)]
@@ -259,8 +263,14 @@ mod tests {
         assert!(s.signup_email_domains.is_empty());
         assert_eq!(s.session_lifetime_days, 30);
         assert!(s.login_message.is_none());
-        assert!(!s.web_auto_login, "single-user auto-login is off by default");
-        assert!(!s.authz_enforced, "authorization enforcement is off by default");
+        assert!(
+            !s.web_auto_login,
+            "single-user auto-login is off by default"
+        );
+        assert!(
+            !s.authz_enforced,
+            "authorization enforcement is off by default"
+        );
     }
 
     #[test]
@@ -268,10 +278,16 @@ mod tests {
         let pool = conn();
         let c = pool.write().unwrap();
         ensure(&c, false).unwrap();
-        assert!(!get(&c).unwrap().allow_signup, "first ensure seeds the value");
+        assert!(
+            !get(&c).unwrap().allow_signup,
+            "first ensure seeds the value"
+        );
         // A later ensure with a different default must NOT overwrite.
         ensure(&c, true).unwrap();
-        assert!(!get(&c).unwrap().allow_signup, "row already existed, left intact");
+        assert!(
+            !get(&c).unwrap().allow_signup,
+            "row already existed, left intact"
+        );
     }
 
     // ── LIF-261: authz_enforced seed default depends on the install ──────
@@ -339,7 +355,10 @@ mod tests {
         // An admin flips it off at runtime…
         let s = update(
             &c,
-            InstanceSettingsPatch { authz_enforced: Some(false), ..Default::default() },
+            InstanceSettingsPatch {
+                authz_enforced: Some(false),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(!s.authz_enforced);
@@ -358,14 +377,20 @@ mod tests {
         let c = pool.write().unwrap();
         let s = update(
             &c,
-            InstanceSettingsPatch { instance_name: Some("  Acme Eng  ".into()), ..Default::default() },
+            InstanceSettingsPatch {
+                instance_name: Some("  Acme Eng  ".into()),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert_eq!(s.instance_name.as_deref(), Some("Acme Eng")); // trimmed
         // Empty clears back to NULL.
         let s = update(
             &c,
-            InstanceSettingsPatch { instance_name: Some("   ".into()), ..Default::default() },
+            InstanceSettingsPatch {
+                instance_name: Some("   ".into()),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.instance_name.is_none());
@@ -394,21 +419,36 @@ mod tests {
     fn update_rejects_bad_domain_and_bad_session() {
         let pool = conn();
         let c = pool.write().unwrap();
-        assert!(update(
-            &c,
-            InstanceSettingsPatch { signup_email_domains: Some(vec!["not a domain".into()]), ..Default::default() },
-        )
-        .is_err());
-        assert!(update(
-            &c,
-            InstanceSettingsPatch { session_lifetime_days: Some(0), ..Default::default() },
-        )
-        .is_err());
-        assert!(update(
-            &c,
-            InstanceSettingsPatch { session_lifetime_days: Some(999), ..Default::default() },
-        )
-        .is_err());
+        assert!(
+            update(
+                &c,
+                InstanceSettingsPatch {
+                    signup_email_domains: Some(vec!["not a domain".into()]),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            update(
+                &c,
+                InstanceSettingsPatch {
+                    session_lifetime_days: Some(0),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            update(
+                &c,
+                InstanceSettingsPatch {
+                    session_lifetime_days: Some(999),
+                    ..Default::default()
+                },
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -437,21 +477,30 @@ mod tests {
 
         let s = update(
             &c,
-            InstanceSettingsPatch { web_auto_login: Some(true), ..Default::default() },
+            InstanceSettingsPatch {
+                web_auto_login: Some(true),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.web_auto_login);
         // Persisted, and an unrelated patch leaves it intact.
         let s = update(
             &c,
-            InstanceSettingsPatch { instance_name: Some("Solo".into()), ..Default::default() },
+            InstanceSettingsPatch {
+                instance_name: Some("Solo".into()),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.web_auto_login, "unrelated patch must not clear the flag");
 
         let s = update(
             &c,
-            InstanceSettingsPatch { web_auto_login: Some(false), ..Default::default() },
+            InstanceSettingsPatch {
+                web_auto_login: Some(false),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(!s.web_auto_login);
@@ -466,21 +515,30 @@ mod tests {
 
         let s = update(
             &c,
-            InstanceSettingsPatch { authz_enforced: Some(true), ..Default::default() },
+            InstanceSettingsPatch {
+                authz_enforced: Some(true),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.authz_enforced);
         // Persisted, and an unrelated patch leaves it intact.
         let s = update(
             &c,
-            InstanceSettingsPatch { instance_name: Some("Solo".into()), ..Default::default() },
+            InstanceSettingsPatch {
+                instance_name: Some("Solo".into()),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(s.authz_enforced, "unrelated patch must not clear the flag");
 
         let s = update(
             &c,
-            InstanceSettingsPatch { authz_enforced: Some(false), ..Default::default() },
+            InstanceSettingsPatch {
+                authz_enforced: Some(false),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(!s.authz_enforced);

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -4,7 +4,7 @@ use argon2::{
 };
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::db::models::*;
+use crate::db::models::{AuthUser, CreateUser, Session, User};
 use crate::error::LificError;
 
 pub(crate) const INVALID_SESSION_MESSAGE: &str = "invalid or expired session";
@@ -879,7 +879,7 @@ pub fn lock_down_account(conn: &Connection, user_id: i64) -> Result<(), LificErr
     })
 }
 
-/// Generate a session token with the lific_sess_ prefix.
+/// Generate a session token with the `lific_sess`_ prefix.
 fn generate_session_token() -> String {
     let bytes: [u8; 32] = rand::random();
     let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
@@ -927,7 +927,7 @@ fn unusable_password_hash() -> Result<String, LificError> {
     hash_password(&random_pw_hex)
 }
 
-/// Whether a failure is SQLite rejecting a write because it broke a constraint
+/// Whether a failure is `SQLite` rejecting a write because it broke a constraint
 /// (UNIQUE, CHECK, foreign key). LIF-367 leans on this to tell "another
 /// connect got here first" apart from a genuine database failure.
 fn is_constraint_violation(err: &LificError) -> bool {
@@ -1156,7 +1156,7 @@ pub fn find_bot_by_owner_and_tool(
     }
 }
 
-/// Find a legacy bot (tool_id NULL, minted before LIFIC-17) by its owner and
+/// Find a legacy bot (`tool_id` NULL, minted before LIFIC-17) by its owner and
 /// its tool *prefix*.
 ///
 /// Legacy bots were keyed by the `{tool}-{owner.username}` username, which
@@ -1209,11 +1209,11 @@ pub fn bot_is_connected(conn: &Connection, bot_id: i64) -> Result<bool, LificErr
 /// another way. Returns the bot user.
 ///
 /// LIFIC-13: the single find-or-create decision all three doors (OAuth
-/// approval, `lific connect`, web create_bot) share.
+/// approval, `lific connect`, web `create_bot`) share.
 ///
 /// LIFIC-17: dedupe keys on the stable `(owner_id, tool_id)` pair, not the
 /// derived username, so renaming the owner never orphans the agent. Legacy
-/// bots minted before the `tool_id` column existed (tool_id NULL) are found
+/// bots minted before the `tool_id` column existed (`tool_id` NULL) are found
 /// by their owner and tool prefix and backfilled in place — safe even when the
 /// owner renamed in the meantime, since the prefix match skips the stale owner
 /// name embedded in their username.
@@ -2192,7 +2192,7 @@ mod tests {
 
     /// Insert an active (non-revoked) `oauth_tokens` row bound to `user_id`.
     fn insert_oauth_token_for(conn: &Connection, user_id: i64) -> i64 {
-        let token_hash = format!("testtoken-{user_id}-{}", user_id);
+        let token_hash = format!("testtoken-{user_id}-{user_id}");
         let client_id = "test-client";
         conn.execute(
             "INSERT INTO oauth_clients (client_id, client_name, redirect_uris) VALUES (?1, 'Test', '[\"http://localhost\"]')",
@@ -3078,7 +3078,7 @@ mod tests {
     /// The first-admin decision is `SELECT COUNT(*) = 0 FROM users` followed by
     /// an insert. Those are two statements, so on a bare writer guard they were
     /// two implicit transactions and two racing signups could both read zero.
-    /// Inside one `BEGIN IMMEDIATE` they cannot: SQLite admits one writer, so
+    /// Inside one `BEGIN IMMEDIATE` they cannot: `SQLite` admits one writer, so
     /// the second signup reads the first one's committed row.
     #[test]
     fn concurrent_signups_produce_exactly_one_first_admin() {

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -1,8 +1,8 @@
 use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
 };
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::db::models::*;
 use crate::error::LificError;
@@ -316,7 +316,9 @@ pub fn update_profile(
     if let Some(dn) = display_name {
         let dn = dn.trim();
         if dn.is_empty() {
-            return Err(LificError::BadRequest("display name cannot be empty".into()));
+            return Err(LificError::BadRequest(
+                "display name cannot be empty".into(),
+            ));
         }
         if dn.chars().count() > 100 {
             return Err(LificError::BadRequest(
@@ -333,15 +335,18 @@ pub fn update_profile(
         if em.is_empty() || !em.contains('@') {
             return Err(LificError::BadRequest("invalid email address".into()));
         }
-        conn.execute("UPDATE users SET email = ?1 WHERE id = ?2", params![em, user_id])
-            .map_err(|e| match e {
-                rusqlite::Error::SqliteFailure(err, _)
-                    if err.code == rusqlite::ErrorCode::ConstraintViolation =>
-                {
-                    LificError::BadRequest("that email is already in use".into())
-                }
-                other => other.into(),
-            })?;
+        conn.execute(
+            "UPDATE users SET email = ?1 WHERE id = ?2",
+            params![em, user_id],
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::SqliteFailure(err, _)
+                if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                LificError::BadRequest("that email is already in use".into())
+            }
+            other => other.into(),
+        })?;
     }
     get_user_by_id(conn, user_id)
 }
@@ -471,7 +476,11 @@ fn derive_username(conn: &Connection, display_name: &str) -> Result<String, Lifi
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("-");
-    let base = if slug.is_empty() { "admin".to_string() } else { slug };
+    let base = if slug.is_empty() {
+        "admin".to_string()
+    } else {
+        slug
+    };
     let mut candidate = base.clone();
     let mut n = 1;
     while get_user_by_username(conn, &candidate).is_ok() {
@@ -901,7 +910,6 @@ pub fn assign_key_to_user(
     }
     Ok(())
 }
-
 
 // ── Bots (connected tools) ───────────────────────────────────
 
@@ -1384,14 +1392,20 @@ pub fn delete_bot(
     conn.execute("DELETE FROM api_keys WHERE user_id = ?1", params![bot_id])?;
     // Delete the bot's OAuth tokens (LIFIC-13 follow-up): leaves no dangling
     // rows pointing at a removed identity.
-    conn.execute("DELETE FROM oauth_tokens WHERE user_id = ?1", params![bot_id])?;
+    conn.execute(
+        "DELETE FROM oauth_tokens WHERE user_id = ?1",
+        params![bot_id],
+    )?;
     // And its in-flight OAuth handshakes (PR #23 review): a pending device or
     // auth code bound to a deleted identity must not stay exchangeable.
     conn.execute(
         "DELETE FROM oauth_device_codes WHERE user_id = ?1",
         params![bot_id],
     )?;
-    conn.execute("DELETE FROM oauth_codes WHERE user_id = ?1", params![bot_id])?;
+    conn.execute(
+        "DELETE FROM oauth_codes WHERE user_id = ?1",
+        params![bot_id],
+    )?;
 
     // Delete any comments made by this bot (or reassign — deleting for now)
     conn.execute("DELETE FROM comments WHERE user_id = ?1", params![bot_id])?;
@@ -1491,7 +1505,10 @@ mod tests {
         assert!(!has_human_users(&conn).unwrap(), "fresh db has no humans");
 
         test_create_user(&conn);
-        assert!(has_human_users(&conn).unwrap(), "human signup flips it true");
+        assert!(
+            has_human_users(&conn).unwrap(),
+            "human signup flips it true"
+        );
     }
 
     #[test]
@@ -1543,8 +1560,12 @@ mod tests {
         let conn = pool.write().unwrap();
         let owner = test_create_user(&conn);
 
-        let first = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap().id;
-        let second = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap().id;
+        let first = ensure_bot(&conn, owner.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
+        let second = ensure_bot(&conn, owner.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
         assert_eq!(first, second, "re-approval must reuse, not duplicate");
     }
 
@@ -1566,8 +1587,12 @@ mod tests {
         )
         .unwrap();
 
-        let a = ensure_bot(&conn, owner_a.id, "opencode", "OpenCode").unwrap().id;
-        let b = ensure_bot(&conn, owner_b.id, "opencode", "OpenCode").unwrap().id;
+        let a = ensure_bot(&conn, owner_a.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
+        let b = ensure_bot(&conn, owner_b.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
         assert_ne!(a, b, "each owner gets its own bot for the same tool");
     }
 
@@ -1583,7 +1608,9 @@ mod tests {
         let conn = pool.write().unwrap();
         let owner = test_create_user(&conn); // username "blake"
 
-        let first = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap().id;
+        let first = ensure_bot(&conn, owner.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
 
         // Simulate the owner renaming their account: username changes, id stays.
         conn.execute(
@@ -1592,8 +1619,13 @@ mod tests {
         )
         .unwrap();
 
-        let second = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap().id;
-        assert_eq!(first, second, "renaming the owner must not orphan the agent");
+        let second = ensure_bot(&conn, owner.id, "opencode", "OpenCode")
+            .unwrap()
+            .id;
+        assert_eq!(
+            first, second,
+            "renaming the owner must not orphan the agent"
+        );
     }
 
     // Bots minted before the tool_id column existed (tool_id NULL) are still
@@ -1606,8 +1638,7 @@ mod tests {
         let conn = pool.write().unwrap();
         let owner = test_create_user(&conn); // username "blake"
         // A pre-migration bot: username "opencode-blake", tool_id NULL.
-        let legacy = create_bot_user(&conn, owner.id, "opencode-blake", "OpenCode", None)
-            .unwrap();
+        let legacy = create_bot_user(&conn, owner.id, "opencode-blake", "OpenCode", None).unwrap();
 
         let reused = ensure_bot(&conn, owner.id, "opencode", "OpenCode").unwrap();
         assert_eq!(
@@ -1621,7 +1652,11 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(stored.as_deref(), Some("opencode"), "legacy bot tool_id backfilled");
+        assert_eq!(
+            stored.as_deref(),
+            Some("opencode"),
+            "legacy bot tool_id backfilled"
+        );
     }
 
     // The legacy backfill holds even when the owner renamed *before* the
@@ -1633,8 +1668,8 @@ mod tests {
         let conn = pool.write().unwrap();
         let owner = test_create_user(&conn); // username "blake"
         // A pre-migration bot whose username still has the old owner name.
-        let legacy = create_bot_user(&conn, owner.id, "opencode-oldname", "OpenCode", None)
-            .unwrap();
+        let legacy =
+            create_bot_user(&conn, owner.id, "opencode-oldname", "OpenCode", None).unwrap();
         // The owner renames before ever reconnecting.
         conn.execute(
             "UPDATE users SET username = ?1 WHERE id = ?2",
@@ -1824,7 +1859,8 @@ mod tests {
     fn migration_038_keeps_the_oldest_bot_and_repoints_every_reference() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        conn.execute_batch("DROP INDEX idx_users_owner_tool;").unwrap();
+        conn.execute_batch("DROP INDEX idx_users_owner_tool;")
+            .unwrap();
 
         let owner = test_create_user(&conn);
         raw_insert_bot(&conn, "opencode-blake", owner.id, Some("opencode")).unwrap();
@@ -1927,8 +1963,10 @@ mod tests {
         )
         .unwrap();
 
-        conn.execute_batch(include_str!("../../../migrations/038_bot_identity_unique.sql"))
-            .unwrap();
+        conn.execute_batch(include_str!(
+            "../../../migrations/038_bot_identity_unique.sql"
+        ))
+        .unwrap();
 
         // The loser is gone, the survivor and the unrelated bot are not.
         let remaining: Vec<i64> = conn
@@ -1989,7 +2027,8 @@ mod tests {
     fn migration_038_merges_colliding_rows_instead_of_dropping_them() {
         let pool = test_db();
         let conn = pool.write().unwrap();
-        conn.execute_batch("DROP INDEX idx_users_owner_tool;").unwrap();
+        conn.execute_batch("DROP INDEX idx_users_owner_tool;")
+            .unwrap();
 
         let owner = test_create_user(&conn);
         raw_insert_bot(&conn, "opencode-blake", owner.id, Some("opencode")).unwrap();
@@ -2053,8 +2092,10 @@ mod tests {
             .unwrap();
         }
 
-        conn.execute_batch(include_str!("../../../migrations/038_bot_identity_unique.sql"))
-            .unwrap();
+        conn.execute_batch(include_str!(
+            "../../../migrations/038_bot_identity_unique.sql"
+        ))
+        .unwrap();
 
         // The strongest role wins per project; nothing is dropped.
         let members: Vec<(i64, i64, String)> = conn
@@ -2638,7 +2679,11 @@ mod tests {
         test_create_user(&conn);
 
         let known = password_challenge(&conn, "blake");
-        assert_ne!(known.hash(), DUMMY_HASH, "a real user verifies their own hash");
+        assert_ne!(
+            known.hash(),
+            DUMMY_HASH,
+            "a real user verifies their own hash"
+        );
         assert!(verify_password("securepassword123", known.hash()).unwrap());
 
         let unknown = password_challenge(&conn, "nobody");
@@ -2672,8 +2717,11 @@ mod tests {
                 .to_string()
         );
 
-        conn.execute("UPDATE users SET is_active = 0 WHERE id = ?1", params![user.id])
-            .unwrap();
+        conn.execute(
+            "UPDATE users SET is_active = 0 WHERE id = ?1",
+            params![user.id],
+        )
+        .unwrap();
         let challenge = password_challenge(&conn, "blake");
         let ok = verify_password("securepassword123", challenge.hash()).unwrap();
         let err = challenge.finish(ok).unwrap_err().to_string();
@@ -2706,7 +2754,9 @@ mod tests {
         assert_eq!(user.email, "mixedcase@example.com", "email is lowercased");
         assert_eq!(user.display_name, "spaced");
         assert_eq!(
-            authenticate(&conn, "spaced", "securepassword123").unwrap().id,
+            authenticate(&conn, "spaced", "securepassword123")
+                .unwrap()
+                .id,
             user.id,
             "the externally-hashed password still logs in"
         );
@@ -3382,7 +3432,10 @@ mod tests {
         let admin = create_passwordless_admin(&conn, "Operator Blake").unwrap();
 
         assert!(admin.is_admin, "first admin is an admin");
-        assert!(!admin.is_bot, "first admin is a person, not a connected tool");
+        assert!(
+            !admin.is_bot,
+            "first admin is a person, not a connected tool"
+        );
         assert_eq!(admin.display_name, "Operator Blake");
     }
 
@@ -3392,7 +3445,9 @@ mod tests {
         let conn = pool.write().unwrap();
         let admin = create_passwordless_admin(&conn, "Operator Blake").unwrap();
 
-        let resolved = first_admin(&conn).unwrap().expect("resolves as first admin");
+        let resolved = first_admin(&conn)
+            .unwrap()
+            .expect("resolves as first admin");
         assert_eq!(resolved.id, admin.id);
         assert_eq!(resolved.username, admin.username);
     }
@@ -3412,7 +3467,10 @@ mod tests {
         let first = create_passwordless_admin(&conn, "Blake").unwrap();
         let second = create_passwordless_admin(&conn, "blake!").unwrap();
 
-        assert_ne!(first.username, second.username, "usernames must not collide");
+        assert_ne!(
+            first.username, second.username,
+            "usernames must not collide"
+        );
         assert!(!first.username.is_empty());
         assert!(!second.username.is_empty());
     }

--- a/src/db/queries/views.rs
+++ b/src/db/queries/views.rs
@@ -132,7 +132,13 @@ pub fn create_view(
         conn.execute(
             "INSERT INTO saved_views (project_id, user_id, name, config, is_default)
              VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![project_id, user_id, input.name, input.config, input.is_default],
+            params![
+                project_id,
+                user_id,
+                input.name,
+                input.config,
+                input.is_default
+            ],
         )
         .map_err(constraint_err(&input.name))?;
         get_view_row(conn, conn.last_insert_rowid())
@@ -356,7 +362,11 @@ mod tests {
             created.id,
             project,
             alice,
-            &UpdateSavedView { name: None, config: Some(r#"{"a":1}"#.into()), is_default: None },
+            &UpdateSavedView {
+                name: None,
+                config: Some(r#"{"a":1}"#.into()),
+                is_default: None,
+            },
         )
         .unwrap();
 
@@ -396,7 +406,11 @@ mod tests {
             alice_view.id,
             project,
             bob,
-            &UpdateSavedView { name: Some("Hijacked".into()), config: None, is_default: None },
+            &UpdateSavedView {
+                name: Some("Hijacked".into()),
+                config: None,
+                is_default: None,
+            },
         )
         .unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
@@ -438,7 +452,10 @@ mod tests {
         assert!(second.is_default);
 
         let refreshed_first = get_view_row(&conn, first.id).unwrap();
-        assert!(!refreshed_first.is_default, "creating a new default must clear the old one");
+        assert!(
+            !refreshed_first.is_default,
+            "creating a new default must clear the old one"
+        );
 
         let defaults: i64 = conn
             .query_row(
@@ -466,7 +483,11 @@ mod tests {
             b.id,
             project,
             alice,
-            &UpdateSavedView { name: None, config: None, is_default: Some(true) },
+            &UpdateSavedView {
+                name: None,
+                config: None,
+                is_default: Some(true),
+            },
         )
         .unwrap();
         assert!(promoted.is_default);
@@ -483,11 +504,16 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         let bob = seed_user(&conn, "bob");
 
-        let alice_default = create_view(&conn, project, alice, &view_input("Alice default", true)).unwrap();
-        let bob_default = create_view(&conn, project, bob, &view_input("Bob default", true)).unwrap();
+        let alice_default =
+            create_view(&conn, project, alice, &view_input("Alice default", true)).unwrap();
+        let bob_default =
+            create_view(&conn, project, bob, &view_input("Bob default", true)).unwrap();
 
         assert!(alice_default.is_default);
-        assert!(bob_default.is_default, "bob's default must not be cleared by alice's");
+        assert!(
+            bob_default.is_default,
+            "bob's default must not be cleared by alice's"
+        );
     }
 
     // ── Validation ──────────────────────────────────────────────
@@ -503,7 +529,11 @@ mod tests {
             &conn,
             project,
             alice,
-            &CreateSavedView { name: "Bad".into(), config: "{not json".into(), is_default: false },
+            &CreateSavedView {
+                name: "Bad".into(),
+                config: "{not json".into(),
+                is_default: false,
+            },
         )
         .unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got {err:?}");
@@ -521,7 +551,11 @@ mod tests {
             &conn,
             project,
             alice,
-            &CreateSavedView { name: "Too big".into(), config: huge, is_default: false },
+            &CreateSavedView {
+                name: "Too big".into(),
+                config: huge,
+                is_default: false,
+            },
         )
         .unwrap_err();
         assert!(matches!(err, LificError::BadRequest(_)), "got {err:?}");
@@ -553,9 +587,16 @@ mod tests {
                 &conn,
                 project,
                 alice,
-                &CreateSavedView { name, config: config.into(), is_default: false },
+                &CreateSavedView {
+                    name,
+                    config: config.into(),
+                    is_default: false,
+                },
             );
-            assert!(result.is_ok(), "expected {config} to be accepted, got {result:?}");
+            assert!(
+                result.is_ok(),
+                "expected {config} to be accepted, got {result:?}"
+            );
         }
     }
 
@@ -603,7 +644,11 @@ mod tests {
             999999,
             project,
             alice,
-            &UpdateSavedView { name: Some("x".into()), config: None, is_default: None },
+            &UpdateSavedView {
+                name: Some("x".into()),
+                config: None,
+                is_default: None,
+            },
         )
         .unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
@@ -620,14 +665,22 @@ mod tests {
         let conn = pool.write().unwrap();
         let project = seed_project(&conn, "CDP");
         let alice = seed_user(&conn, "alice");
-        create_view(&conn, project, alice, &view_input("Gone with project", false)).unwrap();
+        create_view(
+            &conn,
+            project,
+            alice,
+            &view_input("Gone with project", false),
+        )
+        .unwrap();
 
         queries::delete_project(&conn, project).unwrap();
 
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM saved_views WHERE project_id = ?1", params![project], |row| {
-                row.get(0)
-            })
+            .query_row(
+                "SELECT COUNT(*) FROM saved_views WHERE project_id = ?1",
+                params![project],
+                |row| row.get(0),
+            )
             .unwrap();
         assert_eq!(count, 0);
     }
@@ -640,10 +693,15 @@ mod tests {
         let alice = seed_user(&conn, "alice");
         create_view(&conn, project, alice, &view_input("Gone with user", false)).unwrap();
 
-        conn.execute("DELETE FROM users WHERE id = ?1", params![alice]).unwrap();
+        conn.execute("DELETE FROM users WHERE id = ?1", params![alice])
+            .unwrap();
 
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM saved_views WHERE user_id = ?1", params![alice], |row| row.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM saved_views WHERE user_id = ?1",
+                params![alice],
+                |row| row.get(0),
+            )
             .unwrap();
         assert_eq!(count, 0);
     }

--- a/src/db/queries/views.rs
+++ b/src/db/queries/views.rs
@@ -641,7 +641,7 @@ mod tests {
 
         let err = update_view(
             &conn,
-            999999,
+            999_999,
             project,
             alice,
             &UpdateSavedView {
@@ -653,7 +653,7 @@ mod tests {
         .unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
 
-        let err = delete_view(&conn, 999999, project, alice).unwrap_err();
+        let err = delete_view(&conn, 999_999, project, alice).unwrap_err();
         assert!(matches!(err, LificError::NotFound(_)), "got {err:?}");
     }
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -194,7 +194,7 @@ pub(crate) fn staging_is_locked(path: &Path) -> bool {
 /// Take a consistent snapshot of the live DB into the already-reserved staging
 /// file `dest`.
 ///
-/// The SQLite online backup API runs on a read connection, holds no long
+/// The `SQLite` online backup API runs on a read connection, holds no long
 /// writer lock, and copies into a file this process created with
 /// `O_CREAT|O_EXCL|O_NOFOLLOW` — so, unlike `VACUUM INTO`, nothing resolves a
 /// pathname a second time between reserving the destination and writing it.
@@ -335,7 +335,7 @@ fn refresh_activity(file: &File) -> std::io::Result<()> {
 ///
 /// Shared code path used by both `lific dump` and the interval backup task.
 /// Produces a gzip-compressed tar containing `lific.db` (a consistent snapshot
-/// taken with SQLite's online backup API), every non-`.tmp` attachment blob
+/// taken with `SQLite`'s online backup API), every non-`.tmp` attachment blob
 /// under `attachments/`, and `manifest.json`. The finished file is chmod 0600
 /// (it contains the whole DB).
 ///
@@ -523,7 +523,7 @@ struct BlobIdentity {
     ino: u64,
 }
 
-/// Whether an open failure means "that name is a symlink and O_NOFOLLOW
+/// Whether an open failure means "that name is a symlink and `O_NOFOLLOW`
 /// refused it". Linux reports `ELOOP`, the BSDs `EMLINK`;
 /// `ErrorKind::FilesystemLoop` is still unstable, so match the raw codes.
 fn is_symlink(error: &std::io::Error) -> bool {
@@ -588,8 +588,7 @@ fn open_verified_blob(path: &Path) -> Result<Option<VerifiedBlob>, LificError> {
         .modified()
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_secs());
 
     #[cfg(unix)]
     let identity = {
@@ -749,8 +748,7 @@ fn append_bytes<W: std::io::Write>(
     header.set_mtime(
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0),
+            .map_or(0, |d| d.as_secs()),
     );
     header.set_cksum();
     tar.append_data(&mut header, name, bytes)
@@ -1083,7 +1081,7 @@ fn create_staging_file(path: &Path) -> Result<File, LificError> {
         .map_err(|e| LificError::Internal(format!("create staging file: {e}")))
 }
 
-/// Validate the extracted SQLite file before it can replace the live DB. This
+/// Validate the extracted `SQLite` file before it can replace the live DB. This
 /// catches corrupt archives and ensures every metadata attachment reference is
 /// a safe content-addressed filename with matching staged bytes.
 fn validate_staged_database(
@@ -1429,15 +1427,13 @@ fn read_manifest(archive: &Path, limits: &RestoreLimits) -> Result<Manifest, Lif
 /// may still be running (best-effort — see command help).
 fn wal_is_hot(db_path: &Path) -> bool {
     let wal = PathBuf::from(format!("{}-wal", db_path.display()));
-    std::fs::metadata(&wal)
-        .map(|m| m.len() > 0)
-        .unwrap_or(false)
+    std::fs::metadata(&wal).is_ok_and(|m| m.len() > 0)
 }
 
 /// Run `lific restore`: validate the archive, then stage-extract it into the
 /// data dir at `db_path`. Refuses to clobber an existing DB unless `force`;
 /// with `force`, moves the existing DB + `-wal`/`-shm` aside. Refuses archives
-/// created by a newer Lific (higher schema_version than this binary).
+/// created by a newer Lific (higher `schema_version` than this binary).
 // The bounded-default entry point kept for callers with no options to express
 // (the tests, and anything embedding a restore); `lific restore` itself goes
 // through `run_restore_with` so it can pass `--allow-large`.
@@ -1474,8 +1470,7 @@ pub fn run_restore_with(
     let data_dir = db_path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("."));
+        .map_or_else(|| PathBuf::from("."), std::path::Path::to_path_buf);
     std::fs::create_dir_all(&data_dir)
         .map_err(|e| LificError::Internal(format!("create data dir: {e}")))?;
 
@@ -1849,7 +1844,7 @@ mod tests {
 
     /// Build a real on-disk DB with a seeded project, plus an attachments dir
     /// containing one real blob and one `.tmp` stray. Returns (dir guard,
-    /// db_path).
+    /// `db_path`).
     fn seed_data_dir(tag: &str) -> (TempDir, PathBuf) {
         let tmp = temp_dir(tag);
         let dir = tmp.path();
@@ -1915,7 +1910,10 @@ mod tests {
             crate::storage::AttachmentStore::hash_bytes(b"second blob bytes")
         )));
         assert!(
-            !entries.iter().any(|e| e.ends_with(".tmp")),
+            !entries.iter().any(|e| {
+                e.rsplit_once('.')
+                    .is_some_and(|(_, extension)| extension.eq_ignore_ascii_case("tmp"))
+            }),
             "in-progress .tmp writes must be excluded: {entries:?}"
         );
 
@@ -3075,7 +3073,7 @@ mod tests {
         );
         assert!(
             !root
-                .join(format!("{}.pre-restore-clash", ARCHIVE_DB_NAME))
+                .join(format!("{ARCHIVE_DB_NAME}.pre-restore-clash"))
                 .exists(),
             "nothing may be stranded under the pre-restore name"
         );
@@ -3091,7 +3089,7 @@ mod tests {
         let (dir_tmp, db_path, staging, _sha) = seed_install_fixture("install_db_clash");
         let root = dir_tmp.path();
         fs::write(
-            root.join(format!("{}.pre-restore-clash", ARCHIVE_DB_NAME)),
+            root.join(format!("{ARCHIVE_DB_NAME}.pre-restore-clash")),
             b"someone else's file",
         )
         .unwrap();
@@ -3110,7 +3108,7 @@ mod tests {
             .unwrap();
         assert_eq!(live, 1);
         assert_eq!(
-            fs::read(root.join(format!("{}.pre-restore-clash", ARCHIVE_DB_NAME))).unwrap(),
+            fs::read(root.join(format!("{ARCHIVE_DB_NAME}.pre-restore-clash"))).unwrap(),
             b"someone else's file",
             "an unrelated file at the backup path is never clobbered"
         );
@@ -3489,9 +3487,7 @@ mod tests {
         for entry in tar.entries().unwrap() {
             let mut entry = entry.unwrap();
             let name = entry.path().unwrap().to_string_lossy().to_string();
-            if name == ARCHIVE_MANIFEST_NAME {
-                continue;
-            }
+            if name == ARCHIVE_MANIFEST_NAME {}
             let mut buf = Vec::new();
             std::io::Read::read_to_end(&mut entry, &mut buf).unwrap();
             append_bytes(&mut builder, &name, &buf).unwrap();

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -285,9 +285,9 @@ impl TempFile {
             use std::os::unix::fs::OpenOptionsExt;
             options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
         }
-        let file = options
-            .open(&path)
-            .map_err(|error| LificError::Internal(format!("create secure staging file: {error}")))?;
+        let file = options.open(&path).map_err(|error| {
+            LificError::Internal(format!("create secure staging file: {error}"))
+        })?;
         Ok(Self { file, path })
     }
 
@@ -646,9 +646,10 @@ impl VerifiedBlob {
         let digest = hashing.hex_digest();
         // The header already promised `size` bytes; publishing an archive whose
         // body is shorter would leave every later entry misaligned.
-        let written = self.file.stream_position().map_err(|e| {
-            LificError::Internal(format!("measure attachment {expected_sha}: {e}"))
-        })?;
+        let written = self
+            .file
+            .stream_position()
+            .map_err(|e| LificError::Internal(format!("measure attachment {expected_sha}: {e}")))?;
         if written != size {
             return Err(LificError::Internal(format!(
                 "attachment {expected_sha} changed size while being archived \
@@ -1003,7 +1004,9 @@ fn validate_attachment_schema(conn: &rusqlite::Connection) -> Result<(), LificEr
     let invalid_mime_sha = "b".repeat(64);
     let invalid_size_sha = "c".repeat(64);
     insert(&valid_sha, "text/plain", 0).map_err(|e| {
-        LificError::BadRequest(format!("staged attachment schema rejects valid metadata: {e}"))
+        LificError::BadRequest(format!(
+            "staged attachment schema rejects valid metadata: {e}"
+        ))
     })?;
 
     for (sha256, mime, size_bytes) in [
@@ -1237,8 +1240,8 @@ fn validate_staged_database(
     for entry in std::fs::read_dir(&attachments_dir)
         .map_err(|e| LificError::BadRequest(format!("read staged attachments: {e}")))?
     {
-        let entry = entry
-            .map_err(|e| LificError::BadRequest(format!("read staged attachment: {e}")))?;
+        let entry =
+            entry.map_err(|e| LificError::BadRequest(format!("read staged attachment: {e}")))?;
         let path = entry.path();
         let metadata = std::fs::symlink_metadata(&path).map_err(|e| {
             LificError::BadRequest(format!("inspect staged attachment {}: {e}", path.display()))
@@ -1557,9 +1560,9 @@ pub fn run_restore_with(
                 )?;
                 set_owner_only(&path)
                     .map_err(|e| LificError::Internal(format!("chmod staged attachment: {e}")))?;
-                output.sync_all().map_err(|e| {
-                    LificError::Internal(format!("sync staged attachment: {e}"))
-                })?;
+                output
+                    .sync_all()
+                    .map_err(|e| LificError::Internal(format!("sync staged attachment: {e}")))?;
                 attachment_count += 1;
             } else {
                 return Err(LificError::BadRequest(format!(
@@ -1870,21 +1873,9 @@ mod tests {
         fs::create_dir_all(&att).unwrap();
         let first_sha = crate::storage::AttachmentStore::hash_bytes(b"blob one");
         let second_sha = crate::storage::AttachmentStore::hash_bytes(b"second blob bytes");
-        fs::write(
-            att.join(&first_sha),
-            b"blob one",
-        )
-        .unwrap();
-        fs::write(
-            att.join(&second_sha),
-            b"second blob bytes",
-        )
-        .unwrap();
-        fs::write(
-            att.join(format!("{second_sha}.tmp")),
-            b"partial write",
-        )
-        .unwrap();
+        fs::write(att.join(&first_sha), b"blob one").unwrap();
+        fs::write(att.join(&second_sha), b"second blob bytes").unwrap();
+        fs::write(att.join(format!("{second_sha}.tmp")), b"partial write").unwrap();
         (tmp, db_path)
     }
 
@@ -1995,7 +1986,10 @@ mod tests {
         let out = dir.join("out.tar.gz");
         write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap();
         assert!(out.exists());
-        assert!(!has_dump_staging(dir), "staging is removed on the happy path");
+        assert!(
+            !has_dump_staging(dir),
+            "staging is removed on the happy path"
+        );
     }
 
     #[cfg(unix)]
@@ -2011,12 +2005,14 @@ mod tests {
         fs::hard_link(&outside, dir.join("attachments").join("c".repeat(64))).unwrap();
 
         let out = dir.join("late.tar.gz");
-        let error =
-            write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap_err();
+        let error = write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap_err();
 
         assert!(error.to_string().contains("hard-linked"), "got {error}");
         assert!(!out.exists(), "a failed dump publishes nothing");
-        assert!(!has_dump_staging(dir), "staging must not survive the failure");
+        assert!(
+            !has_dump_staging(dir),
+            "staging must not survive the failure"
+        );
     }
 
     #[cfg(unix)]
@@ -2124,8 +2120,7 @@ mod tests {
         fs::remove_file(&entry).unwrap();
         fs::hard_link(&outside, &entry).unwrap();
         let out = dir.join("hardlink.tar.gz");
-        let error =
-            write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap_err();
+        let error = write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out).unwrap_err();
         assert!(error.to_string().contains("hard-linked"), "got {error}");
     }
 
@@ -2156,8 +2151,7 @@ mod tests {
         // restore, bytes intact.
         let (src_tmp, src_db) = seed_data_dir("hash_round_trip");
         let archive = src_tmp.path().join("backup.tar.gz");
-        let manifest =
-            write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
+        let manifest = write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
         assert_eq!(manifest.attachment_count, 2);
 
         let dst = temp_dir("hash_round_trip_dst");
@@ -2199,8 +2193,7 @@ mod tests {
             let db_path = db_path.clone();
             let out = out.clone();
             move || {
-                let result =
-                    write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out);
+                let result = write_dump(&crate::db::open(&db_path).unwrap(), &db_path, &out);
                 done_tx.send(()).unwrap();
                 result
             }
@@ -2394,9 +2387,11 @@ mod tests {
 
         // Blob bytes identical.
         assert_eq!(
-            fs::read(dst_dir.join("attachments").join(
-                crate::storage::AttachmentStore::hash_bytes(b"blob one"),
-            ))
+            fs::read(
+                dst_dir
+                    .join("attachments")
+                    .join(crate::storage::AttachmentStore::hash_bytes(b"blob one"),)
+            )
             .unwrap(),
             b"blob one"
         );
@@ -3057,7 +3052,9 @@ mod tests {
 
         assert!(matches!(error, LificError::Conflict(_)), "got {error:?}");
         assert!(
-            error.to_string().contains("attachment backup already exists"),
+            error
+                .to_string()
+                .contains("attachment backup already exists"),
             "the original cause must survive the rollback: {error}"
         );
         assert!(
@@ -3072,9 +3069,14 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(live, 1, "and it must be the user's database, not the dump's");
+        assert_eq!(
+            live, 1,
+            "and it must be the user's database, not the dump's"
+        );
         assert!(
-            !root.join(format!("{}.pre-restore-clash", ARCHIVE_DB_NAME)).exists(),
+            !root
+                .join(format!("{}.pre-restore-clash", ARCHIVE_DB_NAME))
+                .exists(),
             "nothing may be stranded under the pre-restore name"
         );
         assert_eq!(
@@ -3172,15 +3174,17 @@ mod tests {
         // exceeds.
         let (src_dir_tmp, src_db) = seed_data_dir("allow_large_src");
         let archive = src_dir_tmp.path().join("backup.tar.gz");
-        let manifest =
-            write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
+        let manifest = write_dump(&crate::db::open(&src_db).unwrap(), &src_db, &archive).unwrap();
         let tight = RestoreLimits {
             max_db_bytes: manifest.db_size_bytes - 1,
             ..RestoreLimits::default()
         };
 
         let error = inspect_archive(&archive, &tight).unwrap_err();
-        assert!(error.to_string().contains("exceeds restore limit"), "got {error}");
+        assert!(
+            error.to_string().contains("exceeds restore limit"),
+            "got {error}"
+        );
         inspect_archive(&archive, &RestoreLimits::trusted())
             .expect("--allow-large accepts a trusted oversized archive");
 
@@ -3283,7 +3287,8 @@ mod tests {
             attachment_bytes: 4,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("content address"));
     }
 
@@ -3319,7 +3324,8 @@ mod tests {
             attachment_bytes: 4,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("MIME image/png"));
     }
 
@@ -3357,10 +3363,13 @@ mod tests {
             attachment_bytes: 4,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("invalid content address, MIME, or size"));
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("invalid content address, MIME, or size")
+        );
     }
 
     #[test]
@@ -3385,7 +3394,8 @@ mod tests {
             attachment_bytes: 4,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("content address"));
     }
 
@@ -3416,7 +3426,8 @@ mod tests {
             attachment_bytes: 0,
         };
 
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("attachments table"));
     }
 
@@ -3450,7 +3461,8 @@ mod tests {
             attachment_count: 1,
             attachment_bytes: 4,
         };
-        let error = validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
+        let error =
+            validate_staged_database(&staging, &manifest, &RestoreLimits::default()).unwrap_err();
         assert!(error.to_string().contains("missing attachment"));
     }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -47,8 +47,7 @@ const MAX_EXPORT_JSON_BYTES: usize = MAX_EXPORT_TOTAL_BYTES * 6 + 64 * 1024;
 fn ensure_text_size(label: &str, value: &str) -> Result<(), LificError> {
     if value.len() > MAX_EXPORT_FILE_BYTES {
         return Err(LificError::BadRequest(format!(
-            "{label} exceeds the {} byte limit",
-            MAX_EXPORT_FILE_BYTES
+            "{label} exceeds the {MAX_EXPORT_FILE_BYTES} byte limit"
         )));
     }
     Ok(())
@@ -66,14 +65,12 @@ fn ensure_comment_sizes(conn: &Connection, issue_id: i64) -> Result<(), LificErr
     )?;
     if too_large != 0 {
         return Err(LificError::BadRequest(format!(
-            "an issue comment exceeds the {} byte export limit",
-            MAX_EXPORT_FILE_BYTES
+            "an issue comment exceeds the {MAX_EXPORT_FILE_BYTES} byte export limit"
         )));
     }
     if total_bytes > MAX_EXPORT_FILE_BYTES as i64 {
         return Err(LificError::BadRequest(format!(
-            "issue comments exceed the {} byte aggregate export limit",
-            MAX_EXPORT_FILE_BYTES
+            "issue comments exceed the {MAX_EXPORT_FILE_BYTES} byte aggregate export limit"
         )));
     }
     Ok(())
@@ -183,8 +180,7 @@ fn ensure_metadata_size(items: i64, bytes: i64) -> Result<(), LificError> {
     }
     if bytes > MAX_EXPORT_TOTAL_BYTES as i64 {
         return Err(LificError::BadRequest(format!(
-            "export metadata exceeds the {} byte total limit",
-            MAX_EXPORT_TOTAL_BYTES
+            "export metadata exceeds the {MAX_EXPORT_TOTAL_BYTES} byte total limit"
         )));
     }
     Ok(())
@@ -250,8 +246,7 @@ impl ExportBudget {
             .ok_or_else(|| LificError::BadRequest("export size overflow".into()))?;
         if self.bytes > MAX_EXPORT_TOTAL_BYTES {
             return Err(LificError::BadRequest(format!(
-                "export exceeds the {} byte total limit",
-                MAX_EXPORT_TOTAL_BYTES
+                "export exceeds the {MAX_EXPORT_TOTAL_BYTES} byte total limit"
             )));
         }
         Ok(())
@@ -481,8 +476,7 @@ fn ensure_project_preflight(
     }
     if comment_count > max_comments {
         return Err(LificError::BadRequest(format!(
-            "project export contains too many comments ({} > {})",
-            comment_count, max_comments
+            "project export contains too many comments ({comment_count} > {max_comments})"
         )));
     }
     ensure_metadata_size(metadata_items, metadata_bytes)?;
@@ -494,8 +488,7 @@ fn ensure_project_preflight(
         .ok_or_else(|| LificError::BadRequest("export size overflow".into()))?;
     if source_bytes > max_total_bytes {
         return Err(LificError::BadRequest(format!(
-            "project source exceeds the {} byte total export limit",
-            max_total_bytes
+            "project source exceeds the {max_total_bytes} byte total export limit"
         )));
     }
     let oversized: i64 = conn.query_row(

--- a/src/export.rs
+++ b/src/export.rs
@@ -1100,14 +1100,18 @@ mod tests {
         let bundle = export_project(&conn, "EXP").unwrap();
         assert_eq!(bundle.root, "EXP");
         assert_eq!(bundle.files.len(), 2);
-        assert!(bundle
-            .files
-            .iter()
-            .any(|file| file.path.starts_with("EXP/issues/exp-1-ship-export")));
-        assert!(bundle
-            .files
-            .iter()
-            .any(|file| file.path == "EXP/pages/docs/guides/exp-doc-1-getting-started.md"));
+        assert!(
+            bundle
+                .files
+                .iter()
+                .any(|file| file.path.starts_with("EXP/issues/exp-1-ship-export"))
+        );
+        assert!(
+            bundle
+                .files
+                .iter()
+                .any(|file| file.path == "EXP/pages/docs/guides/exp-doc-1-getting-started.md")
+        );
         let issue_file = bundle
             .files
             .iter()
@@ -1477,9 +1481,8 @@ mod tests {
             .unwrap();
         }
 
-        let error =
-            ensure_project_preflight(&conn, project.id, 32, MAX_EXPORT_PROJECT_COMMENTS)
-                .unwrap_err();
+        let error = ensure_project_preflight(&conn, project.id, 32, MAX_EXPORT_PROJECT_COMMENTS)
+            .unwrap_err();
         assert!(error.to_string().contains("project source exceeds"));
     }
 
@@ -1536,13 +1539,8 @@ mod tests {
             }
         }
 
-        let error = ensure_project_preflight(
-            &conn,
-            project.id,
-            MAX_EXPORT_TOTAL_BYTES as i64,
-            501,
-        )
-        .unwrap_err();
+        let error = ensure_project_preflight(&conn, project.id, MAX_EXPORT_TOTAL_BYTES as i64, 501)
+            .unwrap_err();
         assert!(error.to_string().contains("too many comments"));
     }
 

--- a/src/import/github.rs
+++ b/src/import/github.rs
@@ -230,8 +230,7 @@ pub fn map_issue(
             author: c
                 .user
                 .as_ref()
-                .map(|u| u.login.clone())
-                .unwrap_or_else(|| "ghost".to_string()),
+                .map_or_else(|| "ghost".to_string(), |u| u.login.clone()),
             created_at: c.created_at.clone(),
             body: c.body.clone().unwrap_or_default(),
         })
@@ -500,7 +499,7 @@ impl GithubFetcher for LiveGithub {
             .headers()
             .get("link")
             .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
         let issues: Vec<GithubIssue> = Self::json_bounded(resp, "issues")?;
         if issues.len() > 100 {
             return Err(GithubImportError::Limit(GithubLimit::PageItems {
@@ -524,7 +523,7 @@ impl GithubFetcher for LiveGithub {
                 .headers()
                 .get("link")
                 .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string());
+                .map(std::string::ToString::to_string);
             let batch: Vec<GithubComment> = Self::json_bounded(resp, "comments")?;
             if batch.len() > 100 {
                 return Err(GithubImportError::Limit(GithubLimit::PageItems {

--- a/src/import/github.rs
+++ b/src/import/github.rs
@@ -791,7 +791,11 @@ mod tests {
         ));
 
         let error = collect_with(&fetcher).unwrap_err();
-        assert_eq!(error.limit(), None, "a network drop is not a resource limit");
+        assert_eq!(
+            error.limit(),
+            None,
+            "a network drop is not a resource limit"
+        );
         assert!(matches!(error, GithubImportError::Upstream(_)));
     }
 

--- a/src/import/jira.rs
+++ b/src/import/jira.rs
@@ -70,7 +70,7 @@ fn render_block(node: &serde_json::Value, out: &mut String) {
             let level = node
                 .get("attrs")
                 .and_then(|a| a.get("level"))
-                .and_then(|l| l.as_u64())
+                .and_then(serde_json::Value::as_u64)
                 .unwrap_or(1)
                 .clamp(1, 6) as usize;
             out.push_str(&"#".repeat(level));
@@ -178,8 +178,10 @@ fn render_inline_node(node: &serde_json::Value, out: &mut String) {
                 .get("attrs")
                 .and_then(|a| a.get("text"))
                 .and_then(|t| t.as_str())
-                .map(|s| s.trim_start_matches('@').to_string())
-                .unwrap_or_else(|| "someone".to_string());
+                .map_or_else(
+                    || "someone".to_string(),
+                    |s| s.trim_start_matches('@').to_string(),
+                );
             out.push('@');
             out.push_str(&name);
         }
@@ -225,7 +227,7 @@ fn apply_marks(text: &str, node: &serde_json::Value) -> String {
                     .get("attrs")
                     .and_then(|a| a.get("href"))
                     .and_then(|h| h.as_str())
-                    .map(|s| s.to_string());
+                    .map(std::string::ToString::to_string);
             }
             // Unknown mark: leave text unwrapped.
             _ => {}
@@ -373,8 +375,7 @@ pub fn map_issue(
         .status
         .as_ref()
         .and_then(|s| s.status_category.as_ref())
-        .map(|c| map_status(&c.key, map))
-        .unwrap_or(map.new);
+        .map_or(map.new, |c| map_status(&c.key, map));
 
     let priority = issue
         .fields

--- a/src/import/jira.rs
+++ b/src/import/jira.rs
@@ -421,8 +421,10 @@ pub fn map_issue(
 pub trait JiraFetcher {
     /// Fetch one page of issues. `next_token` is the opaque page token (`None`
     /// for the first page). Returns `(issues, next_token)`.
-    fn fetch_page(&self, next_token: Option<&str>)
-    -> Result<(Vec<JiraIssue>, Option<String>), String>;
+    fn fetch_page(
+        &self,
+        next_token: Option<&str>,
+    ) -> Result<(Vec<JiraIssue>, Option<String>), String>;
 
     /// Fetch all comments for one issue key.
     fn fetch_comments(&self, key: &str) -> Result<Vec<JiraComment>, String>;
@@ -553,7 +555,10 @@ impl JiraFetcher for LiveJira {
             .query(&[
                 ("jql", jql.as_str()),
                 ("maxResults", "50"),
-                ("fields", "summary,description,status,priority,labels,assignee,issuetype"),
+                (
+                    "fields",
+                    "summary,description,status,priority,labels,assignee,issuetype",
+                ),
             ]);
         if let Some(t) = next_token {
             req = req.query(&[("nextPageToken", t)]);

--- a/src/import/linear.rs
+++ b/src/import/linear.rs
@@ -184,11 +184,12 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
     }
 }
 
-/// Abstraction over Linear's GraphQL endpoint for testability. Returns one page
-/// of issues plus the next cursor (`None` when exhausted).
+/// One page of Linear issues plus the next cursor (`None` when exhausted).
+pub type LinearPage = (Vec<LinearIssue>, Option<String>);
+
+/// Abstraction over Linear's GraphQL endpoint for testability.
 pub trait LinearFetcher {
-    fn fetch_page(&self, after: Option<&str>)
-    -> Result<(Vec<LinearIssue>, Option<String>), String>;
+    fn fetch_page(&self, after: Option<&str>) -> Result<LinearPage, String>;
 }
 
 /// Walk all cursor pages and normalize. Assignee/estimate are counted as
@@ -304,10 +305,7 @@ impl LiveLinear {
 }
 
 impl LinearFetcher for LiveLinear {
-    fn fetch_page(
-        &self,
-        after: Option<&str>,
-    ) -> Result<(Vec<LinearIssue>, Option<String>), String> {
+    fn fetch_page(&self, after: Option<&str>) -> Result<LinearPage, String> {
         let body = serde_json::json!({
             "query": ISSUES_QUERY,
             "variables": { "team": self.team, "after": after },
@@ -416,13 +414,10 @@ mod tests {
     }
 
     struct FakeLinear {
-        pages: Vec<(Vec<LinearIssue>, Option<String>)>,
+        pages: Vec<LinearPage>,
     }
     impl LinearFetcher for FakeLinear {
-        fn fetch_page(
-            &self,
-            after: Option<&str>,
-        ) -> Result<(Vec<LinearIssue>, Option<String>), String> {
+        fn fetch_page(&self, after: Option<&str>) -> Result<LinearPage, String> {
             // Page 0 has after=None; subsequent pages keyed by cursor value.
             let idx = match after {
                 None => 0,

--- a/src/import/linear.rs
+++ b/src/import/linear.rs
@@ -163,7 +163,11 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
         .nodes
         .iter()
         .map(|c| NormalizedComment {
-            author: c.user.as_ref().map(|u| u.handle()).unwrap_or_else(|| "unknown".into()),
+            author: c
+                .user
+                .as_ref()
+                .map(|u| u.handle())
+                .unwrap_or_else(|| "unknown".into()),
             created_at: c.created_at.clone(),
             body: c.body.clone().unwrap_or_default(),
         })
@@ -183,7 +187,8 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
 /// Abstraction over Linear's GraphQL endpoint for testability. Returns one page
 /// of issues plus the next cursor (`None` when exhausted).
 pub trait LinearFetcher {
-    fn fetch_page(&self, after: Option<&str>) -> Result<(Vec<LinearIssue>, Option<String>), String>;
+    fn fetch_page(&self, after: Option<&str>)
+    -> Result<(Vec<LinearIssue>, Option<String>), String>;
 }
 
 /// Walk all cursor pages and normalize. Assignee/estimate are counted as
@@ -299,7 +304,10 @@ impl LiveLinear {
 }
 
 impl LinearFetcher for LiveLinear {
-    fn fetch_page(&self, after: Option<&str>) -> Result<(Vec<LinearIssue>, Option<String>), String> {
+    fn fetch_page(
+        &self,
+        after: Option<&str>,
+    ) -> Result<(Vec<LinearIssue>, Option<String>), String> {
         let body = serde_json::json!({
             "query": ISSUES_QUERY,
             "variables": { "team": self.team, "after": after },
@@ -429,10 +437,7 @@ mod tests {
         let issues = fixture();
         let (a, b) = issues.split_at(1);
         let fetcher = FakeLinear {
-            pages: vec![
-                (a.to_vec(), Some("1".into())),
-                (b.to_vec(), None),
-            ],
+            pages: vec![(a.to_vec(), Some("1".into())), (b.to_vec(), None)],
         };
         let fetched = collect(&fetcher, &LinearStatusMap::default()).unwrap();
         assert_eq!(fetched.issues.len(), issues.len());

--- a/src/import/linear.rs
+++ b/src/import/linear.rs
@@ -145,8 +145,7 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
     let status = issue
         .state
         .as_ref()
-        .map(|s| map_state_type(&s.type_, map))
-        .unwrap_or(map.backlog);
+        .map_or(map.backlog, |s| map_state_type(&s.type_, map));
 
     let labels = issue
         .labels
@@ -166,8 +165,7 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
             author: c
                 .user
                 .as_ref()
-                .map(|u| u.handle())
-                .unwrap_or_else(|| "unknown".into()),
+                .map_or_else(|| "unknown".into(), LinearUser::handle),
             created_at: c.created_at.clone(),
             body: c.body.clone().unwrap_or_default(),
         })
@@ -226,7 +224,7 @@ pub fn collect(
 
 /// The GraphQL query used by the live fetcher. `first: 50` batches with nested
 /// label/comment connections to stay well under the ~1500 req/hr budget.
-pub const ISSUES_QUERY: &str = r#"
+pub const ISSUES_QUERY: &str = r"
 query Issues($team: String!, $after: String) {
   issues(
     first: 50
@@ -247,7 +245,7 @@ query Issues($team: String!, $after: String) {
     }
   }
 }
-"#;
+";
 
 /// Live GraphQL fetcher over the blocking reqwest client.
 pub struct LiveLinear {

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -219,7 +219,7 @@ pub fn ensure_label(
 
 /// The write side: import one normalized issue into `project_id`, attributing
 /// comments to `bot_id` (when present). Idempotent — returns `Skipped` if the
-/// source marker already exists. Non-dry-run only; callers gate on dry_run.
+/// source marker already exists. Non-dry-run only; callers gate on `dry_run`.
 pub enum ApplyOutcome {
     /// Newly created; carries how many comments/labels were created.
     Created {
@@ -290,7 +290,7 @@ pub fn apply_issue(
 }
 
 /// Build the full summary for a set of fetched issues, either applying them
-/// (dry_run = false) or just counting (dry_run = true). Shared by CLI + web so
+/// (`dry_run` = false) or just counting (`dry_run` = true). Shared by CLI + web so
 /// a preview and a real run report the same shape.
 pub fn run_import(
     pool: &DbPool,

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -205,10 +205,7 @@ pub fn ensure_label(
     if queries::resolve_label_name(conn, project_id, &label.name).is_ok() {
         return Ok(false);
     }
-    let color = label
-        .color
-        .clone()
-        .unwrap_or_else(|| "#6B7280".to_string());
+    let color = label.color.clone().unwrap_or_else(|| "#6B7280".to_string());
     queries::create_label(
         conn,
         &CreateLabel {
@@ -315,7 +312,8 @@ pub fn run_import(
         // once across the whole batch even if several issues carry it and it
         // doesn't already exist.
         let conn = pool.read()?;
-        let mut planned_labels: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut planned_labels: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         for issue in &fetched.issues {
             if source_exists(&conn, &issue.source)? {
                 summary.issues_skipped_existing += 1;

--- a/src/links.rs
+++ b/src/links.rs
@@ -157,15 +157,14 @@ impl IssueLinkContext {
         host_header: Option<&str>,
         allowed_hosts: &[String],
     ) -> Option<Self> {
-        match public_url {
-            Some(public_url) => Self::parse(public_url),
-            None => {
-                let authority = parse_http_authority(host_header?)?;
-                if !authority_is_allowlisted(&authority, allowed_hosts) {
-                    return None;
-                }
-                Self::parse(&format!("http://{authority}"))
+        if let Some(public_url) = public_url {
+            Self::parse(public_url)
+        } else {
+            let authority = parse_http_authority(host_header?)?;
+            if !authority_is_allowlisted(&authority, allowed_hosts) {
+                return None;
             }
+            Self::parse(&format!("http://{authority}"))
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,10 +73,13 @@ fn write_private_config(path: &std::path::Path, contents: &str) -> std::io::Resu
 /// `sync_all` persists its bytes; the name that reaches them lives in the
 /// parent directory and survives a crash only once that is synced too.
 /// Unix only: Windows exposes no directory handle to sync.
-fn sync_parent_dir(_dir: &std::path::Path) -> std::io::Result<()> {
+fn sync_parent_dir(dir: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(not(unix))]
+    let _ = dir;
+
     #[cfg(unix)]
     {
-        std::fs::File::open(_dir)?.sync_all()?;
+        std::fs::File::open(dir)?.sync_all()?;
     }
     Ok(())
 }
@@ -107,6 +110,7 @@ use rmcp::ServiceExt;
 use tracing::info;
 
 #[tokio::main]
+#[allow(clippy::too_many_lines)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
@@ -584,17 +588,15 @@ fn local_url(cfg: &Config) -> String {
 fn http_backend_url(cli_url: Option<&str>, public_url: Option<&str>, cfg: &Config) -> String {
     cli_url
         .or(public_url)
-        .map(str::to_owned)
-        .unwrap_or_else(|| local_url(cfg))
+        .map_or_else(|| local_url(cfg), str::to_owned)
 }
 /// Poll `<base>/api/health` until it answers 200 or the deadline passes.
 async fn wait_healthy(base_url: &str, timeout: std::time::Duration) -> bool {
-    let client = match reqwest::Client::builder()
+    let Ok(client) = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
         .build()
-    {
-        Ok(c) => c,
-        Err(_) => return false,
+    else {
+        return false;
     };
     let url = format!("{base_url}/api/health");
     let deadline = std::time::Instant::now() + timeout;
@@ -661,9 +663,7 @@ fn load_config_for_init(
 /// explicit `--auth-mode` flag (non-interactive); otherwise, on a TTY, shows
 /// the interactive menu. Refuses (rather than hangs) off a TTY, matching
 /// `prompt_text`/`confirm`, and names the bypass flag.
-fn resolve_auth_mode(
-    flag: &Option<String>,
-) -> Result<config::AuthMode, Box<dyn std::error::Error>> {
+fn resolve_auth_mode(flag: Option<&str>) -> Result<config::AuthMode, Box<dyn std::error::Error>> {
     if let Some(value) = flag {
         return config::AuthMode::parse(value).ok_or_else(|| {
             format!("invalid --auth-mode '{value}': expected login-free or passwords").into()
@@ -723,6 +723,7 @@ fn prompt_password_for_auth_mode() -> Result<String, Box<dyn std::error::Error>>
 // clap can't express the --config conflict, and init threads many small flags;
 // the repo tolerates this for command handlers (see cli/import.rs).
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
 async fn cmd_init(
     config_flag: Option<&std::path::Path>,
     db_flag: Option<&std::path::Path>,
@@ -806,8 +807,10 @@ async fn cmd_init(
     // interactive TTY menu), persist the choice to the config file + database,
     // and create the first admin in that mode. An existing instance with users
     // skips all of this entirely.
-    let created_admin = if !auth::has_human_operator(&pool) {
-        let mode = resolve_auth_mode(&auth_mode_flag)?;
+    let created_admin = if auth::has_human_operator(&pool) {
+        None
+    } else {
+        let mode = resolve_auth_mode(auth_mode_flag.as_deref())?;
 
         // Persist the choice into the config file, editing it in place (the
         // change set `[auth] required` and `[server] host`; every other section
@@ -847,8 +850,6 @@ async fn cmd_init(
         };
         info!(operator = %admin.username, mode = mode.as_str(), "created first human admin");
         Some(admin)
-    } else {
-        None
     };
 
     // Mint the initial API key HERE, in the operator's terminal. Once the
@@ -883,7 +884,7 @@ async fn cmd_init(
                         // port while our unit crash-loops on AddrInUse), and
                         // silence alone is ambiguous. Cross-check the unit's
                         // own active state to say something precise.
-                        let active = cli::service::status(mgr).map(|s| s.active).unwrap_or(false);
+                        let active = cli::service::status(mgr).is_ok_and(|s| s.active);
                         match (healthy, active) {
                             (true, true) => {}
                             (true, false) => {
@@ -920,7 +921,7 @@ async fn cmd_init(
                     "no supported service manager found (needs a systemd user session on \
                      Linux, or launchd on macOS)"
                         .to_string(),
-                )
+                );
             }
         }
     }
@@ -1020,16 +1021,15 @@ async fn cmd_init(
 
     let mut outro_msg = format!("Verify anytime with {}", ui::command("lific doctor"));
     if service_report.is_some() {
-        outro_msg.push_str(&format!(
-            " · manage the service with {}",
-            ui::command("lific service status|restart|stop|uninstall")
-        ));
+        outro_msg.push_str(" · manage the service with ");
+        outro_msg.push_str(&ui::command("lific service status|restart|stop|uninstall"));
     }
     ui::outro(outro_msg);
     Ok(())
 }
 
 /// `lific service <action>`: manage the background service `init` installs.
+#[allow(clippy::too_many_lines)]
 fn cmd_service(
     cfg: &Config,
     config_flag: Option<&std::path::Path>,
@@ -1164,18 +1164,18 @@ mod init_target_tests {
     use crate::db;
     use std::path::{Path, PathBuf};
 
-    fn os_default() -> Option<(PathBuf, PathBuf)> {
-        Some((
+    fn os_default() -> (PathBuf, PathBuf) {
+        (
             PathBuf::from("/home/u/.config/lific/lific.toml"),
             PathBuf::from("/home/u/.local/share/lific/lific.db"),
-        ))
+        )
     }
 
     // LIF-295: bare init targets the OS dirs, with an explicit db path so the
     // generated config can split config dir from data dir.
     #[test]
     fn bare_init_targets_os_dirs() {
-        let (config, db) = resolve_init_target(None, false, false, os_default());
+        let (config, db) = resolve_init_target(None, false, false, Some(os_default()));
         assert_eq!(config, Path::new("/home/u/.config/lific/lific.toml"));
         assert_eq!(
             db.as_deref(),
@@ -1185,7 +1185,7 @@ mod init_target_tests {
 
     #[test]
     fn here_flag_forces_cwd_layout() {
-        let (config, db) = resolve_init_target(None, true, false, os_default());
+        let (config, db) = resolve_init_target(None, true, false, Some(os_default()));
         assert_eq!(config, Path::new("lific.toml"));
         assert_eq!(db, None, "cwd layout keeps the relative default db");
     }
@@ -1194,7 +1194,7 @@ mod init_target_tests {
     // a second instance in the OS dirs.
     #[test]
     fn existing_cwd_config_wins_over_os_dirs() {
-        let (config, db) = resolve_init_target(None, false, true, os_default());
+        let (config, db) = resolve_init_target(None, false, true, Some(os_default()));
         assert_eq!(config, Path::new("lific.toml"));
         assert_eq!(db, None);
     }
@@ -1205,7 +1205,7 @@ mod init_target_tests {
             Some(Path::new("/srv/lific/lific.toml")),
             false,
             true,
-            os_default(),
+            Some(os_default()),
         );
         assert_eq!(config, Path::new("/srv/lific/lific.toml"));
         assert_eq!(db, None);
@@ -1248,7 +1248,7 @@ mod init_target_tests {
 
     /// Run `lific init --config <dir>/lific.toml --no-service` for the operator
     /// `name` and assert on the DB state it wrote (stdout isn't a TTY under the
-    /// test harness, so we can't capture cmd_init's printed JSON — instead we
+    /// test harness, so we can't capture `cmd_init`'s printed JSON — instead we
     /// re-open the database and read back the shared facts).
     async fn run_init(
         dir: &TempDir,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -25,8 +25,8 @@ use crate::storage::AttachmentStore;
 static MCP_HANDLER_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Per-request user identity storage.
-/// Protected from races by MCP_HANDLER_LOCK ensuring serial access.
-/// Uses unwrap_or_else to recover from poison (e.g. if a handler panics).
+/// Protected from races by `MCP_HANDLER_LOCK` ensuring serial access.
+/// Uses `unwrap_or_else` to recover from poison (e.g. if a handler panics).
 static MCP_REQUEST_USER: Mutex<Option<AuthUser>> = Mutex::new(None);
 
 /// Per-request external origin used for structured resource links.
@@ -81,10 +81,10 @@ where
     };
     *MCP_REQUEST_USER
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = user;
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = user;
     *MCP_REQUEST_ISSUE_LINKS
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = issue_links;
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = issue_links;
     // Panic-safe cleanup: clear the globals on scope exit (including if `f`
     // panics), before `_guard` releases MCP_HANDLER_LOCK (reverse declaration
     // order). Without this, a panicking request would leave a stale user in the
@@ -107,10 +107,10 @@ impl Drop for RequestGlobalGuard {
     fn drop(&mut self) {
         *MCP_REQUEST_USER
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
         *MCP_REQUEST_ISSUE_LINKS
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
     }
 }
 
@@ -118,7 +118,7 @@ impl Drop for RequestGlobalGuard {
 pub(crate) fn current_auth_user() -> Option<AuthUser> {
     MCP_REQUEST_USER
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone()
 }
 
@@ -204,7 +204,7 @@ pub(crate) fn current_issue_link_context() -> Option<Arc<IssueLinkContext>> {
     #[cfg(not(test))]
     MCP_REQUEST_ISSUE_LINKS
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone()
 }
 
@@ -672,7 +672,7 @@ mod tests {
                 .to_string();
             let global = MCP_REQUEST_ISSUE_LINKS
                 .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone()
                 .expect("production request context should also be populated")
                 .issue_markdown("LIF-1")
@@ -690,7 +690,7 @@ mod tests {
         assert!(
             MCP_REQUEST_ISSUE_LINKS
                 .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .is_none()
         );
     }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -535,9 +535,9 @@ mod tests {
         use crate::error::LificError;
 
         assert_eq!(
-            sanitize_error(LificError::Database(
-                rusqlite::Error::InvalidColumnName("secret_column".into())
-            )),
+            sanitize_error(LificError::Database(rusqlite::Error::InvalidColumnName(
+                "secret_column".into()
+            ))),
             "internal server error"
         );
         assert_eq!(
@@ -555,7 +555,9 @@ mod tests {
                 "Bad request: invalid status 'nope'",
             ),
             (
-                LificError::Forbidden("requires at least 'maintainer' access to this project".into()),
+                LificError::Forbidden(
+                    "requires at least 'maintainer' access to this project".into(),
+                ),
                 "Forbidden: requires at least 'maintainer' access to this project",
             ),
             (

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -204,9 +204,7 @@ pub struct CreatePageInput {
     pub folder: Option<String>,
     #[schemars(description = "Status: draft, active, complete, archived")]
     pub status: Option<String>,
-    #[schemars(
-        description = "Label names to attach (project-scoped; ignored on workspace pages)"
-    )]
+    #[schemars(description = "Label names to attach (project-scoped; ignored on workspace pages)")]
     pub labels: Option<Vec<String>>,
 }
 
@@ -274,9 +272,13 @@ pub struct DeleteInput {
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ListResourcesInput {
-    #[schemars(description = "Resource type: project, module, label, folder, page, issue, or plan")]
+    #[schemars(
+        description = "Resource type: project, module, label, folder, page, issue, or plan"
+    )]
     pub resource_type: String,
-    #[schemars(description = "Project ID (required for issues, plans, modules, labels, and folders; optional for pages and projects)")]
+    #[schemars(
+        description = "Project ID (required for issues, plans, modules, labels, and folders; optional for pages and projects)"
+    )]
     pub project: Option<String>,
     #[schemars(description = "Folder name (for pages)")]
     pub folder: Option<String>,
@@ -292,7 +294,9 @@ pub struct ListResourcesInput {
     pub order_by: Option<String>,
     #[schemars(description = "Sort direction (for page lists): asc (default) or desc")]
     pub order: Option<String>,
-    #[schemars(description = "Max results (plans default to 50 and cap at 500; issues and pages default to 100; other lists ignore this field)")]
+    #[schemars(
+        description = "Max results (plans default to 50 and cap at 500; issues and pages default to 100; other lists ignore this field)"
+    )]
     pub limit: Option<i64>,
     #[schemars(description = "Zero-indexed offset for issue, page, or plan paging")]
     pub offset: Option<i64>,
@@ -332,7 +336,9 @@ pub struct ManageResourceInput {
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct AddCommentInput {
-    #[schemars(description = "Issue ID (e.g. LIF-1), project page ID (e.g. LIF-DOC-1), or workspace page ID (e.g. DOC-1)")]
+    #[schemars(
+        description = "Issue ID (e.g. LIF-1), project page ID (e.g. LIF-DOC-1), or workspace page ID (e.g. DOC-1)"
+    )]
     pub identifier: String,
     #[schemars(description = "Comment content (markdown)")]
     pub content: String,
@@ -340,7 +346,9 @@ pub struct AddCommentInput {
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ListCommentsInput {
-    #[schemars(description = "Issue ID (e.g. LIF-1), project page ID (e.g. LIF-DOC-1), or workspace page ID (e.g. DOC-1)")]
+    #[schemars(
+        description = "Issue ID (e.g. LIF-1), project page ID (e.g. LIF-DOC-1), or workspace page ID (e.g. DOC-1)"
+    )]
     pub identifier: String,
     #[schemars(description = "Filter to comments by this author username")]
     pub author: Option<String>,
@@ -462,7 +470,9 @@ pub struct UpdatePlanStepInput {
     pub move_position: Option<i64>,
     #[schemars(description = "Delete the step and its subtree")]
     pub delete: Option<bool>,
-    #[schemars(description = "Return the full re-rendered tree instead of the delta (default false)")]
+    #[schemars(
+        description = "Return the full re-rendered tree instead of the delta (default false)"
+    )]
     pub echo_tree: Option<bool>,
 }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -10,12 +10,12 @@ use rmcp::{handler::server::wrapper::Parameters, tool, tool_router};
 
 use crate::{
     authz::filter_visible,
-    db::{models, queries, DbPool},
+    db::{DbPool, models, queries},
     links::{IssueLinkContext, MarkdownReference},
 };
 
 use super::schemas::*;
-use super::{current_issue_link_context, sanitize_error, LificMcp};
+use super::{LificMcp, current_issue_link_context, sanitize_error};
 
 /// Self-onboarding nudge (LIF-257): shown by cold read tools when the DB has
 /// **zero** projects, so the first agent connecting to a fresh install learns
@@ -3235,7 +3235,11 @@ impl LificMcp {
                 let lead_user_id = super::current_auth_user().and_then(|u| {
                     self.read(|conn| {
                         Ok(conn
-                            .query_row("SELECT 1 FROM users WHERE id = ?1", rusqlite::params![u.id], |_| Ok(()))
+                            .query_row(
+                                "SELECT 1 FROM users WHERE id = ?1",
+                                rusqlite::params![u.id],
+                                |_| Ok(()),
+                            )
                             .is_ok())
                     })
                     .ok()
@@ -7503,7 +7507,9 @@ mod tests {
         // 1 and 2 fell off the front, 3 leads, and the newest closes it.
         assert!(!result.contains("comment number 1\n"), "got: {result}");
         assert!(!result.contains("comment number 2\n"), "got: {result}");
-        let first = result.find("comment number 3\n").expect("oldest of the window");
+        let first = result
+            .find("comment number 3\n")
+            .expect("oldest of the window");
         let last = result
             .find(&format!("comment number {total}\n"))
             .expect("newest comment");
@@ -7558,7 +7564,10 @@ mod tests {
             .find(&format!("comment number {}\n", total - 2))
             .unwrap();
         let newest = recent.find(&format!("comment number {total}\n")).unwrap();
-        assert!(oldest < newest, "the trail must read oldest first: {recent}");
+        assert!(
+            oldest < newest,
+            "the trail must read oldest first: {recent}"
+        );
     }
 
     #[test]
@@ -9591,7 +9600,9 @@ mod tests {
         );
         assert_eq!(
             deleted,
-            format!("Comment #{comment_id} deleted from [PRJ-1](https://tracker.example/PRJ/issues/PRJ-1)")
+            format!(
+                "Comment #{comment_id} deleted from [PRJ-1](https://tracker.example/PRJ/issues/PRJ-1)"
+            )
         );
     }
 
@@ -10302,10 +10313,7 @@ mod tests {
             got.contains("    Second line survives too."),
             "multi-line descriptions keep tree indentation: {got}"
         );
-        assert!(
-            !got.contains('…'),
-            "no ellipsis in the rehydrate: {got}"
-        );
+        assert!(!got.contains('…'), "no ellipsis in the rehydrate: {got}");
     }
 
     #[tokio::test]
@@ -11261,7 +11269,12 @@ mod tests {
             offset: None,
             limit: None,
         }));
-        assert!(result.content.iter().all(|content| content.as_image().is_none()));
+        assert!(
+            result
+                .content
+                .iter()
+                .all(|content| content.as_image().is_none())
+        );
         assert!(text_of(&result).contains("Binary, download at"));
     }
 
@@ -12117,7 +12130,12 @@ mod authz_gating_tests {
         });
         assert!(created.starts_with("Created"), "got: {created}");
 
-        let [edit_comment_id, delete_comment_id, foreign_edit_id, foreign_delete_id] = [
+        let [
+            edit_comment_id,
+            delete_comment_id,
+            foreign_edit_id,
+            foreign_delete_id,
+        ] = [
             (&viewer, "Keep this comment"),
             (&viewer, "Keep this one too"),
             (&lead, "Do not disclose ownership"),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -14,7 +14,15 @@ use crate::{
     links::{IssueLinkContext, MarkdownReference},
 };
 
-use super::schemas::*;
+use super::schemas::{
+    AddCommentInput, BulkUpdateInput, CreateIssueInput, CreatePageInput, CreatePlanInput,
+    DeleteCommentInput, DeleteInput, EditCommentInput, EditIssueInput, EditPageInput,
+    EditPlanStepInput, ExportInput, GetActivityInput, GetAttachmentInput, GetBoardInput,
+    GetIssueInput, GetPageInput, GetPlanInput, LinkIssuesInput, ListAttachmentsInput,
+    ListCommentsInput, ListIssuesInput, ListResourcesInput, ManageResourceInput, PlanStepInput,
+    SearchInput, UnlinkIssuesInput, UpdateIssueInput, UpdatePageInput, UpdatePlanStepInput,
+    UploadAttachmentInput,
+};
 use super::{LificMcp, current_issue_link_context, sanitize_error};
 
 /// Self-onboarding nudge (LIF-257): shown by cold read tools when the DB has
@@ -431,8 +439,8 @@ impl Display for CommentLines<'_> {
     }
 }
 
-/// Render a plan + its step tree for get_plan output, with complete step
-/// descriptions (get_plan is the rehydration tool and the only read path
+/// Render a plan + its step tree for `get_plan` output, with complete step
+/// descriptions (`get_plan` is the rehydration tool and the only read path
 /// for them). Step lines carry `#<id>` so the agent can target edits, and
 /// issue-linked steps show provenance ("via LIF-42" / "reopened — LIF-42
 /// reopened").
@@ -727,12 +735,13 @@ impl Display for PlanSteps<'_> {
             }?;
             formatter.write_char('\n')?;
             (!node.description.is_empty())
-                .then(|| match self.full_descriptions {
-                    true => node.description.lines().try_for_each(|line| {
-                        (0..self.depth).try_for_each(|_| formatter.write_str("  "))?;
-                        writeln!(formatter, "    {line}")
-                    }),
-                    false => {
+                .then(|| {
+                    if self.full_descriptions {
+                        node.description.lines().try_for_each(|line| {
+                            (0..self.depth).try_for_each(|_| formatter.write_str("  "))?;
+                            writeln!(formatter, "    {line}")
+                        })
+                    } else {
                         (0..self.depth).try_for_each(|_| formatter.write_str("  "))?;
                         writeln!(formatter, "    {}", truncate_value(&node.description, 100))
                     }
@@ -1419,7 +1428,7 @@ impl LificMcp {
                         return Ok(self.empty_search_result());
                     }
                     Err(crate::error::LificError::NotFound(error)) => {
-                        return Err(error.to_string());
+                        return Err(error.clone());
                     }
                     Ok(_) => {
                         return Ok(self.empty_search_result());
@@ -1962,18 +1971,14 @@ impl LificMcp {
         .map_err(|error| format!("export worker failed: {error}"))??;
 
         match kind {
-            Kind::Page => Ok(bundle
-                .files
-                .into_iter()
-                .next()
-                .map(|file| file.content)
-                .unwrap_or_else(|| "Error: page export produced no files".into())),
-            Kind::Issue => Ok(bundle
-                .files
-                .into_iter()
-                .next()
-                .map(|file| file.content)
-                .unwrap_or_else(|| "Error: issue export produced no files".into())),
+            Kind::Page => Ok(bundle.files.into_iter().next().map_or_else(
+                || "Error: page export produced no files".into(),
+                |file| file.content,
+            )),
+            Kind::Issue => Ok(bundle.files.into_iter().next().map_or_else(
+                || "Error: issue export produced no files".into(),
+                |file| file.content,
+            )),
             Kind::Project => Ok(render_response(|output| {
                 writeln!(output, "{} exported file(s):", bundle.files.len())?;
                 bundle
@@ -4105,8 +4110,8 @@ impl LificMcp {
                     separator: "; ",
                 }
             )?;
-            match input.echo_tree.unwrap_or(false) {
-                true => write!(
+            if input.echo_tree.unwrap_or(false) {
+                write!(
                     output,
                     "{}",
                     PlanView {
@@ -4114,15 +4119,16 @@ impl LificMcp {
                         context: context.as_deref(),
                         full_descriptions: false,
                     }
-                ),
-                false => write!(
+                )
+            } else {
+                write!(
                     output,
                     "{} [{}]: {}/{} done",
                     plan_reference(context.as_deref(), &plan),
                     plan.status,
                     plan.done_count,
                     plan.step_count
-                ),
+                )
             }
         }))
     }
@@ -4451,8 +4457,8 @@ impl LificMcp {
     }
 }
 
-/// Recursively resolve an MCP PlanStepInput (issue identifiers → ids) into a
-/// query-layer CreatePlanStep, so create_plan can author the whole tree in one
+/// Recursively resolve an MCP `PlanStepInput` (issue identifiers → ids) into a
+/// query-layer `CreatePlanStep`, so `create_plan` can author the whole tree in one
 /// transaction.
 fn build_create_step(
     conn: &rusqlite::Connection,
@@ -4624,9 +4630,10 @@ impl Display for AttachmentLines<'_> {
                 HumanSize(row.size_bytes),
                 row.uploader,
                 row.created_at,
-                match row.links.is_empty() {
-                    true => "unlinked".to_string(),
-                    false => row.links.join(","),
+                if row.links.is_empty() {
+                    "unlinked".to_string()
+                } else {
+                    row.links.join(",")
                 }
             )
         })
@@ -4755,7 +4762,7 @@ mod tests {
         std::iter::from_fn(|| rx.try_recv().ok().map(|message| message.event)).collect()
     }
 
-    /// Seed a project via manage_resource, return identifier.
+    /// Seed a project via `manage_resource`, return identifier.
     fn seed_project(mcp: &LificMcp, name: &str, ident: &str) -> String {
         let result = mcp.manage_resource(Parameters(ManageResourceInput {
             resource_type: "project".into(),
@@ -5548,7 +5555,7 @@ mod tests {
         );
     }
 
-    /// LIF-411: REST has never returned raw SQLite text to a client
+    /// LIF-411: REST has never returned raw `SQLite` text to a client
     /// (`error.rs` logs it and answers "internal server error"); MCP handed it
     /// straight to the agent, leaking schema details into whatever transcript
     /// the agent writes. The detail now goes to the log only.
@@ -7108,7 +7115,7 @@ mod tests {
         attachment.id
     }
 
-    /// Every (entity_type, entity_id) an attachment is currently linked to.
+    /// Every (`entity_type`, `entity_id`) an attachment is currently linked to.
     fn links_for(m: &LificMcp, attachment_id: i64) -> Vec<(String, i64)> {
         let conn = m.db.read().unwrap();
         let mut stmt = conn
@@ -8352,7 +8359,7 @@ mod tests {
 
         let result = m.edit_issue(Parameters(EditIssueInput {
             identifier: "EDE-1".into(),
-            old_string: "".into(),
+            old_string: String::new(),
             new_string: "x".into(),
             field: None,
             replace_all: None,
@@ -8808,7 +8815,7 @@ mod tests {
     }
 
     /// Move a page into a folder, then move it back to root via the
-    /// empty-string sentinel (folder_id = NULL).
+    /// empty-string sentinel (`folder_id` = NULL).
     #[test]
     fn mcp_update_page_clears_folder_with_empty_string() {
         let (m, _guard) = mcp();
@@ -9401,7 +9408,7 @@ mod tests {
     // ── LIF-143: edit_comment / delete_comment ─────────────────────────────
 
     /// Set `MCP_REQUEST_USER` to `user` (identity for the acting-user
-    /// resolution in edit/delete_comment) and hand the handler lock back so
+    /// resolution in `edit/delete_comment`) and hand the handler lock back so
     /// the caller holds it for its whole body — same discipline as
     /// `seed_user`. Create a fresh user first, then call this.
     fn act_as(user: &models::User) -> tokio::sync::MutexGuard<'static, ()> {
@@ -10171,8 +10178,8 @@ mod tests {
     /// Regression (LIF-155): rmcp executes tools on internally-spawned
     /// tasks, where tokio task-locals set around `service.handle()` are
     /// invisible. Attribution must therefore come from the serialized
-    /// MCP_REQUEST_USER global via LificMcp::write()'s explicit re-stamp.
-    /// This test reproduces the boundary with a literal tokio::spawn.
+    /// `MCP_REQUEST_USER` global via `LificMcp::write()`'s explicit re-stamp.
+    /// This test reproduces the boundary with a literal `tokio::spawn`.
     #[tokio::test]
     async fn mcp_attribution_survives_task_spawn() {
         let (m, _guard) = mcp();

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -35,8 +35,7 @@ const MAX_DYNAMIC_CLIENT_STORAGE_BYTES: i64 = 4 * 1024 * 1024;
 const MAX_DEVICE_CODE_ROWS: i64 = 1024;
 
 /// Per-process CSRF secret, generated randomly on startup.
-static CSRF_SECRET: std::sync::LazyLock<[u8; 32]> =
-    std::sync::LazyLock::new(rand::random);
+static CSRF_SECRET: std::sync::LazyLock<[u8; 32]> = std::sync::LazyLock::new(rand::random);
 
 /// Generate a CSRF token bound to the approving session: `timestamp.hmac(ts || binding)`.
 ///
@@ -218,9 +217,7 @@ pub(crate) fn validate_redirect_uri(uri: &str) -> Result<(), &'static str> {
     }
     // Require some host after `://`.
     let rest = &after_scheme[3..];
-    let host_end = rest
-        .find(['/', '?', '#'])
-        .unwrap_or(rest.len());
+    let host_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     if rest[..host_end].is_empty() {
         return Err("redirect_uri must include a host");
     }
@@ -247,10 +244,7 @@ pub fn router(state: OAuthState) -> Router {
             "/oauth/authorize",
             get(authorize_page).post(authorize_approve),
         )
-        .route(
-            "/oauth/device_authorization",
-            post(device_authorization),
-        )
+        .route("/oauth/device_authorization", post(device_authorization))
         .route("/oauth/device", get(device_page).post(device_approve))
         .route("/oauth/token", post(token_exchange))
         .route("/oauth/revoke", post(revoke_token))
@@ -359,7 +353,9 @@ async fn register_client(
             })),
         )
             .into_response();
-        if retry > 0 && let Ok(v) = retry.to_string().parse() {
+        if retry > 0
+            && let Ok(v) = retry.to_string().parse()
+        {
             resp.headers_mut().insert("retry-after", v);
         }
         return resp;
@@ -393,9 +389,7 @@ async fn register_client(
     }
 
     let client_name = req.client_name.unwrap_or_else(|| "MCP Client".into());
-    if client_name.len() > MAX_CLIENT_NAME_BYTES
-        || client_name.chars().any(|c| c.is_control())
-    {
+    if client_name.len() > MAX_CLIENT_NAME_BYTES || client_name.chars().any(|c| c.is_control()) {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -1058,18 +1052,17 @@ fn resolve_approval_bot(
 ) -> Result<i64, (StatusCode, String)> {
     let tool_text = match (tool, tool_custom) {
         // A specific known tool chosen from the pick-list.
-        (Some(id), _)
-            if !id.trim().is_empty() && id.trim() != CUSTOM_TOOL_OPTION =>
-        {
-            id.clone()
-        }
+        (Some(id), _) if !id.trim().is_empty() && id.trim() != CUSTOM_TOOL_OPTION => id.clone(),
         // "Custom tool…" chosen — the free-text name is required.
-        (Some(id), Some(name))
-            if id.trim() == CUSTOM_TOOL_OPTION && !name.trim().is_empty() =>
-        {
+        (Some(id), Some(name)) if id.trim() == CUSTOM_TOOL_OPTION && !name.trim().is_empty() => {
             name.clone()
         }
-        _ => return Err((StatusCode::BAD_REQUEST, "Pick which tool is connecting".into())),
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Pick which tool is connecting".into(),
+            ));
+        }
     };
     let (tool_id, display_name) = match resolve_tool(&tool_text) {
         Ok(v) => v,
@@ -1162,7 +1155,9 @@ async fn device_authorization(
             })),
         )
             .into_response();
-        if retry > 0 && let Ok(v) = retry.to_string().parse() {
+        if retry > 0
+            && let Ok(v) = retry.to_string().parse()
+        {
             resp.headers_mut().insert("retry-after", v);
         }
         return resp;
@@ -1186,11 +1181,9 @@ async fn device_authorization(
         })
     };
 
-    if req
-        .client_name
-        .as_deref()
-        .is_some_and(|name| name.len() > MAX_CLIENT_NAME_BYTES || name.chars().any(|c| c.is_control()))
-    {
+    if req.client_name.as_deref().is_some_and(|name| {
+        name.len() > MAX_CLIENT_NAME_BYTES || name.chars().any(|c| c.is_control())
+    }) {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -1217,17 +1210,16 @@ async fn device_authorization(
         warn!(%error, "failed to clean up expired OAuth device codes");
         return (StatusCode::SERVICE_UNAVAILABLE, "database cleanup error").into_response();
     }
-    let device_count: i64 = match conn.query_row(
-        "SELECT COUNT(*) FROM oauth_device_codes",
-        [],
-        |row| row.get(0),
-    ) {
-        Ok(count) => count,
-        Err(error) => {
-            warn!(%error, "failed to inspect OAuth device-code storage");
-            return (StatusCode::SERVICE_UNAVAILABLE, "database error").into_response();
-        }
-    };
+    let device_count: i64 =
+        match conn.query_row("SELECT COUNT(*) FROM oauth_device_codes", [], |row| {
+            row.get(0)
+        }) {
+            Ok(count) => count,
+            Err(error) => {
+                warn!(%error, "failed to inspect OAuth device-code storage");
+                return (StatusCode::SERVICE_UNAVAILABLE, "database error").into_response();
+            }
+        };
     if device_count >= MAX_DEVICE_CODE_ROWS {
         warn!("OAuth device-code storage limit reached");
         return (
@@ -1755,7 +1747,11 @@ async fn token_exchange(
 /// `expired_token`) or, on approval, mints and returns an access token.
 fn device_token_exchange(state: &OAuthState, req: &TokenRequest) -> Response {
     let Some(device_code) = req.device_code.as_deref().filter(|c| !c.is_empty()) else {
-        return device_error(StatusCode::BAD_REQUEST, "invalid_request", Some("missing device_code"));
+        return device_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            Some("missing device_code"),
+        );
     };
     let device_code_hash = sha256_hex(device_code.as_bytes());
 
@@ -2034,12 +2030,10 @@ async fn revoke_token(
         .map(|s| s.trim().to_string());
 
     let is_authenticated = match &caller_token {
-        Some(t) if t.starts_with("lific_sess_") => {
-            match state.db.read() {
-                Ok(conn) => crate::db::queries::users::validate_session(&conn, t).is_ok(),
-                Err(_) => false,
-            }
-        }
+        Some(t) if t.starts_with("lific_sess_") => match state.db.read() {
+            Ok(conn) => crate::db::queries::users::validate_session(&conn, t).is_ok(),
+            Err(_) => false,
+        },
         Some(t) if t.starts_with("lific_at_") => authenticate_oauth_token(&state.db, t).is_some(),
         // LIF-208: default-deny unknown bearer shapes. The previous
         // `Some(_) => true` treated *any* other string (including arbitrary
@@ -2234,14 +2228,22 @@ pub fn resolve_oauth_credential(db: &DbPool, token: &str) -> Result<OAuthCredent
     let Some(bound_user_id) = row.bound_user_id else {
         return Ok(OAuthCredential::LegacyUnbound);
     };
-    let (Some(user_id), Some(username), Some(display_name), Some(is_admin), Some(is_active), Some(is_bot)) = (
+    let (
+        Some(user_id),
+        Some(username),
+        Some(display_name),
+        Some(is_admin),
+        Some(is_active),
+        Some(is_bot),
+    ) = (
         row.user_id,
         row.username,
         row.display_name,
         row.is_admin,
         row.is_active,
         row.is_bot,
-    ) else {
+    )
+    else {
         return Err(OAuthReject::DeadBinding);
     };
     debug_assert_eq!(user_id, bound_user_id);
@@ -2619,7 +2621,10 @@ mod tests {
     #[test]
     fn csrf_rejects_tampered_and_malformed_signatures() {
         let t = generate_csrf_token("sess");
-        assert!(validate_csrf_token(&t, "sess"), "honest token must validate");
+        assert!(
+            validate_csrf_token(&t, "sess"),
+            "honest token must validate"
+        );
 
         let (ts, sig) = t.split_once('.').unwrap();
 
@@ -2811,11 +2816,7 @@ mod tests {
     // public_url is never overridden, and forwarded headers are ignored.
 
     /// GET a metadata path and parse the JSON body.
-    async fn get_metadata(
-        app: &Router,
-        path: &str,
-        headers: &[(&str, &str)],
-    ) -> serde_json::Value {
+    async fn get_metadata(app: &Router, path: &str, headers: &[(&str, &str)]) -> serde_json::Value {
         let mut builder = Request::builder().uri(path);
         for (name, value) in headers {
             builder = builder.header(*name, *value);
@@ -2841,10 +2842,7 @@ mod tests {
         )
         .await;
         assert_eq!(val["issuer"], "http://localhost:3456");
-        assert_eq!(
-            val["token_endpoint"],
-            "http://localhost:3456/oauth/token"
-        );
+        assert_eq!(val["token_endpoint"], "http://localhost:3456/oauth/token");
 
         let val = get_metadata(
             &app,
@@ -3555,11 +3553,13 @@ mod tests {
             )
         };
 
-        assert!(approve(app.clone(), &generate_csrf_token(&session_token))
-            .await
-            .unwrap()
-            .status()
-            .is_redirection());
+        assert!(
+            approve(app.clone(), &generate_csrf_token(&session_token))
+                .await
+                .unwrap()
+                .status()
+                .is_redirection()
+        );
         let first_id: i64 = {
             let conn = db.read().unwrap();
             conn.query_row(
@@ -3570,11 +3570,13 @@ mod tests {
             .unwrap()
         };
         // Re-approval of the same tool+owner must reuse the same bot.
-        assert!(approve(app.clone(), &generate_csrf_token(&session_token))
-            .await
-            .unwrap()
-            .status()
-            .is_redirection());
+        assert!(
+            approve(app.clone(), &generate_csrf_token(&session_token))
+                .await
+                .unwrap()
+                .status()
+                .is_redirection()
+        );
         let second_id: i64 = {
             let conn = db.read().unwrap();
             conn.query_row(
@@ -3646,7 +3648,10 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/oauth/authorize?client_id={client_id}&redirect_uri={}&response_type=code", urlencoding::encode("http://localhost/callback")))
+                    .uri(format!(
+                        "/oauth/authorize?client_id={client_id}&redirect_uri={}&response_type=code",
+                        urlencoding::encode("http://localhost/callback")
+                    ))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
@@ -3686,7 +3691,10 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/oauth/authorize?client_id={client_id}&redirect_uri={}&response_type=code", urlencoding::encode("http://localhost/callback")))
+                    .uri(format!(
+                        "/oauth/authorize?client_id={client_id}&redirect_uri={}&response_type=code",
+                        urlencoding::encode("http://localhost/callback")
+                    ))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
@@ -3867,10 +3875,7 @@ mod tests {
     }
 
     /// POST the device grant to /oauth/token and return (status, json).
-    async fn poll_device_token(
-        app: &Router,
-        device_code: &str,
-    ) -> (StatusCode, serde_json::Value) {
+    async fn poll_device_token(app: &Router, device_code: &str) -> (StatusCode, serde_json::Value) {
         let body = format!(
             "grant_type={}&device_code={}",
             urlencoding::encode("urn:ietf:params:oauth:grant-type:device_code"),
@@ -4361,7 +4366,10 @@ mod tests {
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let html = String::from_utf8_lossy(&bytes);
         // Normalized + uppercased + dash-inserted into the input value.
-        assert!(html.contains("value=\"BCDF-GHJK\""), "prefill missing: {html}");
+        assert!(
+            html.contains("value=\"BCDF-GHJK\""),
+            "prefill missing: {html}"
+        );
     }
 
     #[test]
@@ -5203,7 +5211,6 @@ mod tests {
                 .unwrap();
             assert_eq!(bots, 0);
         }
-
 
         /// Refusing a device is not a grant, so it must not be made harder
         /// than approving one. Someone who sees a code they do not recognise

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -389,7 +389,7 @@ async fn register_client(
     }
 
     let client_name = req.client_name.unwrap_or_else(|| "MCP Client".into());
-    if client_name.len() > MAX_CLIENT_NAME_BYTES || client_name.chars().any(|c| c.is_control()) {
+    if client_name.len() > MAX_CLIENT_NAME_BYTES || client_name.chars().any(char::is_control) {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -991,8 +991,7 @@ fn tool_pick_list_html(preset_id: Option<&str>) -> String {
     }
     let custom_option = if is_custom { " selected" } else { "" };
     options.push_str(&format!(
-        "<option value=\"{}\"{custom_option}>Custom tool&hellip;</option>",
-        CUSTOM_TOOL_OPTION
+        "<option value=\"{CUSTOM_TOOL_OPTION}\"{custom_option}>Custom tool&hellip;</option>"
     ));
 
     // The placeholder is only the selected placeholder when there's no remembered
@@ -1018,10 +1017,9 @@ fn tool_pick_list_html(preset_id: Option<&str>) -> String {
         var tool = document.getElementById('tool');
         var custom = document.getElementById('custom_tool');
         tool.addEventListener('change', function () {{
-            custom.style.display = tool.value === '{custom_option_value}' ? 'block' : 'none';
+            custom.style.display = tool.value === '{CUSTOM_TOOL_OPTION}' ? 'block' : 'none';
         }});
         </script>",
-        custom_option_value = CUSTOM_TOOL_OPTION,
     )
 }
 
@@ -1099,7 +1097,7 @@ fn resolve_approval_bot(
 fn normalize_user_code(input: &str) -> String {
     let cleaned: String = input
         .chars()
-        .filter(|c| c.is_ascii_alphanumeric())
+        .filter(char::is_ascii_alphanumeric)
         .map(|c| c.to_ascii_uppercase())
         .collect();
     if cleaned.len() == 8 {
@@ -1182,7 +1180,7 @@ async fn device_authorization(
     };
 
     if req.client_name.as_deref().is_some_and(|name| {
-        name.len() > MAX_CLIENT_NAME_BYTES || name.chars().any(|c| c.is_control())
+        name.len() > MAX_CLIENT_NAME_BYTES || name.chars().any(char::is_control)
     }) {
         return (
             StatusCode::BAD_REQUEST,
@@ -1505,8 +1503,8 @@ struct TokenRequest {
     /// is then refused by the `grant_type` match: we issue no refresh tokens.
     #[allow(dead_code)]
     refresh_token: Option<String>,
-    /// RFC 8628 device grant: the opaque device_code returned by
-    /// /oauth/device_authorization.
+    /// RFC 8628 device grant: the opaque `device_code` returned by
+    /// /`oauth/device_authorization`.
     device_code: Option<String>,
 }
 
@@ -1818,8 +1816,7 @@ fn device_token_exchange(state: &OAuthState, req: &TokenRequest) -> Response {
 
     // Expiry check first (RFC 8628: expired_token).
     let expired = chrono::DateTime::parse_from_rfc3339(&row.expires_at)
-        .map(|t| now >= t.with_timezone(&chrono::Utc))
-        .unwrap_or(true);
+        .map_or(true, |t| now >= t.with_timezone(&chrono::Utc));
     if expired {
         let _ = conn.execute(
             "DELETE FROM oauth_device_codes WHERE device_code_hash = ?1",
@@ -2167,7 +2164,7 @@ pub enum OAuthReject {
 
 /// Resolve an OAuth bearer token with one SQL statement.
 ///
-/// A connection alone is not a snapshot in SQLite autocommit mode: each
+/// A connection alone is not a snapshot in `SQLite` autocommit mode: each
 /// statement starts its own read transaction. Keep token validity, its nullable
 /// binding, the bound user, and the bot owner's liveness in one joined query so
 /// revocation cannot land between those decisions.
@@ -2349,7 +2346,7 @@ mod tests {
         router(state).layer(MockConnectInfo(SocketAddr::from(([127, 0, 0, 1], 4242))))
     }
 
-    /// Register a client, returning the client_id.
+    /// Register a client, returning the `client_id`.
     async fn register_client_helper(app: &Router, redirect_uri: &str) -> String {
         let body = serde_json::json!({
             "redirect_uris": [redirect_uri],
@@ -3851,7 +3848,7 @@ mod tests {
 
     // ── LIF-252: device authorization flow (RFC 8628) ────────────────────
 
-    /// POST /oauth/device_authorization and return the parsed JSON.
+    /// POST /`oauth/device_authorization` and return the parsed JSON.
     async fn request_device_code(app: &Router, client_name: Option<&str>) -> serde_json::Value {
         let body = match client_name {
             Some(n) => format!("client_name={}", urlencoding::encode(n)),
@@ -4664,7 +4661,7 @@ mod tests {
         }
     }
 
-    /// Every OAuth expiry column is written with `to_rfc3339`, and SQLite's
+    /// Every OAuth expiry column is written with `to_rfc3339`, and `SQLite`'s
     /// `datetime('now')` is not that format. Compared as raw text they
     /// disagree within the same day: 'T' sorts after every digit, so
     /// '2026-08-20T11:59:00+00:00' reads as later than '2026-08-20 12:00:00'

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -107,9 +107,9 @@ fn le_u32(bytes: &[u8], off: usize) -> Option<u32> {
 }
 
 fn le_u64(bytes: &[u8], off: usize) -> Option<u64> {
-    bytes.get(off..off + 8).map(|s| {
-        u64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]])
-    })
+    bytes
+        .get(off..off + 8)
+        .map(|s| u64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]))
 }
 
 /// Locate the end-of-central-directory record. It sits at the very end unless
@@ -132,7 +132,10 @@ fn central_directory_location(bytes: &[u8], eocd: usize) -> Option<(usize, usize
     let offset = le_u32(bytes, eocd + 16)? as u64;
 
     if entries != u64::from(u16::MAX) && offset != u64::from(u32::MAX) {
-        return Some((usize::try_from(offset).ok()?, usize::try_from(entries).ok()?));
+        return Some((
+            usize::try_from(offset).ok()?,
+            usize::try_from(entries).ok()?,
+        ));
     }
 
     // Zip64: a 20-byte locator immediately precedes the EOCD and points at
@@ -147,7 +150,10 @@ fn central_directory_location(bytes: &[u8], eocd: usize) -> Option<(usize, usize
     }
     let entries = le_u64(bytes, eocd64 + 32)?;
     let offset = le_u64(bytes, eocd64 + 48)?;
-    Some((usize::try_from(offset).ok()?, usize::try_from(entries).ok()?))
+    Some((
+        usize::try_from(offset).ok()?,
+        usize::try_from(entries).ok()?,
+    ))
 }
 
 /// Walk a zip's central directory and list what it contains.
@@ -418,7 +424,9 @@ mod tests {
 
     #[test]
     fn zip_preview_caps_entries_and_flags_truncation() {
-        let names: Vec<String> = (0..MAX_ZIP_ENTRIES + 5).map(|i| format!("f{i}.txt")).collect();
+        let names: Vec<String> = (0..MAX_ZIP_ENTRIES + 5)
+            .map(|i| format!("f{i}.txt"))
+            .collect();
         let files: Vec<(&str, &[u8])> = names.iter().map(|n| (n.as_str(), &b"x"[..])).collect();
         let zip = build_zip(&files);
 

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -2,7 +2,7 @@
 //!
 //! Some uploads are interesting for what is *inside* them rather than for
 //! their bytes. A zip attached to a bug report is usually a set of logs, and a
-//! SQLite file attached to one is usually a reproduction database. Downloading
+//! `SQLite` file attached to one is usually a reproduction database. Downloading
 //! either just to see what it holds is friction, so this module answers that
 //! question server-side and the API returns it as JSON.
 //!
@@ -15,7 +15,7 @@
 //! costs us the same handful of microseconds as an empty one, and the
 //! declared size is reported as the untrusted number it is.
 //!
-//! The SQLite reader opens a *copy* of the file with `immutable=1`, `mode=ro`
+//! The `SQLite` reader opens a *copy* of the file with `immutable=1`, `mode=ro`
 //! and `query_only`, and runs exactly two shapes of query: a `sqlite_master`
 //! scan restricted to `type='table'`, and a `COUNT(*)` per table. Views and
 //! triggers are skipped on purpose, since evaluating a view means executing
@@ -43,7 +43,7 @@ pub struct ZipEntry {
     pub compressed: u64,
 }
 
-/// One table in a SQLite database, with its real row count.
+/// One table in a `SQLite` database, with its real row count.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SqliteTable {
     pub name: String,
@@ -70,7 +70,7 @@ pub enum Preview {
 
 /// Build the preview for a blob, choosing the parser by magic bytes.
 ///
-/// The stored MIME is deliberately not consulted. A SQLite file uploaded
+/// The stored MIME is deliberately not consulted. A `SQLite` file uploaded
 /// before `application/vnd.sqlite3` joined the allowlist may be recorded as
 /// something else entirely, and the header is the authoritative answer either
 /// way.
@@ -128,8 +128,8 @@ fn find_eocd(bytes: &[u8]) -> Option<usize> {
 /// Resolve `(central directory offset, declared entry count)`, following the
 /// Zip64 locator when the classic 16-bit / 32-bit fields are saturated.
 fn central_directory_location(bytes: &[u8], eocd: usize) -> Option<(usize, usize)> {
-    let entries = le_u16(bytes, eocd + 10)? as u64;
-    let offset = le_u32(bytes, eocd + 16)? as u64;
+    let entries = u64::from(le_u16(bytes, eocd + 10)?);
+    let offset = u64::from(le_u32(bytes, eocd + 16)?);
 
     if entries != u64::from(u16::MAX) && offset != u64::from(u32::MAX) {
         return Some((
@@ -239,10 +239,10 @@ fn sanitize_entry_name(raw: &[u8]) -> String {
 
 // ── SQLite ───────────────────────────────────────────────────
 
-/// Open a copy of `bytes` as a read-only SQLite database and list its tables
+/// Open a copy of `bytes` as a read-only `SQLite` database and list its tables
 /// with row counts.
 ///
-/// The copy is the point. `immutable=1` already promises SQLite the file will
+/// The copy is the point. `immutable=1` already promises `SQLite` the file will
 /// not change, which suppresses WAL and journal creation, but writing the copy
 /// into a fresh temporary directory means the stored, content-addressed blob
 /// is not even reachable from the connection.
@@ -369,7 +369,7 @@ pub(crate) mod fixtures {
         out
     }
 
-    /// Serialize a tiny real SQLite database to bytes.
+    /// Serialize a tiny real `SQLite` database to bytes.
     pub(crate) fn build_sqlite() -> Vec<u8> {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("fixture.sqlite3");

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -265,9 +265,7 @@ impl RateLimiter {
         let now = Instant::now();
         let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
 
-        if !state.attempts.contains_key(key)
-            && !Self::make_room(&mut state, now, self.window)
-        {
+        if !state.attempts.contains_key(key) && !Self::make_room(&mut state, now, self.window) {
             return None;
         }
 
@@ -389,9 +387,7 @@ impl<'a> Reservation<'a> {
         first: &str,
         second: &str,
     ) -> Result<Self, ReservationRejection> {
-        let first_id = limiter
-            .reserve(first)
-            .ok_or(ReservationRejection::First)?;
+        let first_id = limiter.reserve(first).ok_or(ReservationRejection::First)?;
         let Some(second_id) = limiter.reserve(second) else {
             limiter.refund(first, first_id);
             return Err(ReservationRejection::Second);
@@ -791,8 +787,7 @@ mod tests {
 
     #[test]
     fn trusted_proxy_chain_skips_trusted_intermediate_hops() {
-        let trusted = parse_trusted_proxies(&["127.0.0.0/8".into(), "10.0.0.0/8".into()])
-            .unwrap();
+        let trusted = parse_trusted_proxies(&["127.0.0.0/8".into(), "10.0.0.0/8".into()]).unwrap();
         let peer = "127.0.0.1".parse().unwrap();
         let mut h = HeaderMap::new();
         h.insert("x-forwarded-for", "203.0.113.9, 10.0.0.2".parse().unwrap());
@@ -801,8 +796,7 @@ mod tests {
 
     #[test]
     fn all_trusted_forwarded_for_hops_fall_back_to_peer() {
-        let trusted = parse_trusted_proxies(&["127.0.0.0/8".into(), "10.0.0.0/8".into()])
-            .unwrap();
+        let trusted = parse_trusted_proxies(&["127.0.0.0/8".into(), "10.0.0.0/8".into()]).unwrap();
         let peer = "127.0.0.1".parse().unwrap();
         let mut h = HeaderMap::new();
         h.insert("x-forwarded-for", "10.0.0.2, 127.0.0.2".parse().unwrap());

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -124,7 +124,8 @@ fn header_ip(headers: &HeaderMap, name: &str) -> Option<IpAddr> {
 /// right to left. `None` means the chain was malformed or entirely trusted.
 fn x_forwarded_for_client_ip(headers: &HeaderMap, trusted_proxies: &[IpNetwork]) -> Option<IpAddr> {
     let mut entries = Vec::new();
-    for value in headers.get_all("x-forwarded-for").iter() {
+    let forwarded_for = headers.get_all("x-forwarded-for");
+    for value in &forwarded_for {
         let line = value.to_str().ok()?;
         entries.extend(line.split(','));
     }
@@ -156,9 +157,7 @@ pub fn client_ip(peer: IpAddr, headers: &HeaderMap, trusted_proxies: &[IpNetwork
     let client = if headers.contains_key("x-forwarded-for") {
         x_forwarded_for_client_ip(headers, trusted_proxies).unwrap_or(peer)
     } else {
-        header_ip(headers, "x-real-ip")
-            .map(normalize_ip)
-            .unwrap_or(peer)
+        header_ip(headers, "x-real-ip").map_or(peer, normalize_ip)
     };
     normalize_ip(client).to_string()
 }
@@ -263,7 +262,10 @@ impl RateLimiter {
             return None;
         }
         let now = Instant::now();
-        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         if !state.attempts.contains_key(key) && !Self::make_room(&mut state, now, self.window) {
             return None;
@@ -309,7 +311,10 @@ impl RateLimiter {
             return;
         }
         let now = Instant::now();
-        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let Some(entry) = state.attempts.get_mut(key) else {
             return;
         };
@@ -325,14 +330,17 @@ impl RateLimiter {
 
     /// How many seconds until the oldest attempt in the window expires.
     pub fn retry_after(&self, key: &str) -> u64 {
-        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Instant::now();
         match state.attempts.get(key) {
             Some(entries) if !entries.is_empty() => {
                 let oldest = entries[0].at;
                 let elapsed = now.saturating_duration_since(oldest);
                 if elapsed < self.window {
-                    (self.window - elapsed).as_secs() + 1
+                    self.window.checked_sub(elapsed).unwrap().as_secs() + 1
                 } else {
                     0
                 }
@@ -345,7 +353,7 @@ impl RateLimiter {
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.state
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .attempts
             .contains_key(key)
     }
@@ -756,8 +764,8 @@ mod tests {
     #[test]
     fn a_reservation_that_is_never_refunded_stays_spent() {
         let rl = RateLimiter::new(2, Duration::from_secs(60));
-        let _spent = Reservation::acquire(&rl, "ip", "id").expect("free");
-        drop(_spent);
+        let spent = Reservation::acquire(&rl, "ip", "id").expect("free");
+        drop(spent);
         // Dropping is not refunding: a failed attempt must cost something.
         assert!(rl.check("ip"));
         assert!(!rl.check("ip"));

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -510,12 +510,11 @@ async fn bounded_send<F>(send: F) -> SocketFlow
 where
     F: std::future::Future<Output = Result<(), axum::Error>>,
 {
-    match time::timeout(SOCKET_SEND_TIMEOUT, send).await {
-        Ok(result) => SocketFlow::from_send(result),
-        Err(_) => {
-            warn!("realtime websocket send timed out; dropping the socket");
-            SocketFlow::Close
-        }
+    if let Ok(result) = time::timeout(SOCKET_SEND_TIMEOUT, send).await {
+        SocketFlow::from_send(result)
+    } else {
+        warn!("realtime websocket send timed out; dropping the socket");
+        SocketFlow::Close
     }
 }
 
@@ -626,7 +625,7 @@ async fn handle_client_message(
     message: Option<Result<Message, axum::Error>>,
 ) -> SocketFlow {
     match message {
-        Some(Ok(Message::Close(_))) | Some(Err(_)) | None => SocketFlow::Close,
+        Some(Ok(Message::Close(_)) | Err(_)) | None => SocketFlow::Close,
         Some(Ok(message)) => {
             let now = Instant::now();
             if client.admit_message(now) == ClientAdmission::RateLimited {
@@ -656,20 +655,19 @@ async fn send_activity_baseline(
     client: &mut ClientState,
 ) -> SocketFlow {
     let now = Instant::now();
-    let baseline = match client.cached_activity_baseline(now) {
-        Some(event) => Ok(event),
-        None => {
-            let baseline_db = db.clone();
-            let baseline_user = auth_user.clone();
-            tokio::task::spawn_blocking(move || activity_baseline(&baseline_db, &baseline_user))
-                .await
-                .unwrap_or_else(|error| {
-                    Err(crate::error::LificError::Internal(format!(
-                        "websocket baseline task failed: {error}"
-                    )))
-                })
-                .inspect(|event| client.cache_activity_baseline(now, event.clone()))
-        }
+    let baseline = if let Some(event) = client.cached_activity_baseline(now) {
+        Ok(event)
+    } else {
+        let baseline_db = db.clone();
+        let baseline_user = auth_user.clone();
+        tokio::task::spawn_blocking(move || activity_baseline(&baseline_db, &baseline_user))
+            .await
+            .unwrap_or_else(|error| {
+                Err(crate::error::LificError::Internal(format!(
+                    "websocket baseline task failed: {error}"
+                )))
+            })
+            .inspect(|event| client.cache_activity_baseline(now, event.clone()))
     };
     match baseline_response(baseline) {
         RealtimeEvent::ResyncRequired => send_resync(socket, client).await,
@@ -720,12 +718,11 @@ fn activity_baseline(
 }
 
 async fn send_event(socket: &mut WebSocket, event: &RealtimeEvent) -> SocketFlow {
-    match serde_json::to_string(event) {
-        Ok(json) => send_bounded(socket, Message::Text(json.into())).await,
-        Err(_) => {
-            warn!("failed to serialize realtime event");
-            close_socket(socket).await
-        }
+    if let Ok(json) = serde_json::to_string(event) {
+        send_bounded(socket, Message::Text(json.into())).await
+    } else {
+        warn!("failed to serialize realtime event");
+        close_socket(socket).await
     }
 }
 

--- a/src/resolve_caller.rs
+++ b/src/resolve_caller.rs
@@ -81,8 +81,8 @@ pub fn resolve_caller(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{self, queries};
     use crate::db::models::CreateUser;
+    use crate::db::{self, queries};
 
     fn test_db() -> db::DbPool {
         db::open_memory().expect("test db")
@@ -138,7 +138,12 @@ mod tests {
         let conn = pool.read().unwrap();
         let regular = seed_regular(&conn, "alice");
 
-        for transport in [Transport::Web, Transport::Mcp, Transport::Api, Transport::Cli] {
+        for transport in [
+            Transport::Web,
+            Transport::Mcp,
+            Transport::Api,
+            Transport::Cli,
+        ] {
             let id = resolve_caller_conn(&conn, Some(regular.clone()), transport)
                 .unwrap()
                 .expect("Some(credential) always resolves");
@@ -196,9 +201,11 @@ mod tests {
         drop(conn);
 
         let conn = pool.read().unwrap();
-        assert!(resolve_caller_conn(&conn, None, Transport::Api)
-            .unwrap()
-            .is_none());
+        assert!(
+            resolve_caller_conn(&conn, None, Transport::Api)
+                .unwrap()
+                .is_none()
+        );
     }
 
     // Zero-user bootstrap: no credential and no users at all → None. This is
@@ -207,9 +214,11 @@ mod tests {
     fn none_credential_zero_users_returns_none() {
         let pool = test_db();
         let conn = pool.read().unwrap();
-        assert!(resolve_caller_conn(&conn, None, Transport::System)
-            .unwrap()
-            .is_none());
+        assert!(
+            resolve_caller_conn(&conn, None, Transport::System)
+                .unwrap()
+                .is_none()
+        );
     }
 
     // ── DbPool wrapper mirrors the conn core ──────────────────────────────

--- a/src/server.rs
+++ b/src/server.rs
@@ -413,8 +413,7 @@ fn build_app_with_store(
             info!(
                 acting_as = authless_user
                     .as_ref()
-                    .map(|u| u.username.as_str())
-                    .unwrap_or("<anonymous>"),
+                    .map_or("<anonymous>", |u| u.username.as_str()),
                 "authless MCP endpoint enabled at /mcp/<token>"
             );
             build_authless_mcp_router(
@@ -524,9 +523,7 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         // stale or toggled flag must not turn a reachable instance into
         // passwordless admin. On a genuinely local instance with an https
         // public_url on a private network, keep the loud warning.
-        let auto_login = db::queries::settings::get(&conn)
-            .map(|s| s.web_auto_login)
-            .unwrap_or(false);
+        let auto_login = db::queries::settings::get(&conn).is_ok_and(|s| s.web_auto_login);
         if auto_login && let Some(exposure) = reachability.public_exposure() {
             return Err(format!(
                 "refusing to start: single-user web auto-login is enabled while \
@@ -584,7 +581,7 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     // Start backup task
     if cfg.backup.enabled {
         let pool_arc = Arc::new(pool.clone());
-        backup::start_backup_task(pool_arc, cfg.database.path.clone(), cfg.backup.clone());
+        backup::start_backup_task(pool_arc, cfg.database.path.clone(), &cfg.backup);
         info!(
             dir = %cfg.backup_dir().display(),
             interval = %format!("{}m", cfg.backup.interval_minutes),
@@ -776,8 +773,8 @@ async fn shutdown_signal(pool: db::DbPool) {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+        () = ctrl_c => {},
+        () = terminate => {},
     }
 
     info!("shutdown signal received, checkpointing WAL...");

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,7 +32,9 @@ use tracing::{info, warn};
 use api_keys_simplified::ApiKeyManagerV0;
 
 use crate::config::{self, Config};
-use crate::{actor, api, auth, backup, db, links, mcp, oauth, ratelimit, realtime, resolve_caller, storage};
+use crate::{
+    actor, api, auth, backup, db, links, mcp, oauth, ratelimit, realtime, resolve_caller, storage,
+};
 
 /// Embedded frontend assets compiled from web/dist/.
 /// Falls back gracefully if dist/ doesn't exist (e.g. dev builds without frontend).
@@ -269,10 +271,11 @@ fn build_app_with_store(
     // so reverse proxies (Tailscale funnel, nginx, etc.) can forward requests.
     if let Some(ref url) = cfg.server.public_url
         && let Ok(parsed) = url.parse::<axum::http::Uri>()
-            && let Some(authority) = parsed.authority() {
-                let host: String = authority.host().to_string();
-                mcp_allowed_hosts.push(host);
-            }
+        && let Some(authority) = parsed.authority()
+    {
+        let host: String = authority.host().to_string();
+        mcp_allowed_hosts.push(host);
+    }
 
     let mcp_config = StreamableHttpServerConfig::default()
         .with_stateful_mode(false)
@@ -397,14 +400,12 @@ fn build_app_with_store(
                             }),
                         // LIFIC-8: the "no credential → first admin"
                         // fallback is consolidated in `resolve_caller`.
-                        None => resolve_caller::resolve_caller_conn(
-                            &conn,
-                            None,
-                            actor::Transport::Mcp,
-                        )
-                        .ok()
-                        .flatten()
-                        .map(|i| i.user),
+                        None => {
+                            resolve_caller::resolve_caller_conn(&conn, None, actor::Transport::Mcp)
+                                .ok()
+                                .flatten()
+                                .map(|i| i.user)
+                        }
                     },
                     Err(_) => None,
                 }
@@ -569,7 +570,9 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         // A human operator exists (should_mint was false for lack of
         // keys alone) but no key has been created yet: keys are minted
         // on demand via `lific key create`.
-        info!("human operator present — passwordless mode; mint keys on demand with `lific key create`");
+        info!(
+            "human operator present — passwordless mode; mint keys on demand with `lific key create`"
+        );
     } else {
         let count = auth::list_api_keys(&pool)?
             .iter()
@@ -594,10 +597,7 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     // request router so its operation lock covers both upload and GC paths.
     let attachment_store = storage::AttachmentStore::from_db_path(&cfg.database.path);
     let gc_attachment_store = attachment_store.clone();
-    storage::start_gc_task(
-        pool.clone(),
-        gc_attachment_store,
-    );
+    storage::start_gc_task(pool.clone(), gc_attachment_store);
 
     let app = build_app_with_store(
         cfg,
@@ -673,10 +673,8 @@ fn build_global_cors(cors_origins: &[String]) -> CorsLayer {
     if cors_origins.is_empty() {
         layer.allow_origin(Any)
     } else {
-        let origins: Vec<HeaderValue> = cors_origins
-            .iter()
-            .filter_map(|o| o.parse().ok())
-            .collect();
+        let origins: Vec<HeaderValue> =
+            cors_origins.iter().filter_map(|o| o.parse().ok()).collect();
         layer.allow_origin(origins)
     }
 }
@@ -706,12 +704,7 @@ fn build_authless_mcp_router(
         .with_json_response(true)
         .with_allowed_hosts(allowed_hosts);
     let service = StreamableHttpService::new(
-        move || {
-            Ok(mcp::LificMcp::with_realtime(
-                pool.clone(),
-                realtime.clone(),
-            ))
-        },
+        move || Ok(mcp::LificMcp::with_realtime(pool.clone(), realtime.clone())),
         Arc::new(LocalSessionManager::default()),
         config,
     );
@@ -919,7 +912,10 @@ mod cors_tests {
             .uri("/mcp")
             .header("origin", "https://claude.ai")
             .header("access-control-request-method", "POST")
-            .header("access-control-request-headers", "authorization,content-type")
+            .header(
+                "access-control-request-headers",
+                "authorization,content-type",
+            )
             .body(Body::empty())
             .unwrap();
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -72,7 +72,7 @@ fn existing_regular_file(path: &Path, label: &str) -> Result<bool, LificError> {
         Err(error) => {
             return Err(LificError::Internal(format!(
                 "inspect {label} path: {error}"
-            )))
+            )));
         }
     };
     if !metadata.file_type().is_file() {
@@ -84,9 +84,7 @@ fn existing_regular_file(path: &Path, label: &str) -> Result<bool, LificError> {
     {
         use std::os::unix::fs::MetadataExt;
         if metadata.nlink() != 1 {
-            return Err(LificError::Internal(format!(
-                "{label} path is hard-linked"
-            )));
+            return Err(LificError::Internal(format!("{label} path is hard-linked")));
         }
     }
     Ok(true)
@@ -1402,10 +1400,7 @@ mod tests {
             Some(7),
             "and must proceed once the store is free"
         );
-        assert_eq!(
-            requester.try_with_string_lock(|_| Ok(8)).unwrap(),
-            Some(8)
-        );
+        assert_eq!(requester.try_with_string_lock(|_| Ok(8)).unwrap(), Some(8));
     }
 
     #[test]
@@ -1767,7 +1762,9 @@ mod tests {
             match (&in_memory, &streamed) {
                 (Ok(a), Ok(b)) => assert_eq!(a, b, "disagreement on {declared:?} {bytes:?}"),
                 (Err(_), Err(_)) => {}
-                _ => panic!("streamed and in-memory sniffing disagree: {in_memory:?} vs {streamed:?}"),
+                _ => panic!(
+                    "streamed and in-memory sniffing disagree: {in_memory:?} vs {streamed:?}"
+                ),
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,6 @@
 //! LIF-262: content-addressed file storage for attachments.
 //!
-//! Raw bytes never touch SQLite. Each uploaded blob is written to
+//! Raw bytes never touch `SQLite`. Each uploaded blob is written to
 //! `<data_dir>/attachments/<sha256>`, where `<data_dir>` is the directory
 //! containing the database file (see [`AttachmentStore::from_db_path`]). The
 //! file name IS the content hash, so identical bytes uploaded twice collapse
@@ -97,10 +97,13 @@ fn existing_regular_file(path: &Path, label: &str) -> Result<bool, LificError> {
 /// its own fsync. Without this, a crash right after an upload can leave a
 /// database row pointing at a blob whose directory entry never landed.
 /// Unix only: Windows has no directory handle to sync.
-fn sync_dir(_dir: &Path) -> Result<(), LificError> {
+fn sync_dir(dir: &Path) -> Result<(), LificError> {
+    #[cfg(not(unix))]
+    let _ = dir;
+
     #[cfg(unix)]
     {
-        std::fs::File::open(_dir)
+        std::fs::File::open(dir)
             .and_then(|dir| dir.sync_all())
             .map_err(|e| LificError::Internal(format!("sync directory: {e}")))?;
     }
@@ -262,8 +265,7 @@ impl AttachmentStore {
 
     /// Compute the lowercase hex SHA-256 of a byte slice — the content address.
     pub fn hash_bytes(bytes: &[u8]) -> String {
-        let digest = Sha256::digest(bytes);
-        digest.iter().map(|b| format!("{b:02x}")).collect()
+        crate::auth::hex_encode(&Sha256::digest(bytes))
     }
 
     /// Path of the store's cross-process lock file.
@@ -571,7 +573,7 @@ pub fn sweep_orphans(
 /// `attachments_fts` yet.
 ///
 /// Two populations need this: uploads that predate migration 042 (the
-/// migration can seed filenames from SQLite, but the bytes live on disk where
+/// migration can seed filenames from `SQLite`, but the bytes live on disk where
 /// SQL can't reach them), and any upload whose extraction was interrupted.
 /// Idempotent by construction — the driving query only returns rows with an
 /// empty `extracted_text`, so a second run finds nothing and does nothing.
@@ -635,7 +637,7 @@ pub fn start_gc_task(
             let store = store.clone();
             move || match backfill_attachment_text(&pool, &store) {
                 Ok(n) if n > 0 => {
-                    tracing::info!(indexed = n, "attachment text backfill indexed files")
+                    tracing::info!(indexed = n, "attachment text backfill indexed files");
                 }
                 Ok(_) => {}
                 Err(e) => tracing::warn!(error = %e, "attachment text backfill failed"),
@@ -654,7 +656,7 @@ pub fn start_gc_task(
                 let store = store.clone();
                 move || match sweep_orphans(&pool, &store, ORPHAN_GRACE_SECONDS) {
                     Ok(n) if n > 0 => {
-                        tracing::info!(collected = n, "attachment GC swept orphans")
+                        tracing::info!(collected = n, "attachment GC swept orphans");
                     }
                     Ok(_) => {}
                     Err(e) => tracing::warn!(error = %e, "attachment GC sweep failed"),
@@ -892,8 +894,11 @@ fn read_fully<R: Read>(reader: &mut R, buf: &mut [u8]) -> std::io::Result<usize>
         match reader.read(&mut buf[filled..]) {
             Ok(0) => break,
             Ok(n) => filled += n,
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(e) => return Err(e),
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::Interrupted {
+                    return Err(e);
+                }
+            }
         }
     }
     Ok(filled)
@@ -1032,7 +1037,7 @@ fn sniff_magic(bytes: &[u8]) -> Option<&'static str> {
     None
 }
 
-/// The 16-byte header every SQLite database file starts with, NUL included.
+/// The 16-byte header every `SQLite` database file starts with, NUL included.
 pub const SQLITE_MAGIC: &[u8] = b"SQLite format 3\0";
 
 /// Heuristic executable/script sniff for the signature-less path. Blocks the
@@ -1117,7 +1122,7 @@ pub fn generate_thumbnail(bytes: &[u8]) -> Result<Option<Vec<u8>>, LificError> {
     }
 
     let image = reader_for(bytes)
-        .and_then(|r| r.decode())
+        .and_then(image::ImageReader::decode)
         .map_err(|e| LificError::BadRequest(format!("undecodable image: {e}")))?;
     // `thumbnail` preserves the aspect ratio and fits inside the box, so a
     // 1000x200 strip comes back 480x96 rather than stretched.
@@ -1567,7 +1572,7 @@ mod tests {
                 &sha,
                 "server.log",
                 "text/plain",
-                body.len() as i64,
+                i64::try_from(body.len()).expect("test body length fits i64"),
                 None,
             )
             .unwrap()
@@ -1731,7 +1736,9 @@ mod tests {
             if self.remaining == 0 {
                 return Ok(0);
             }
-            let take = buf.len().min(self.remaining as usize);
+            let take = usize::try_from(self.remaining)
+                .unwrap_or(buf.len())
+                .min(buf.len());
             buf[..take].fill(self.byte);
             self.remaining -= take as u64;
             self.served += take as u64;
@@ -1899,7 +1906,7 @@ mod tests {
         );
     }
 
-    /// QuickTime shares the ISO base media container with mp4 but is not on
+    /// `QuickTime` shares the ISO base media container with mp4 but is not on
     /// the allowlist, so it must not be waved through wearing an mp4 label.
     #[test]
     fn quicktime_is_not_relabelled_as_mp4() {


### PR DESCRIPTION
Follow-up to #44.

This branch starts from PR #44 and applies Clippy's machine-applicable pedantic fixes across the Rust sources, including explicit imports, simpler option/result handling, redundant-closure removal, documentation markup, and a lifetime-safe X-Forwarded-For iteration fix.

If you'd like I could start with a smaller subset, but I figured I'd just get all the lints out of the way in one go and see what the damage is. also pedantic is turbo-picky, we don't quite have to go for all the pedantic rules.

when #44 gets merged we can re-parent this one and it'll make it easier to review.