### PR TITLE
chore: add some new Clippy lints and enforce all locally and in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets -- -D warnings
+        language: system
+        pass_filenames: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ include = [
 ]
 
 [lints.clippy]
+branches_sharing_code = "deny"
 cast_sign_loss = "deny"
+collection_is_never_read = "deny"
 derive_partial_eq_without_eq = "deny"
 format_collect = "deny"
 future_not_send = "deny"
@@ -30,7 +32,9 @@ needless_collect = "deny"
 or_fun_call = "deny"
 redundant_clone = "deny"
 unchecked_time_subtraction = "deny"
+unnecessary_struct_initialization = "deny"
 unnecessary_wraps = "deny"
+useless_let_if_seq = "deny"
 unused_async = "deny"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,15 @@ include = [
 
 [lints.clippy]
 cast_sign_loss = "deny"
+derive_partial_eq_without_eq = "deny"
 format_collect = "deny"
+future_not_send = "deny"
+literal_string_with_formatting_args = "deny"
 map_unwrap_or = "deny"
 match_wildcard_for_single_variants = "deny"
+needless_collect = "deny"
+or_fun_call = "deny"
+redundant_clone = "deny"
 unchecked_time_subtraction = "deny"
 unnecessary_wraps = "deny"
 unused_async = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ include = [
 [lints.clippy]
 format_collect = "deny"
 map_unwrap_or = "deny"
+match_wildcard_for_single_variants = "deny"
+unchecked_time_subtraction = "deny"
 unnecessary_wraps = "deny"
+unused_async = "deny"
 
 [dependencies]
 # HTTP

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
 ]
 
 [lints.clippy]
+cast_sign_loss = "deny"
 format_collect = "deny"
 map_unwrap_or = "deny"
 match_wildcard_for_single_variants = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ include = [
     "README.md",
 ]
 
+[lints.clippy]
+format_collect = "deny"
+map_unwrap_or = "deny"
+unnecessary_wraps = "deny"
+
 [dependencies]
 # HTTP
 axum = { version = "0.8", features = ["json", "multipart", "ws"] }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -73,7 +73,7 @@ pub async fn scope<F: std::future::Future>(ctx: ActorCtx, fut: F) -> F::Output {
 /// The actor for the current execution context.
 /// Task-local (request) → process default (CLI) → system.
 pub fn current() -> ActorCtx {
-    ACTOR.try_with(|a| *a).unwrap_or(ActorCtx {
+    ACTOR.try_with(|a| *a).unwrap_or_else(|_| ActorCtx {
         user_id: None,
         transport: *DEFAULT_TRANSPORT.get().unwrap_or(&Transport::System),
     })

--- a/src/api/activity.rs
+++ b/src/api/activity.rs
@@ -20,7 +20,7 @@ use super::with_read;
 /// `Viewer` gate (LIF-197 scope item 2: single-resource reads resolve
 /// project_id from the target then check). Workspace-level pages
 /// (`project_id = None`) fall back to admin-only.
-async fn require_scope_viewer(
+fn require_scope_viewer(
     db: &DbPool,
     identity: &Option<crate::resolve_caller::ResolvedIdentity>,
     scope: &ActivityScope,
@@ -58,7 +58,7 @@ pub(super) async fn issue_activity(
     Query(q): Query<ActivityQuery>,
 ) -> Result<Json<ActivityFeed>, LificError> {
     let scope = ActivityScope::Issue(id);
-    require_scope_viewer(&db, &identity, &scope).await?;
+    require_scope_viewer(&db, &identity, &scope)?;
     with_read(&db, |conn| list_activity(conn, scope, q.limit, q.offset)).map(Json)
 }
 
@@ -70,7 +70,7 @@ pub(super) async fn page_activity(
     Query(q): Query<ActivityQuery>,
 ) -> Result<Json<ActivityFeed>, LificError> {
     let scope = ActivityScope::Page(id);
-    require_scope_viewer(&db, &identity, &scope).await?;
+    require_scope_viewer(&db, &identity, &scope)?;
     with_read(&db, |conn| list_activity(conn, scope, q.limit, q.offset)).map(Json)
 }
 
@@ -83,7 +83,7 @@ pub(super) async fn plan_activity(
     Query(q): Query<ActivityQuery>,
 ) -> Result<Json<ActivityFeed>, LificError> {
     let scope = ActivityScope::Plan(id);
-    require_scope_viewer(&db, &identity, &scope).await?;
+    require_scope_viewer(&db, &identity, &scope)?;
     with_read(&db, |conn| list_activity(conn, scope, q.limit, q.offset)).map(Json)
 }
 
@@ -96,7 +96,7 @@ pub(super) async fn project_activity(
     Query(q): Query<ActivityQuery>,
 ) -> Result<Json<ActivityFeed>, LificError> {
     let scope = ActivityScope::Project(id);
-    require_scope_viewer(&db, &identity, &scope).await?;
+    require_scope_viewer(&db, &identity, &scope)?;
     with_read(&db, |conn| list_activity(conn, scope, q.limit, q.offset)).map(Json)
 }
 

--- a/src/api/attachments.rs
+++ b/src/api/attachments.rs
@@ -486,8 +486,7 @@ pub(super) async fn download_attachment(
     let requested = headers
         .get(header::RANGE)
         .and_then(|v| v.to_str().ok())
-        .map(|v| parse_range(v, total))
-        .unwrap_or(RangeRequest::Whole);
+        .map_or(RangeRequest::Whole, |v| parse_range(v, total));
 
     let (status, body, content_range) = match requested {
         RangeRequest::Whole => (StatusCode::OK, bytes, None),

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -380,6 +380,7 @@ pub(super) async fn auth_auto_login(
         admin.id,
         Some(settings.session_lifetime_days * 24),
     )?;
+    drop(conn);
 
     let mut headers = HeaderMap::new();
     headers.insert(

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -22,11 +22,10 @@ fn session_cookie(token: &str, expires_at: &str, secure: bool) -> String {
     use chrono::DateTime;
     // Parse expiry for Max-Age calculation; fall back to 30 days
     let max_age = DateTime::parse_from_rfc3339(expires_at)
-        .map(|exp| {
+        .map_or(30 * 24 * 3600, |exp| {
             let exp_utc: DateTime<chrono::Utc> = exp.into();
             (exp_utc - chrono::Utc::now()).num_seconds().max(0)
-        })
-        .unwrap_or(30 * 24 * 3600);
+        });
 
     let secure_attr = if secure { "; Secure" } else { "" };
     format!("lific_token={token}; Path=/; Max-Age={max_age}; HttpOnly{secure_attr}; SameSite=Lax")
@@ -295,9 +294,7 @@ pub(super) async fn auth_login(
     let verified_hash = user.password_hash.clone();
     let (user, session) = db.transaction(|tx| {
         let user = crate::db::queries::users::finalize_login(tx, user.id, &verified_hash)?;
-        let lifetime_days = crate::db::queries::settings::get(tx)
-            .map(|s| s.session_lifetime_days)
-            .unwrap_or(30);
+        let lifetime_days = crate::db::queries::settings::get(tx)?.session_lifetime_days;
         let session =
             crate::db::queries::users::create_session(tx, user.id, Some(lifetime_days * 24))?;
         Ok((user, session))

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -2676,16 +2676,15 @@ mod tests {
         async fn reservations_bound_how_many_password_changes_are_admitted() {
             let f = fixture_with_limiter(2);
             let limiter = f.limiter.clone().expect("limiter");
-            let held: Vec<_> = (0..2)
-                .map(|i| {
-                    crate::ratelimit::Reservation::acquire(
-                        &limiter,
-                        &format!("password_change_ip:10.0.0.{i}"),
-                        &format!("password_change_user:{}", f.user_id),
-                    )
-                    .expect("within budget")
-                })
-                .collect();
+            // Building the array eagerly reserves both slots before the probe.
+            let held: [_; 2] = std::array::from_fn(|i| {
+                crate::ratelimit::Reservation::acquire(
+                    &limiter,
+                    &format!("password_change_ip:10.0.0.{i}"),
+                    &format!("password_change_user:{}", f.user_id),
+                )
+                .expect("within budget")
+            });
 
             let (status, body) =
                 change_password_attempt(&f, &f.session, PASSWORD, "a whole new password").await;
@@ -3995,19 +3994,17 @@ mod tests {
             3,
             std::time::Duration::from_secs(15 * 60),
         ));
-        // Stand in for three requests that have reached the reservation but
-        // not yet finished verifying: exactly the state peek-then-record
-        // could not represent, because nothing was recorded until afterwards.
-        let held: Vec<_> = (0..3)
-            .map(|i| {
-                crate::ratelimit::Reservation::acquire(
-                    &limiter,
-                    &format!("login_ip:10.0.0.{i}"),
-                    "login_id:victim",
-                )
-                .expect("within budget")
-            })
-            .collect();
+        // Building the array eagerly stands in for three requests that have
+        // reserved slots but not yet finished verifying: exactly the state
+        // peek-then-record could not represent.
+        let held: [_; 3] = std::array::from_fn(|i| {
+            crate::ratelimit::Reservation::acquire(
+                &limiter,
+                &format!("login_ip:10.0.0.{i}"),
+                "login_id:victim",
+            )
+            .expect("within budget")
+        });
 
         let app = login_app_with_limiter_arc(limiter.clone(), test_peer());
         let (status, body) = login_attempt(&app, "victim", "10.0.0.99").await;

--- a/src/api/plans.rs
+++ b/src/api/plans.rs
@@ -399,7 +399,6 @@ mod tests {
         let first = body_json(json_get(&app, &format!("/api/plans?project_id={project_id}&order_by=id&limit=2")).await).await;
         let first = first.as_array().unwrap();
         assert_eq!(first.len(), 2);
-        let first_ids = first.iter().map(|plan| plan["id"].as_i64().unwrap()).collect::<Vec<_>>();
         let cursor_id = first[1]["id"].as_i64().unwrap();
 
         let response = json_get(
@@ -413,7 +412,12 @@ mod tests {
         let second = body_json(response).await;
         let second = second.as_array().unwrap();
         assert_eq!(second.len(), 1);
-        assert!(!first_ids.contains(&second[0]["id"].as_i64().unwrap()));
+        let second_id = second[0]["id"].as_i64().unwrap();
+        assert!(
+            !first
+                .iter()
+                .any(|plan| plan["id"].as_i64().unwrap() == second_id)
+        );
 
         for query in [
             format!("/api/plans?project_id={project_id}&before_id={cursor_id}"),

--- a/src/api/plans.rs
+++ b/src/api/plans.rs
@@ -229,10 +229,10 @@ pub(super) async fn update_step(
         if let Some(issue) = input.issue_id {
             plans::set_step_issue(conn, step_id, issue)?;
         }
-        let mut effect = None;
-        if let Some(done) = input.done {
-            effect = Some(plans::set_step_done(conn, step_id, done)?);
-        }
+        let effect = input
+            .done
+            .map(|done| plans::set_step_done(conn, step_id, done))
+            .transpose()?;
         if input.move_to_root.unwrap_or(false)
             || input.move_parent_step_id.is_some()
             || input.move_position.is_some()

--- a/src/api/projects.rs
+++ b/src/api/projects.rs
@@ -277,7 +277,7 @@ pub(super) async fn get_board(
             "module" => issue
                 .module_id
                 .and_then(|m| module_names.get(&m).cloned())
-                .unwrap_or("unassigned".into()),
+                .unwrap_or_else(|| "unassigned".into()),
             _ => issue.status.to_string(),
         };
         board.entry(key).or_default().push(issue);

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2146,7 +2146,7 @@ mod tests {
         let _key2 = create_api_key(&pool, &manager, "key-2", None).unwrap();
 
         // Extract key_id from key1 and look it up
-        let secure_key = SecureString::from(key1.clone());
+        let secure_key = SecureString::from(key1);
         let key_id = manager.extract_key_id(&secure_key);
 
         let conn = pool.read().unwrap();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -378,6 +378,7 @@ pub fn revoke_api_key(db: &DbPool, name: &str) -> Result<(), crate::error::Lific
         "UPDATE api_keys SET revoked = 1 WHERE name = ?1 AND revoked = 0",
         params![name],
     )?;
+    drop(conn);
     if changed == 0 {
         return Err(crate::error::LificError::NotFound(format!(
             "no active key named '{name}'"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -28,7 +28,13 @@ pub struct AuthState {
 /// LIF-383: the one hex encoder in the tree. Four copies of this loop used to
 /// live in oauth.rs, mcp/mod.rs, auth.rs and db/queries/users.rs.
 pub(crate) fn hex_encode(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
 }
 
 /// SHA-256 a byte slice and return the lowercase hex digest. This is how every
@@ -3643,9 +3649,7 @@ mod tests {
             format!(
                 "{}|{}",
                 actor.transport.as_str(),
-                identity
-                    .map(|i| i.transport.as_str().to_string())
-                    .unwrap_or_else(|| "none".into())
+                identity.map_or_else(|| "none".into(), |i| i.transport.as_str().to_string())
             )
         }
 

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -595,7 +595,7 @@ mod tests {
 
         assert!(require_role_conn(&conn, &id(viewer.clone()), project, Role::Viewer).is_ok());
         assert!(require_role_conn(&conn, &id(viewer.clone()), project, Role::Maintainer).is_err());
-        assert!(require_role_conn(&conn, &id(viewer.clone()), project, Role::Lead).is_err());
+        assert!(require_role_conn(&conn, &id(viewer), project, Role::Lead).is_err());
     }
 
     #[test]
@@ -611,7 +611,7 @@ mod tests {
         assert!(
             require_role_conn(&conn, &id(maintainer.clone()), project, Role::Maintainer).is_ok()
         );
-        assert!(require_role_conn(&conn, &id(maintainer.clone()), project, Role::Lead).is_err());
+        assert!(require_role_conn(&conn, &id(maintainer), project, Role::Lead).is_err());
     }
 
     #[test]
@@ -713,7 +713,7 @@ mod tests {
         let project = seed_project(&conn, "LGO"); // unowned
 
         let identity = first_admin_identity(&conn).expect("first admin resolves");
-        assert!(require_role_conn(&conn, &Some(identity.clone()), project, Role::Lead).is_ok());
+        assert!(require_role_conn(&conn, &Some(identity), project, Role::Lead).is_ok());
         assert!(require_role_conn(&conn, &None, project, Role::Lead).is_err());
     }
 
@@ -758,9 +758,9 @@ mod tests {
         .unwrap()
         .id;
 
-        assert!(require_role_conn(&conn, &id(lead.clone()), project, Role::Lead).is_ok());
-        assert!(require_role_conn(&conn, &id(admin.clone()), project, Role::Lead).is_ok());
-        assert!(require_role_conn(&conn, &id(regular.clone()), project, Role::Lead).is_err());
+        assert!(require_role_conn(&conn, &id(lead), project, Role::Lead).is_ok());
+        assert!(require_role_conn(&conn, &id(admin), project, Role::Lead).is_ok());
+        assert!(require_role_conn(&conn, &id(regular), project, Role::Lead).is_err());
         assert!(require_role_conn(&conn, &None, project, Role::Lead).is_err());
 
         // Additive: a co-lead granted purely via project_members (no
@@ -930,7 +930,7 @@ mod tests {
         );
         // The resolved-first-admin identity an unbound key produces is unrestricted.
         assert_eq!(
-            visible_project_ids(&pool, &Some(identity.clone())).unwrap(),
+            visible_project_ids(&pool, &Some(identity)).unwrap(),
             None,
             "resolved-first-admin (unbound key) sees all projects"
         );

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -455,6 +455,10 @@ mod tests {
     /// the gates — only `user` drives membership/admin checks). Mirrors what
     /// [`crate::resolve_caller`] produces in production for a credential that
     /// already names a user.
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "test helper mirrors the optional production identity API"
+    )]
     fn id(user: AuthUser) -> Option<ResolvedIdentity> {
         Some(ResolvedIdentity {
             user,

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -474,12 +474,7 @@ mod tests {
         queries::users::first_admin(conn)
             .unwrap()
             .map(|admin| ResolvedIdentity {
-                user: AuthUser {
-                    id: admin.id,
-                    username: admin.username,
-                    display_name: admin.display_name,
-                    is_admin: admin.is_admin,
-                },
+                user: admin,
                 transport: Transport::Api,
             })
     }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -167,8 +167,7 @@ fn run_backup(
     match dump::write_dump(pool, db_path, &backup_path) {
         Ok(manifest) => {
             let size = std::fs::metadata(&backup_path)
-                .map(|m| m.len())
-                .unwrap_or(0);
+                .map_or(0, |m| m.len());
             info!(
                 path = %backup_path.display(),
                 size_kb = size / 1024,

--- a/src/cli/connect/mod.rs
+++ b/src/cli/connect/mod.rs
@@ -690,7 +690,7 @@ pub fn run(
         base,
         key_source.as_ref(),
         manager.as_ref(),
-    )?;
+    );
 
     // AGENTS.md (LIF-251).
     let agents_md = maybe_write_agents_md(&args, base, stdin_tty)?;
@@ -715,9 +715,8 @@ pub fn run(
 }
 
 /// Write (or render, under `--dry-run`) every selected client, minting each
-/// client's own key as it goes (LIF-259). Errors only on a key-minting failure;
-/// per-client write failures and skips are recorded as outcomes so the run
-/// continues.
+/// client's own key as it goes (LIF-259). Per-client key-minting/write failures
+/// and skips are recorded as outcomes so the run continues.
 fn write_all_clients(
     selected: &[String],
     args: &ConnectArgs,
@@ -726,7 +725,7 @@ fn write_all_clients(
     base: &PathBase,
     key_source: Option<&KeySource>,
     manager: Option<&api_keys_simplified::ApiKeyManagerV0>,
-) -> Result<Vec<ClientOutcome>, String> {
+) -> Vec<ClientOutcome> {
     let mut outcomes = Vec::new();
     for id in selected {
         let Some(spec) = clients::find_client(id) else {
@@ -858,7 +857,7 @@ fn write_all_clients(
             }
         }
     }
-    Ok(outcomes)
+    outcomes
 }
 
 /// Decide whether and how to touch AGENTS.md for this run.

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -96,7 +96,7 @@ fn render_from(
     } else {
         Action::Created
     };
-    let existing_str = existing.map(|e| e.contents.as_str()).unwrap_or("");
+    let existing_str = existing.map_or("", |e| e.contents.as_str());
     let contents = match format {
         Format::Json => render_json(existing_str, entry)?,
         Format::Toml => render_toml(existing_str, entry)?,
@@ -110,7 +110,7 @@ fn render_from(
 pub fn write(path: &Path, format: Format, entry: &CompiledEntry) -> Result<Action, WriteError> {
     let existing = read_existing(path)?;
     let rendered = render_from(existing.as_ref(), format, entry)?;
-    let parent_existed = path.parent().map(|parent| parent.exists()).unwrap_or(true);
+    let parent_existed = path.parent().is_none_or(|parent| parent.exists());
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
@@ -179,6 +179,7 @@ pub fn write(path: &Path, format: Format, entry: &CompiledEntry) -> Result<Actio
 /// `connect` cannot leave the config missing even though the write reported
 /// success. Unix only: Windows exposes no directory handle to sync, and
 /// `fsync` on a directory has no meaning there.
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn sync_parent_dir(_dir: &Path) -> Result<(), WriteError> {
     #[cfg(unix)]
     {
@@ -191,6 +192,7 @@ fn sync_parent_dir(_dir: &Path) -> Result<(), WriteError> {
     Ok(())
 }
 
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn set_private_file(_file: &std::fs::File) -> Result<(), WriteError> {
     #[cfg(unix)]
     {
@@ -202,6 +204,7 @@ fn set_private_file(_file: &std::fs::File) -> Result<(), WriteError> {
     Ok(())
 }
 
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn set_private_dir(_path: &Path) -> Result<(), WriteError> {
     #[cfg(unix)]
     {

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -463,7 +463,7 @@ fn json_to_toml_value(v: &serde_json::Value) -> Result<toml_edit::Item, WriteErr
             }
             Ok(Item::Value(Value::InlineTable(inline)))
         }
-        other => Err(WriteError::new(format!("unsupported TOML value: {other}"))),
+        serde_json::Value::Null => Err(WriteError::new("unsupported TOML value: null")),
     }
 }
 

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -300,8 +300,7 @@ pub fn delete(base_url: &str) -> bool {
     let key = normalize_base_url(base_url);
     let kr = keyring_delete(&key);
     let file = default_file_path()
-        .map(|p| FileStore::new(p).delete(&key).unwrap_or(false))
-        .unwrap_or(false);
+        .is_some_and(|p| FileStore::new(p).delete(&key).unwrap_or(false));
     kr || file
 }
 

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -167,6 +167,7 @@ fn issue(
                     ..Default::default()
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&issue);
@@ -212,6 +213,7 @@ fn issue(
                     ..Default::default()
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&issue);
@@ -269,6 +271,7 @@ fn project(
                     ..Default::default()
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&project);
@@ -293,6 +296,7 @@ fn project(
                     ..Default::default()
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&project);
@@ -388,6 +392,7 @@ fn page(pool: &DbPool, action: &PageAction, json: bool) -> Result<(), Box<dyn st
                     ..Default::default()
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&page);
@@ -425,6 +430,7 @@ fn page(pool: &DbPool, action: &PageAction, json: bool) -> Result<(), Box<dyn st
                     ..Default::default()
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&page);
@@ -558,6 +564,7 @@ fn comment(
                 user_id,
                 content,
             )?;
+            drop(conn);
 
             if json {
                 print_json(&comment);
@@ -607,6 +614,7 @@ fn module(
                     emoji: None,
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&module);
@@ -635,6 +643,7 @@ fn module(
                     ..Default::default()
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&module);
@@ -648,6 +657,7 @@ fn module(
             let project_id = queries::resolve_project_identifier(&conn, project)?;
             let module_id = queries::resolve_module_name(&conn, project_id, name)?;
             queries::delete_module(&conn, module_id)?;
+            drop(conn);
 
             if json {
                 print_json(&render::Deleted::named(name));
@@ -694,6 +704,7 @@ fn label(
                     color: color.clone(),
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&label);
@@ -719,6 +730,7 @@ fn label(
                     color: color.clone(),
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&label);
@@ -732,6 +744,7 @@ fn label(
             let project_id = queries::resolve_project_identifier(&conn, project)?;
             let label_id = queries::resolve_label_name(&conn, project_id, name)?;
             queries::delete_label(&conn, label_id)?;
+            drop(conn);
 
             if json {
                 print_json(&render::Deleted::named(name));
@@ -774,6 +787,7 @@ fn folder(
                     name: name.clone(),
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&folder);
@@ -797,6 +811,7 @@ fn folder(
                     name: Some(new_name.clone()),
                 },
             )?;
+            drop(conn);
 
             if json {
                 print_json(&folder);
@@ -810,6 +825,7 @@ fn folder(
             let project_id = queries::resolve_project_identifier(&conn, project)?;
             let folder_id = queries::resolve_folder_name(&conn, project_id, name)?;
             queries::delete_folder(&conn, folder_id)?;
+            drop(conn);
 
             if json {
                 print_json(&render::Deleted::named(name));

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -1004,7 +1004,7 @@ impl HttpBackend {
         Ok(response.json().await?)
     }
 
-    async fn send_json<T: Serialize + ?Sized>(
+    async fn send_json<T: Serialize + Sync + ?Sized>(
         &self,
         method: Method,
         path: &str,

--- a/src/cli/key.rs
+++ b/src/cli/key.rs
@@ -35,7 +35,7 @@ pub fn run(
                 expires.as_deref(),
                 owner,
             )?;
-            let assigned = user.clone();
+            let assigned = user;
 
             if json {
                 let out = serde_json::json!({

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -360,7 +360,7 @@ fn finish(args: &LoginArgs, base: &str, outcome: PollOutcome, json: bool) -> Res
 }
 
 /// `lific logout`: delete the stored credential and best-effort revoke it.
-pub fn run_logout(url: Option<&str>, cfg: &Config, json: bool) -> Result<(), String> {
+pub fn run_logout(url: Option<&str>, cfg: &Config, json: bool) {
     let base = resolve_base_url(url, cfg);
     // Grab the token first so we can revoke it before deleting.
     let existing = crate::cli::credentials::load(&base);
@@ -385,7 +385,6 @@ pub fn run_logout(url: Option<&str>, cfg: &Config, json: bool) -> Result<(), Str
     } else {
         crate::cli::ui::info(format!("No stored credential for {base}."));
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -196,7 +196,7 @@ impl DeviceFlow for HttpDeviceFlow {
             .send()
             .map_err(|e| format!("token poll failed: {e}"))?;
         let status = resp.status();
-        let body: serde_json::Value = resp.json().unwrap_or(serde_json::json!({}));
+        let body: serde_json::Value = resp.json().unwrap_or_else(|_| serde_json::json!({}));
         if status.is_success() {
             let token = body
                 .get("access_token")

--- a/src/cli/member.rs
+++ b/src/cli/member.rs
@@ -69,6 +69,7 @@ pub fn run(
                         Err(e) => return Err(e.into()),
                     }
                 }
+                drop(conn);
                 if json {
                     let out = serde_json::json!({
                         "user": u.username,
@@ -94,6 +95,7 @@ pub fn run(
                 let ident = project.expect("clap: --project required unless --all");
                 let pid = db::queries::resolve_project_identifier(&conn, &ident)?;
                 let member = db::queries::members::add_member(&conn, pid, u.id, &role)?;
+                drop(conn);
                 if json {
                     let out = serde_json::json!({
                         "project": ident,
@@ -119,6 +121,7 @@ pub fn run(
             let u = db::queries::users::get_user_by_username(&conn, &user)?;
             let pid = db::queries::resolve_project_identifier(&conn, &project)?;
             let member = db::queries::members::change_role(&conn, pid, u.id, &role)?;
+            drop(conn);
             if json {
                 let out = serde_json::json!({
                     "project": project,
@@ -138,6 +141,7 @@ pub fn run(
             let u = db::queries::users::get_user_by_username(&conn, &user)?;
             let pid = db::queries::resolve_project_identifier(&conn, &project)?;
             db::queries::members::remove_member_guarded(&conn, pid, u.id)?;
+            drop(conn);
             if json {
                 let out = serde_json::json!({
                     "project": project,

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -118,8 +118,7 @@ pub fn detect() -> Option<Manager> {
         let ok = Command::new("systemctl")
             .args(["--user", "show", "--property=Version"])
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
+            .is_ok_and(|o| o.status.success());
         if ok {
             return Some(Manager::SystemdUser);
         }
@@ -252,6 +251,10 @@ fn xml_escape(s: &str) -> String {
 /// public enum: a caller can construct `Launchd` on any platform, and a
 /// wrong-platform request deserves a message, not a panic.
 #[cfg(unix)]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "the non-unix implementation can fail and callers are platform-neutral"
+)]
 fn launchd_domain() -> Result<String, String> {
     // POSIX guarantees getuid() always succeeds and sets no errno.
     Ok(format!("gui/{}", unsafe { libc::getuid() }))
@@ -315,8 +318,7 @@ pub fn install(manager: Manager, plan: &ServicePlan) -> Result<InstallReport, St
             let linger = Command::new("loginctl")
                 .arg("enable-linger")
                 .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
+                .is_ok_and(|s| s.success());
             Ok(InstallReport {
                 manager: manager.label().into(),
                 definition: path.display().to_string(),
@@ -385,13 +387,11 @@ pub fn status(manager: Manager) -> Result<StatusReport, String> {
         Manager::SystemdUser => Command::new("systemctl")
             .args(["--user", "is-active", "--quiet", SYSTEMD_UNIT_NAME])
             .status()
-            .map(|s| s.success())
-            .unwrap_or(false),
+            .is_ok_and(|s| s.success()),
         Manager::Launchd => Command::new("launchctl")
             .args(["print", &format!("{}/{LAUNCHD_LABEL}", launchd_domain()?)])
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false),
+            .is_ok_and(|o| o.status.success()),
     };
     Ok(StatusReport {
         manager: manager.label().into(),

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -45,8 +45,8 @@ pub fn run(
             let user = db::queries::users::create_user(
                 &conn,
                 &db::models::CreateUser {
-                    username: username.clone(),
-                    email: email.clone(),
+                    username,
+                    email,
                     password: pw,
                     display_name: None,
                     is_admin: admin,

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -53,6 +53,7 @@ pub fn run(
                     is_bot: bot,
                 },
             )?;
+            drop(conn);
 
             if json {
                 let out = serde_json::json!({
@@ -138,6 +139,7 @@ pub fn run(
                 db::queries::users::update_password(&conn, user.id, &pw)?;
                 db::queries::users::lock_down_account(&conn, user.id)
             })?;
+            drop(conn);
 
             if json {
                 let out = serde_json::json!({

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ struct ConfigFile {
 /// was read from. Fails closed on symlinks: [`read_config_file`] opens with
 /// `O_NOFOLLOW`, so a symlinked config never produces a [`ConfigFile`] to
 /// tighten in the first place.
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn tighten_config_permissions(_config: &ConfigFile) -> std::io::Result<()> {
     #[cfg(unix)]
     {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -341,6 +341,7 @@ fn secure_parent(path: &Path) -> Result<(), LificError> {
     Ok(())
 }
 
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn secure_file(_path: &Path) -> Result<(), LificError> {
     #[cfg(unix)]
     {

--- a/src/db/queries/issues.rs
+++ b/src/db/queries/issues.rs
@@ -1283,7 +1283,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].title, "Blocked");
         // Its unresolved blocker is surfaced as blocked_by.
-        assert_eq!(result[0].blocked_by, vec![blocker.identifier.clone()]);
+        assert_eq!(result[0].blocked_by, vec![blocker.identifier]);
     }
 
     #[test]

--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -94,9 +94,10 @@ impl<T> Page<T> {
     /// Split rows fetched with [`over_fetch`] into the page the caller asked
     /// for, plus the `has_more` the extra row implies.
     pub fn from_over_fetch(mut items: Vec<T>, limit: i64) -> Self {
-        let has_more = items.len() as i64 > limit;
+        let limit = usize::try_from(limit.max(0)).unwrap_or(usize::MAX);
+        let has_more = items.len() > limit;
         if has_more {
-            items.truncate(limit.max(0) as usize);
+            items.truncate(limit);
         }
         Self { items, has_more }
     }
@@ -183,7 +184,7 @@ pub use search::*;
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, NO_LIMIT, page, page_unbounded, page_with,
+        DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, NO_LIMIT, Page, page, page_unbounded, page_with,
         unescape_text,
     };
 
@@ -246,6 +247,24 @@ mod tests {
         assert_eq!(page_unbounded(Some(-5), None).0, 1);
         assert_eq!(page_unbounded(Some(i64::MAX), None).0, MAX_PAGE_LIMIT);
         assert_eq!(page_unbounded(Some(5), Some(-5)).1, 0);
+    }
+
+    #[test]
+    fn page_from_over_fetch_handles_signed_bounds() {
+        assert_eq!(
+            Page::from_over_fetch(vec![1, 2], -1),
+            Page {
+                items: Vec::new(),
+                has_more: true,
+            }
+        );
+        assert_eq!(
+            Page::from_over_fetch(vec![1, 2], i64::MAX),
+            Page {
+                items: vec![1, 2],
+                has_more: false,
+            }
+        );
     }
 
     #[test]

--- a/src/db/queries/settings.rs
+++ b/src/db/queries/settings.rs
@@ -93,28 +93,29 @@ fn defaults() -> InstanceSettings {
 /// (no server start / `ensure` / `update` has run), returns code defaults so
 /// this is safe on a read-only pool connection.
 pub fn get(conn: &Connection) -> Result<InstanceSettings, LificError> {
-    let found = conn
-        .query_row(
-            "SELECT allow_signup, instance_name, signup_email_domains,
+    match conn.query_row(
+        "SELECT allow_signup, instance_name, signup_email_domains,
                     session_lifetime_days, login_message, web_auto_login,
                     authz_enforced
              FROM instance_settings WHERE id = 1",
-            [],
-            |row| {
-                let domains: String = row.get(2)?;
-                Ok(InstanceSettings {
-                    allow_signup: row.get::<_, i64>(0)? != 0,
-                    instance_name: row.get(1)?,
-                    signup_email_domains: parse_domains(&domains),
-                    session_lifetime_days: row.get(3)?,
-                    login_message: row.get(4)?,
-                    web_auto_login: row.get::<_, i64>(5)? != 0,
-                    authz_enforced: row.get::<_, i64>(6)? != 0,
-                })
-            },
-        )
-        .ok();
-    Ok(found.unwrap_or_else(defaults))
+        [],
+        |row| {
+            let domains: String = row.get(2)?;
+            Ok(InstanceSettings {
+                allow_signup: row.get::<_, i64>(0)? != 0,
+                instance_name: row.get(1)?,
+                signup_email_domains: parse_domains(&domains),
+                session_lifetime_days: row.get(3)?,
+                login_message: row.get(4)?,
+                web_auto_login: row.get::<_, i64>(5)? != 0,
+                authz_enforced: row.get::<_, i64>(6)? != 0,
+            })
+        },
+    ) {
+        Ok(settings) => Ok(settings),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(defaults()),
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Apply a partial update and return the new settings. Validates lengths,
@@ -261,6 +262,15 @@ mod tests {
         assert!(s.login_message.is_none());
         assert!(!s.web_auto_login, "single-user auto-login is off by default");
         assert!(!s.authz_enforced, "authorization enforcement is off by default");
+    }
+
+    #[test]
+    fn get_propagates_database_errors() {
+        let pool = conn();
+        let c = pool.write().unwrap();
+        c.execute("DROP TABLE instance_settings", []).unwrap();
+
+        assert!(matches!(get(&c), Err(LificError::Database(_))));
     }
 
     #[test]

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -474,11 +474,16 @@ fn derive_username(conn: &Connection, display_name: &str) -> Result<String, Lifi
     let base = if slug.is_empty() { "admin".to_string() } else { slug };
     let mut candidate = base.clone();
     let mut n = 1;
-    while get_user_by_username(conn, &candidate).is_ok() {
-        candidate = format!("{base}-{n}");
-        n += 1;
+    loop {
+        match get_user_by_username(conn, &candidate) {
+            Ok(_) => {
+                candidate = format!("{base}-{n}");
+                n += 1;
+            }
+            Err(LificError::NotFound(_)) => return Ok(candidate),
+            Err(error) => return Err(error),
+        }
     }
-    Ok(candidate)
 }
 
 /// Create the first human admin on a fresh install — a passwordless operator.
@@ -873,7 +878,7 @@ pub fn lock_down_account(conn: &Connection, user_id: i64) -> Result<(), LificErr
 /// Generate a session token with the lific_sess_ prefix.
 fn generate_session_token() -> String {
     let bytes: [u8; 32] = rand::random();
-    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    let hex = crate::auth::hex_encode(&bytes);
     format!("lific_sess_{hex}")
 }
 
@@ -915,7 +920,7 @@ pub fn assign_key_to_user(
 /// guaranteeing `authenticate` can never succeed against it.
 fn unusable_password_hash() -> Result<String, LificError> {
     let random_pw: [u8; 32] = rand::random();
-    let random_pw_hex: String = random_pw.iter().map(|b| format!("{b:02x}")).collect();
+    let random_pw_hex = crate::auth::hex_encode(&random_pw);
     hash_password(&random_pw_hex)
 }
 
@@ -1182,16 +1187,14 @@ pub fn find_bot_legacy_by_tool_prefix(
 /// independent of OAuth token expiry (the agent self-heals via re-auth).
 /// Used to refuse re-connecting a tool that's already connected via either door.
 pub fn bot_is_connected(conn: &Connection, bot_id: i64) -> Result<bool, LificError> {
-    let has: bool = conn
-        .query_row(
-            "SELECT
+    conn.query_row(
+        "SELECT
                 EXISTS(SELECT 1 FROM api_keys WHERE user_id = ?1 AND revoked = 0)
                 OR EXISTS(SELECT 1 FROM oauth_tokens WHERE user_id = ?1 AND revoked = 0)",
-            params![bot_id],
-            |row| row.get(0),
-        )
-        .unwrap_or(false);
-    Ok(has)
+        params![bot_id],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
 }
 
 /// Ensure a per-tool bot exists for `owner_id`, reusing an existing one rather
@@ -1515,6 +1518,18 @@ mod tests {
             !has_human_users(&conn).unwrap(),
             "a bot-only instance still reads as having no human accounts"
         );
+    }
+
+    #[test]
+    fn derive_username_propagates_database_errors() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        conn.execute("DROP TABLE users", []).unwrap();
+
+        assert!(matches!(
+            derive_username(&conn, "Blake"),
+            Err(LificError::Database(_))
+        ));
     }
 
     // ── ensure_bot (LIFIC-13) ────────────────────────────────
@@ -2365,6 +2380,18 @@ mod tests {
             "a bot with only revoked credentials must list as disconnected"
         );
         assert!(!bot_is_connected(&conn, bot.id).unwrap());
+    }
+
+    #[test]
+    fn bot_is_connected_propagates_database_errors() {
+        let pool = test_db();
+        let conn = pool.write().unwrap();
+        conn.execute("DROP TABLE oauth_tokens", []).unwrap();
+
+        assert!(matches!(
+            bot_is_connected(&conn, 1),
+            Err(LificError::Database(_))
+        ));
     }
 
     #[test]

--- a/src/db/queries/users.rs
+++ b/src/db/queries/users.rs
@@ -1745,19 +1745,18 @@ mod tests {
             test_create_user(&conn).id
         };
 
-        let ids: Vec<i64> = std::thread::scope(|scope| {
-            let handles: Vec<_> = (0..4)
-                .map(|_| {
-                    let pool = pool.clone();
-                    scope.spawn(move || {
-                        let conn = pool.write().unwrap();
-                        ensure_bot(&conn, owner_id, "opencode", "OpenCode")
-                            .expect("ensure_bot must not fail on a repeat connect")
-                            .id
-                    })
+        let ids: [i64; 4] = std::thread::scope(|scope| {
+            // Build every handle before joining so the connects actually overlap.
+            let handles: [_; 4] = std::array::from_fn(|_| {
+                let pool = pool.clone();
+                scope.spawn(move || {
+                    let conn = pool.write().unwrap();
+                    ensure_bot(&conn, owner_id, "opencode", "OpenCode")
+                        .expect("ensure_bot must not fail on a repeat connect")
+                        .id
                 })
-                .collect();
-            handles.into_iter().map(|h| h.join().unwrap()).collect()
+            });
+            handles.map(|handle| handle.join().unwrap())
         });
 
         assert!(

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -214,6 +214,13 @@ fn snapshot_db(pool: &DbPool, dest: &TempFile) -> Result<(), LificError> {
 }
 
 /// Set 0600 permissions on a file (owner-only) on Unix. No-op elsewhere.
+#[cfg_attr(
+    not(unix),
+    expect(
+        clippy::unnecessary_wraps,
+        reason = "keep one fallible cross-platform dump API"
+    )
+)]
 fn set_owner_only(path: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -2207,7 +2207,6 @@ mod tests {
 
         let (done_tx, done_rx) = sync_channel::<()>(1);
         let dumper = std::thread::spawn({
-            let db_path = db_path.clone();
             let out = out.clone();
             move || {
                 let result =
@@ -2261,7 +2260,6 @@ mod tests {
 
         let (done_tx, done_rx) = sync_channel::<()>(1);
         let restorer = std::thread::spawn({
-            let archive = archive.clone();
             let dst_db = dst_db.clone();
             move || {
                 let result = run_restore(&archive, &dst_db, false);

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -228,6 +228,7 @@ fn set_owner_only(path: &Path) -> std::io::Result<()> {
 }
 
 /// Set 0600 on an already-open handle, so no pathname is resolved again.
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn set_owner_only_file(file: &File) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -242,6 +243,7 @@ fn set_owner_only_file(file: &File) -> std::io::Result<()> {
 }
 
 /// Set 0700 permissions on a directory (owner-only) on Unix. No-op elsewhere.
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn set_owner_only_dir(path: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -257,6 +259,7 @@ fn set_owner_only_dir(path: &Path) -> std::io::Result<()> {
 
 /// fsync a directory so a rename into it is durable. Unix only: Windows has no
 /// directory handle to sync, and its rename ordering does not need one.
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn sync_dir(path: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -588,8 +591,7 @@ fn open_verified_blob(path: &Path) -> Result<Option<VerifiedBlob>, LificError> {
         .modified()
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_secs());
 
     #[cfg(unix)]
     let identity = {
@@ -681,11 +683,7 @@ impl<R: Read> HashingReader<R> {
     }
 
     fn hex_digest(self) -> String {
-        self.hasher
-            .finalize()
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect()
+        crate::auth::hex_encode(&self.hasher.finalize())
     }
 }
 
@@ -700,6 +698,7 @@ impl<R: Read> Read for HashingReader<R> {
 /// Refuse to publish a dump onto a destination another user could have
 /// prepared: a symlink or hard link at the target, a symlinked parent, or a
 /// group/world-writable parent without the sticky bit.
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn validate_dump_destination(out_path: &Path) -> Result<(), LificError> {
     #[cfg(unix)]
     {
@@ -748,8 +747,7 @@ fn append_bytes<W: std::io::Write>(
     header.set_mtime(
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0),
+            .map_or(0, |d| d.as_secs()),
     );
     header.set_cksum();
     tar.append_data(&mut header, name, bytes)
@@ -971,8 +969,7 @@ fn hash_file(path: &Path) -> Result<String, LificError> {
         }
         digest.update(&buffer[..read]);
     }
-    let digest = digest.finalize();
-    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+    Ok(crate::auth::hex_encode(&digest.finalize()))
 }
 
 fn validate_attachment_schema(conn: &rusqlite::Connection) -> Result<(), LificError> {
@@ -1426,9 +1423,7 @@ fn read_manifest(archive: &Path, limits: &RestoreLimits) -> Result<Manifest, Lif
 /// may still be running (best-effort — see command help).
 fn wal_is_hot(db_path: &Path) -> bool {
     let wal = PathBuf::from(format!("{}-wal", db_path.display()));
-    std::fs::metadata(&wal)
-        .map(|m| m.len() > 0)
-        .unwrap_or(false)
+    std::fs::metadata(&wal).is_ok_and(|m| m.len() > 0)
 }
 
 /// Run `lific restore`: validate the archive, then stage-extract it into the
@@ -1471,8 +1466,7 @@ pub fn run_restore_with(
     let data_dir = db_path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("."));
+        .map_or_else(|| PathBuf::from("."), |p| p.to_path_buf());
     std::fs::create_dir_all(&data_dir)
         .map_err(|e| LificError::Internal(format!("create data dir: {e}")))?;
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1643,8 +1643,7 @@ fn install_restore(
     db_path: &Path,
     restore_id: &str,
 ) -> Result<Option<PathBuf>, LificError> {
-    let mut moved_existing_to: Option<PathBuf> = None;
-    if db_path.exists() {
+    let moved_existing_to = if db_path.exists() {
         checkpoint_db_file(db_path)?;
         let dest = PathBuf::from(format!("{}.pre-restore-{restore_id}", db_path.display()));
         if std::fs::symlink_metadata(&dest).is_ok() {
@@ -1666,8 +1665,10 @@ fn install_restore(
                 return Err(rollback_moved_db(&dest, db_path, cause));
             }
         }
-        moved_existing_to = Some(dest);
-    }
+        Some(dest)
+    } else {
+        None
+    };
     let moved = moved_existing_to.clone();
     let fail = move |cause: LificError| fail_after_move(moved.as_deref(), db_path, cause);
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1173,7 +1173,6 @@ fn validate_staged_database(
             if !crate::storage::valid_sha256(&sha)
                 || min_size < 0
                 || min_size != max_size
-                || max_size as u64 > limits.max_attachment_bytes
                 || invalid_mimes != 0
             {
                 return Err(LificError::BadRequest(
@@ -1181,7 +1180,18 @@ fn validate_staged_database(
                         .into(),
                 ));
             }
-            let size = max_size as u64;
+            let size = u64::try_from(max_size).map_err(|_| {
+                LificError::BadRequest(
+                    "staged attachment metadata has an invalid content address, MIME, or size"
+                        .into(),
+                )
+            })?;
+            if size > limits.max_attachment_bytes {
+                return Err(LificError::BadRequest(
+                    "staged attachment metadata has an invalid content address, MIME, or size"
+                        .into(),
+                ));
+            }
             let path = staging.join("attachments").join(&sha);
             let metadata = std::fs::metadata(&path).map_err(|_| {
                 LificError::BadRequest(format!(

--- a/src/export.rs
+++ b/src/export.rs
@@ -1243,7 +1243,7 @@ mod tests {
 
             let output = scratch_dir("bundle-escape");
             let error = unpack_zip_to_directory(&archive, output.path())
-                .expect_err("'{escape}' should be rejected");
+                .expect_err(&format!("'{escape}' should be rejected"));
             assert!(
                 error.to_string().contains("outside the output directory"),
                 "unexpected error for '{escape}': {error}"
@@ -1272,7 +1272,7 @@ mod tests {
                 },
                 &output,
             )
-            .expect_err("'{escape}' should be rejected");
+            .expect_err(&format!("'{escape}' should be rejected"));
             assert!(
                 error.to_string().contains("outside the output directory"),
                 "unexpected error for '{escape}': {error}"

--- a/src/import/github.rs
+++ b/src/import/github.rs
@@ -230,8 +230,7 @@ pub fn map_issue(
             author: c
                 .user
                 .as_ref()
-                .map(|u| u.login.clone())
-                .unwrap_or_else(|| "ghost".to_string()),
+                .map_or_else(|| "ghost".to_string(), |u| u.login.clone()),
             created_at: c.created_at.clone(),
             body: c.body.clone().unwrap_or_default(),
         })

--- a/src/import/jira.rs
+++ b/src/import/jira.rs
@@ -134,11 +134,9 @@ fn render_list(node: &serde_json::Value, out: &mut String, ordered: bool) {
         render_block_children(item, &mut item_body);
         // Prefix the first line with the marker; indent continuation lines.
         let mut lines = item_body.lines();
+        out.push_str(&marker);
         if let Some(first) = lines.next() {
-            out.push_str(&marker);
             out.push_str(first);
-        } else {
-            out.push_str(&marker);
         }
         for line in lines {
             out.push('\n');

--- a/src/import/jira.rs
+++ b/src/import/jira.rs
@@ -178,8 +178,10 @@ fn render_inline_node(node: &serde_json::Value, out: &mut String) {
                 .get("attrs")
                 .and_then(|a| a.get("text"))
                 .and_then(|t| t.as_str())
-                .map(|s| s.trim_start_matches('@').to_string())
-                .unwrap_or_else(|| "someone".to_string());
+                .map_or_else(
+                    || "someone".to_string(),
+                    |s| s.trim_start_matches('@').to_string(),
+                );
             out.push('@');
             out.push_str(&name);
         }
@@ -373,8 +375,7 @@ pub fn map_issue(
         .status
         .as_ref()
         .and_then(|s| s.status_category.as_ref())
-        .map(|c| map_status(&c.key, map))
-        .unwrap_or(map.new);
+        .map_or(map.new, |c| map_status(&c.key, map));
 
     let priority = issue
         .fields

--- a/src/import/linear.rs
+++ b/src/import/linear.rs
@@ -129,11 +129,11 @@ pub fn map_state_type(type_: &str, map: &LinearStatusMap) -> Status {
 /// Map Linear's numeric priority (0 none, 1 urgent, 2 high, 3 medium, 4 low) to
 /// a Lific [`Priority`].
 pub fn map_priority(priority: f64) -> Priority {
-    match priority.round() as i64 {
-        1 => Priority::Urgent,
-        2 => Priority::High,
-        3 => Priority::Medium,
-        4 => Priority::Low,
+    match priority.round() {
+        1.0 => Priority::Urgent,
+        2.0 => Priority::High,
+        3.0 => Priority::Medium,
+        4.0 => Priority::Low,
         _ => Priority::None,
     }
 }
@@ -384,6 +384,8 @@ mod tests {
         assert_eq!(map_priority(2.0), Priority::High);
         assert_eq!(map_priority(3.0), Priority::Medium);
         assert_eq!(map_priority(4.0), Priority::Low);
+        assert_eq!(map_priority(f64::NAN), Priority::None);
+        assert_eq!(map_priority(f64::INFINITY), Priority::None);
     }
 
     #[test]

--- a/src/import/linear.rs
+++ b/src/import/linear.rs
@@ -145,8 +145,7 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
     let status = issue
         .state
         .as_ref()
-        .map(|s| map_state_type(&s.type_, map))
-        .unwrap_or(map.backlog);
+        .map_or(map.backlog, |s| map_state_type(&s.type_, map));
 
     let labels = issue
         .labels
@@ -163,7 +162,10 @@ pub fn map_issue(issue: &LinearIssue, map: &LinearStatusMap) -> NormalizedIssue 
         .nodes
         .iter()
         .map(|c| NormalizedComment {
-            author: c.user.as_ref().map(|u| u.handle()).unwrap_or_else(|| "unknown".into()),
+            author: c
+                .user
+                .as_ref()
+                .map_or_else(|| "unknown".into(), |u| u.handle()),
             created_at: c.created_at.clone(),
             body: c.body.clone().unwrap_or_default(),
         })

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -45,7 +45,7 @@ use crate::error::LificError;
 
 /// A source-agnostic issue ready to be written into Lific. Every importer maps
 /// its native representation to this shape; the shared core does the rest.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedIssue {
     /// Stable idempotency marker, e.g. `github:owner/name#12`.
     pub source: String,
@@ -63,14 +63,14 @@ pub struct NormalizedIssue {
     pub comments: Vec<NormalizedComment>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedLabel {
     pub name: String,
     /// Hex color (`#RRGGBB`) if the source provided one.
     pub color: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedComment {
     /// Original author handle/name (without `@`).
     pub author: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ fn write_private_config(path: &std::path::Path, contents: &str) -> std::io::Resu
 /// `sync_all` persists its bytes; the name that reaches them lives in the
 /// parent directory and survives a crash only once that is synced too.
 /// Unix only: Windows exposes no directory handle to sync.
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn sync_parent_dir(_dir: &std::path::Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -351,8 +352,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cli::login::run_logout(url.as_deref(), &cfg_clone, json)
             })
             .await
-            .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?
-            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
             return Ok(());
         }
 
@@ -584,8 +584,7 @@ fn local_url(cfg: &Config) -> String {
 fn http_backend_url(cli_url: Option<&str>, public_url: Option<&str>, cfg: &Config) -> String {
     cli_url
         .or(public_url)
-        .map(str::to_owned)
-        .unwrap_or_else(|| local_url(cfg))
+        .map_or_else(|| local_url(cfg), str::to_owned)
 }
 /// Poll `<base>/api/health` until it answers 200 or the deadline passes.
 async fn wait_healthy(base_url: &str, timeout: std::time::Duration) -> bool {
@@ -883,7 +882,7 @@ async fn cmd_init(
                         // port while our unit crash-loops on AddrInUse), and
                         // silence alone is ambiguous. Cross-check the unit's
                         // own active state to say something precise.
-                        let active = cli::service::status(mgr).map(|s| s.active).unwrap_or(false);
+                        let active = cli::service::status(mgr).is_ok_and(|s| s.active);
                         match (healthy, active) {
                             (true, true) => {}
                             (true, false) => {
@@ -1164,18 +1163,18 @@ mod init_target_tests {
     use crate::db;
     use std::path::{Path, PathBuf};
 
-    fn os_default() -> Option<(PathBuf, PathBuf)> {
-        Some((
+    fn os_default() -> (PathBuf, PathBuf) {
+        (
             PathBuf::from("/home/u/.config/lific/lific.toml"),
             PathBuf::from("/home/u/.local/share/lific/lific.db"),
-        ))
+        )
     }
 
     // LIF-295: bare init targets the OS dirs, with an explicit db path so the
     // generated config can split config dir from data dir.
     #[test]
     fn bare_init_targets_os_dirs() {
-        let (config, db) = resolve_init_target(None, false, false, os_default());
+        let (config, db) = resolve_init_target(None, false, false, Some(os_default()));
         assert_eq!(config, Path::new("/home/u/.config/lific/lific.toml"));
         assert_eq!(
             db.as_deref(),
@@ -1185,7 +1184,7 @@ mod init_target_tests {
 
     #[test]
     fn here_flag_forces_cwd_layout() {
-        let (config, db) = resolve_init_target(None, true, false, os_default());
+        let (config, db) = resolve_init_target(None, true, false, Some(os_default()));
         assert_eq!(config, Path::new("lific.toml"));
         assert_eq!(db, None, "cwd layout keeps the relative default db");
     }
@@ -1194,7 +1193,7 @@ mod init_target_tests {
     // a second instance in the OS dirs.
     #[test]
     fn existing_cwd_config_wins_over_os_dirs() {
-        let (config, db) = resolve_init_target(None, false, true, os_default());
+        let (config, db) = resolve_init_target(None, false, true, Some(os_default()));
         assert_eq!(config, Path::new("lific.toml"));
         assert_eq!(db, None);
     }
@@ -1205,7 +1204,7 @@ mod init_target_tests {
             Some(Path::new("/srv/lific/lific.toml")),
             false,
             true,
-            os_default(),
+            Some(os_default()),
         );
         assert_eq!(config, Path::new("/srv/lific/lific.toml"));
         assert_eq!(db, None);

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2376,12 +2376,13 @@ impl LificMcp {
         // there); count how many we drop so a trailing note can report
         // the omission. Status grouping keeps the groups but renders
         // them as count-only stubs (handled below).
-        let mut closed_omitted = 0i64;
-        if !include_closed && group_by != "status" {
+        let closed_omitted = if !include_closed && group_by != "status" {
             let before = issues.len();
             issues.retain(|i| !is_closed(i));
-            closed_omitted = (before - issues.len()) as i64;
-        }
+            (before - issues.len()) as i64
+        } else {
+            0
+        };
         let module_names: std::collections::HashMap<i64, String> = if group_by == "module" {
             if let Ok(conn) = self.db.read() {
                 queries::list_modules(&conn, pid)

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2455,8 +2455,11 @@ impl LificMcp {
                     );
                 }
                 writeln!(output, "── {} ({}) ──", group, items.len())?;
-                let shown =
-                    max_per_column.map_or(items.len(), |limit| (limit as usize).min(items.len()));
+                let shown = max_per_column.map_or(items.len(), |limit| {
+                    usize::try_from(limit)
+                        .unwrap_or(usize::MAX)
+                        .min(items.len())
+                });
                 items[..shown].iter().try_for_each(|issue| {
                     writeln!(
                         output,
@@ -4558,14 +4561,17 @@ fn render_attachment_text(
 ) -> String {
     let text = String::from_utf8_lossy(bytes);
     let lines: Vec<&str> = text.lines().collect();
-    let total = lines.len() as i64;
+    let total = lines.len();
     let offset = offset.unwrap_or(0).max(0);
-    let limit = limit
-        .unwrap_or(ATTACHMENT_TEXT_DEFAULT_LINES)
-        .clamp(1, queries::MAX_PAGE_LIMIT);
-    let start = offset.min(total);
-    let end = offset.saturating_add(limit).min(total);
-    let shown = &lines[start as usize..end as usize];
+    let start = usize::try_from(offset).unwrap_or(usize::MAX).min(total);
+    let limit = usize::try_from(
+        limit
+            .unwrap_or(ATTACHMENT_TEXT_DEFAULT_LINES)
+            .clamp(1, queries::MAX_PAGE_LIMIT),
+    )
+    .expect("page limit fits usize");
+    let end = start.saturating_add(limit).min(total);
+    let shown = &lines[start..end];
 
     render_response(|output| {
         if shown.is_empty() {
@@ -6140,6 +6146,25 @@ mod tests {
         // Exactly two issue lines rendered.
         let rendered = result.matches("| todo | ").count();
         assert_eq!(rendered, 2, "got: {result}");
+    }
+
+    #[test]
+    fn board_oversized_max_per_column_shows_every_issue() {
+        let (m, _guard) = mcp();
+        seed_project(&m, "Unbounded Board", "BCU");
+        m.create_issue(Parameters(CreateIssueInput {
+            project: "BCU".into(),
+            title: "still-visible".into(),
+            status: Some("todo".into()),
+            ..Default::default()
+        }));
+        let result = m.get_board(Parameters(GetBoardInput {
+            project: "BCU".into(),
+            max_per_column: Some(i64::MAX),
+            ..Default::default()
+        }));
+        assert!(result.contains("still-visible"), "got: {result}");
+        assert!(!result.contains("more (use list_issues)"), "got: {result}");
     }
 
     #[test]
@@ -7763,7 +7788,7 @@ mod tests {
         seed_issue(&m, "PRJ", "Long thread");
         let _guard = seed_user(&m);
         let total = queries::DEFAULT_PAGE_LIMIT + 5;
-        seed_comment_trail(&m, total as usize);
+        seed_comment_trail(&m, usize::try_from(total).unwrap());
 
         let result = m.list_comments(Parameters(ListCommentsInput {
             identifier: "PRJ-1".into(),
@@ -11233,6 +11258,15 @@ mod tests {
             limit: None,
         })));
         assert!(past.contains("no lines at offset 9000 of 250"), "{past}");
+        let unrepresentable = text_of(&m.get_attachment(Parameters(GetAttachmentInput {
+            attachment_id: id,
+            offset: Some(i64::MAX),
+            limit: None,
+        })));
+        assert!(
+            unrepresentable.contains(&format!("no lines at offset {} of 250", i64::MAX)),
+            "{unrepresentable}"
+        );
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1966,14 +1966,18 @@ impl LificMcp {
                 .files
                 .into_iter()
                 .next()
-                .map(|file| file.content)
-                .unwrap_or_else(|| "Error: page export produced no files".into())),
+                .map_or_else(
+                    || "Error: page export produced no files".into(),
+                    |file| file.content,
+                )),
             Kind::Issue => Ok(bundle
                 .files
                 .into_iter()
                 .next()
-                .map(|file| file.content)
-                .unwrap_or_else(|| "Error: issue export produced no files".into())),
+                .map_or_else(
+                    || "Error: issue export produced no files".into(),
+                    |file| file.content,
+                )),
             Kind::Project => Ok(render_response(|output| {
                 writeln!(output, "{} exported file(s):", bundle.files.len())?;
                 bundle
@@ -4633,28 +4637,34 @@ impl Display for AttachmentLines<'_> {
 /// project comes back so the caller can drop links it has no role on;
 /// `None` means the linked entity is gone (a dangling link the GC has not
 /// swept yet) and the row simply omits it.
+fn optional_entity<T>(
+    result: Result<T, crate::error::LificError>,
+) -> Result<Option<T>, crate::error::LificError> {
+    match result {
+        Ok(entity) => Ok(Some(entity)),
+        Err(crate::error::LificError::NotFound(_)) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
 fn attachment_link_label(
     conn: &rusqlite::Connection,
     entity: models::AttachmentEntity,
     entity_id: i64,
 ) -> Result<Option<(String, Option<i64>)>, crate::error::LificError> {
-    Ok(match entity {
-        models::AttachmentEntity::Issue => queries::get_issue(conn, entity_id)
-            .ok()
+    let label = match entity {
+        models::AttachmentEntity::Issue => optional_entity(queries::get_issue(conn, entity_id))?
             .map(|issue| (issue.identifier, Some(issue.project_id))),
-        models::AttachmentEntity::Page => queries::get_page(conn, entity_id)
-            .ok()
+        models::AttachmentEntity::Page => optional_entity(queries::get_page(conn, entity_id))?
             .map(|page| (page.identifier, page.project_id)),
         models::AttachmentEntity::Comment => {
-            match queries::comments::get_comment(conn, entity_id).ok() {
+            match optional_entity(queries::comments::get_comment(conn, entity_id))? {
                 None => None,
                 Some(comment) => {
                     let parent = match (comment.issue_id, comment.page_id) {
-                        (Some(issue_id), _) => queries::get_issue(conn, issue_id)
-                            .ok()
+                        (Some(issue_id), _) => optional_entity(queries::get_issue(conn, issue_id))?
                             .map(|issue| (issue.identifier, Some(issue.project_id))),
-                        (None, Some(page_id)) => queries::get_page(conn, page_id)
-                            .ok()
+                        (None, Some(page_id)) => optional_entity(queries::get_page(conn, page_id))?
                             .map(|page| (page.identifier, page.project_id)),
                         (None, None) => None,
                     };
@@ -4664,7 +4674,8 @@ fn attachment_link_label(
                 }
             }
         }
-    })
+    };
+    Ok(label)
 }
 
 // LIFIC-11: process-wide serialization lock for MCP tests. `MCP_REQUEST_USER`
@@ -10939,6 +10950,24 @@ mod tests {
             .filter_map(|content| content.as_text().map(|text| text.text.clone()))
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn attachment_link_label_ignores_missing_entities_but_propagates_database_errors() {
+        let db = crate::db::open_memory().expect("test db");
+        let conn = db.write().unwrap();
+
+        assert!(
+            attachment_link_label(&conn, models::AttachmentEntity::Issue, 1)
+                .unwrap()
+                .is_none()
+        );
+
+        conn.execute("DROP TABLE issues", []).unwrap();
+        assert!(matches!(
+            attachment_link_label(&conn, models::AttachmentEntity::Issue, 1),
+            Err(crate::error::LificError::Database(_))
+        ));
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1419,7 +1419,7 @@ impl LificMcp {
                         return Ok(self.empty_search_result());
                     }
                     Err(crate::error::LificError::NotFound(error)) => {
-                        return Err(error.to_string());
+                        return Err(error);
                     }
                     Ok(_) => {
                         return Ok(self.empty_search_result());
@@ -1617,11 +1617,10 @@ impl LificMcp {
                 ActivityScopeReference::Project => ReferenceKind::Project(&scope_identifier),
             },
         );
-        let activity_project_identifier = project_identifier.as_deref().or(matches!(
-            scope_reference.kind,
-            ReferenceKind::Project(_)
-        )
-        .then_some(scope_identifier.as_str()));
+        let activity_project_identifier = project_identifier.as_deref().or_else(|| {
+            matches!(scope_reference.kind, ReferenceKind::Project(_))
+                .then_some(scope_identifier.as_str())
+        });
         let rendered = self.read(|conn| {
             let feed = queries::activity::list_activity(conn, scope, Some(limit), Some(offset))?;
             if feed.items.is_empty() {
@@ -1754,7 +1753,9 @@ impl LificMcp {
             let id = queries::resolve_identifier(conn, &input.identifier)?;
             let issue = queries::get_issue(conn, id)?;
             let module_name = match issue.module_id {
-                Some(mid) => queries::get_module_name(conn, mid).unwrap_or("unknown".into()),
+                Some(mid) => {
+                    queries::get_module_name(conn, mid).unwrap_or_else(|_| "unknown".into())
+                }
                 None => "none".into(),
             };
             // LIF-303: annotate each relation identifier with the related
@@ -2271,12 +2272,12 @@ impl LificMcp {
             // a double-escaping client matches stored content.
             let (current, old_norm, new_norm) = match field {
                 "description" => (
-                    issue.description.clone(),
+                    issue.description,
                     queries::unescape_text(&input.old_string),
                     queries::unescape_text(&input.new_string),
                 ),
                 "title" => (
-                    issue.title.clone(),
+                    issue.title,
                     input.old_string.clone(),
                     input.new_string.clone(),
                 ),
@@ -2402,7 +2403,7 @@ impl LificMcp {
                 "module" => issue
                     .module_id
                     .and_then(|m| module_names.get(&m).cloned())
-                    .unwrap_or("unassigned".into()),
+                    .unwrap_or_else(|| "unassigned".into()),
                 _ => issue.status.to_string(),
             };
             groups.entry(key).or_default().push(issue);
@@ -2766,12 +2767,12 @@ impl LificMcp {
             // edit from a double-escaping client matches stored content.
             let (current, old_norm, new_norm) = match field {
                 "content" => (
-                    page.content.clone(),
+                    page.content,
                     queries::unescape_text(&input.old_string),
                     queries::unescape_text(&input.new_string),
                 ),
                 "title" => (
-                    page.title.clone(),
+                    page.title,
                     input.old_string.clone(),
                     input.new_string.clone(),
                 ),
@@ -3322,7 +3323,7 @@ impl LificMcp {
                             project_id: pid,
                             name: name.clone(),
                             description: input.description.clone().unwrap_or_default(),
-                            status: input.status.clone().unwrap_or("active".into()),
+                            status: input.status.clone().unwrap_or_else(|| "active".into()),
                             emoji: emoji_for_create(&input.emoji),
                         },
                     )
@@ -3385,7 +3386,10 @@ impl LificMcp {
                         &models::CreateLabel {
                             project_id: pid,
                             name: name.clone(),
-                            color: input.color.clone().unwrap_or("#6B7280".into()),
+                            color: input
+                                .color
+                                .clone()
+                                .unwrap_or_else(|| "#6B7280".into()),
                         },
                     )
                 })?;
@@ -4320,7 +4324,7 @@ impl LificMcp {
                 )),
                 Content::image(
                     base64::engine::general_purpose::STANDARD.encode(&bytes),
-                    attachment.mime.clone(),
+                    attachment.mime,
                 ),
             ]);
         }
@@ -12874,7 +12878,7 @@ mod authz_gating_tests {
                 auth_state,
                 crate::auth::require_api_key,
             ))
-            .with_state(m.clone());
+            .with_state(m);
 
         async fn call_get(app: Router, uri: String, token: &str) -> String {
             let resp = app
@@ -12954,7 +12958,7 @@ mod authz_gating_tests {
         );
 
         let outsider_write = run(call_create(
-            app.clone(),
+            app,
             serde_json::json!({"project": "MEM", "title": "by token outsider"}),
             &outsider_token,
         ));

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -490,6 +490,7 @@ async fn register_client(
         tracing::error!(error = %e, "failed to register OAuth client");
         return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
     }
+    drop(conn);
 
     info!(client_id = %client_id, name = %client_name, "OAuth client registered");
 
@@ -867,6 +868,7 @@ async fn authorize_approve(
         tracing::error!(error = %e, "failed to commit OAuth authorization");
         return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
     }
+    drop(conn);
 
     let mut redirect_url = form.redirect_uri.clone();
     redirect_url.push_str(if redirect_url.contains('?') { "&" } else { "?" });
@@ -1264,6 +1266,7 @@ async fn device_authorization(
             }
         }
     }
+    drop(conn);
     if !inserted {
         return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
     }
@@ -1482,6 +1485,7 @@ async fn device_approve(
         tracing::error!(error = %e, "failed to commit device approval");
         return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response();
     }
+    drop(conn);
 
     info!(user_code = %normalized, decision = %new_status, "OAuth device verification");
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1822,8 +1822,7 @@ fn device_token_exchange(state: &OAuthState, req: &TokenRequest) -> Response {
 
     // Expiry check first (RFC 8628: expired_token).
     let expired = chrono::DateTime::parse_from_rfc3339(&row.expires_at)
-        .map(|t| now >= t.with_timezone(&chrono::Utc))
-        .unwrap_or(true);
+        .map_or(true, |t| now >= t.with_timezone(&chrono::Utc));
     if expired {
         let _ = conn.execute(
             "DELETE FROM oauth_device_codes WHERE device_code_hash = ?1",

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -434,7 +434,7 @@ async fn register_client(
             .into_response();
     }
 
-    let db = state.db.clone();
+    let db = state.db;
     let conn = match db.write() {
         Ok(c) => c,
         Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "database error").into_response(),
@@ -952,7 +952,7 @@ fn resolve_tool(raw: &str) -> Result<(String, String), LificError> {
             "tool id '{slug}' is reserved"
         )));
     }
-    Ok((slug.clone(), trimmed.to_string()))
+    Ok((slug, trimmed.to_string()))
 }
 
 /// HTML `<option>` value that means "this isn't a known tool — let me type it".
@@ -3889,7 +3889,7 @@ mod tests {
             .unwrap();
         let status = resp.status();
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        let val = serde_json::from_slice(&bytes).unwrap_or(serde_json::json!({}));
+        let val = serde_json::from_slice(&bytes).unwrap_or_else(|_| serde_json::json!({}));
         (status, val)
     }
 
@@ -4915,7 +4915,7 @@ mod tests {
             let bytes = resp.into_body().collect().await.unwrap().to_bytes();
             (
                 status,
-                serde_json::from_slice(&bytes).unwrap_or(serde_json::json!({})),
+                serde_json::from_slice(&bytes).unwrap_or_else(|_| serde_json::json!({})),
             )
         }
 

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -332,11 +332,10 @@ impl RateLimiter {
             Some(entries) if !entries.is_empty() => {
                 let oldest = entries[0].at;
                 let elapsed = now.saturating_duration_since(oldest);
-                if elapsed < self.window {
-                    (self.window - elapsed).as_secs() + 1
-                } else {
-                    0
-                }
+                self.window
+                    .checked_sub(elapsed)
+                    .filter(|remaining| !remaining.is_zero())
+                    .map_or(0, |remaining| remaining.as_secs() + 1)
             }
             _ => 0,
         }

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -157,8 +157,7 @@ pub fn client_ip(peer: IpAddr, headers: &HeaderMap, trusted_proxies: &[IpNetwork
         x_forwarded_for_client_ip(headers, trusted_proxies).unwrap_or(peer)
     } else {
         header_ip(headers, "x-real-ip")
-            .map(normalize_ip)
-            .unwrap_or(peer)
+            .map_or(peer, normalize_ip)
     };
     normalize_ip(client).to_string()
 }

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -94,6 +94,7 @@ impl RealtimeHub {
         }
         *count += 1;
         connections.total += 1;
+        drop(connections);
         Some(SocketPermit {
             connections: Arc::clone(&self.connections),
             user_id,

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -946,7 +946,7 @@ mod tests {
         assert!(hub.try_acquire_socket(7).is_none());
 
         // Dropping one slot frees exactly one.
-        slots.pop();
+        drop(slots.pop());
         assert!(hub.try_acquire_socket(7).is_some());
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -412,8 +412,7 @@ fn build_app_with_store(
             info!(
                 acting_as = authless_user
                     .as_ref()
-                    .map(|u| u.username.as_str())
-                    .unwrap_or("<anonymous>"),
+                    .map_or("<anonymous>", |u| u.username.as_str()),
                 "authless MCP endpoint enabled at /mcp/<token>"
             );
             build_authless_mcp_router(
@@ -523,9 +522,7 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         // stale or toggled flag must not turn a reachable instance into
         // passwordless admin. On a genuinely local instance with an https
         // public_url on a private network, keep the loud warning.
-        let auto_login = db::queries::settings::get(&conn)
-            .map(|s| s.web_auto_login)
-            .unwrap_or(false);
+        let auto_login = db::queries::settings::get(&conn)?.web_auto_login;
         if auto_login && let Some(exposure) = reachability.public_exposure() {
             return Err(format!(
                 "refusing to start: single-user web auto-login is enabled while \

--- a/src/server.rs
+++ b/src/server.rs
@@ -523,6 +523,7 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         // passwordless admin. On a genuinely local instance with an https
         // public_url on a private network, keep the loud warning.
         let auto_login = db::queries::settings::get(&conn)?.web_auto_login;
+        drop(conn);
         if auto_login && let Some(exposure) = reachability.public_exposure() {
             return Err(format!(
                 "refusing to start: single-user web auto-login is enabled while \

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -99,6 +99,7 @@ fn existing_regular_file(path: &Path, label: &str) -> Result<bool, LificError> {
 /// its own fsync. Without this, a crash right after an upload can leave a
 /// database row pointing at a blob whose directory entry never landed.
 /// Unix only: Windows has no directory handle to sync.
+#[cfg_attr(not(unix), expect(clippy::unnecessary_wraps, reason = "fallible on Unix"))]
 fn sync_dir(_dir: &Path) -> Result<(), LificError> {
     #[cfg(unix)]
     {
@@ -265,7 +266,7 @@ impl AttachmentStore {
     /// Compute the lowercase hex SHA-256 of a byte slice — the content address.
     pub fn hash_bytes(bytes: &[u8]) -> String {
         let digest = Sha256::digest(bytes);
-        digest.iter().map(|b| format!("{b:02x}")).collect()
+        crate::auth::hex_encode(&digest)
     }
 
     /// Path of the store's cross-process lock file.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1464,7 +1464,7 @@ mod tests {
             .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
             .filter(|name| valid_sha256(name))
             .collect();
-        assert_eq!(blobs, vec![sha1.clone()]);
+        assert_eq!(blobs, vec![sha1]);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

This turns the useful parts of Clippy's pedantic and nursery lint sets into a repository-wide policy, fixes the findings that exposed real bugs or worthwhile cleanup, and runs the same standard Clippy command before commit and in CI.

## What changed and why

### Put the existing Clippy gate in the developer loop

The local pre-commit hook runs `cargo clippy --all-targets -- -D warnings`, matching CI. This catches the repository's standard lint set before a push without introducing another script or tool-specific wrapper.

### Stop hiding errors behind convenient defaults

The first lint group (`format_collect`, `map_unwrap_or`, and `unnecessary_wraps`) exposed places where fallback-shaped code was masking meaningful failures. The fixes distinguish “not found” from database failure when reading settings, deriving usernames, checking bot connections, and resolving attachment labels. They also propagate settings failures during login instead of silently substituting a session lifetime.

Related cleanup removes result wrappers from functions that are genuinely infallible, centralizes lowercase hexadecimal encoding in the existing helper, and avoids building formatted strings one byte at a time through an iterator.

### Make async, matching, and time arithmetic say what they mean

The next group (`match_wildcard_for_single_variants`, `unchecked_time_subtraction`, and `unused_async`) removes an async boundary from the synchronous activity authorization helper, matches the only unsupported TOML variant explicitly, and uses checked duration subtraction for retry timing. These changes make the supported cases and failure behavior visible in the type and control flow instead of relying on broad matches or arithmetic assumptions.

### Make signed-to-unsigned boundaries explicit

Enabling `cast_sign_loss` found pagination and display limits that crossed from API-sized signed integers into native collection indexes. Those paths now clamp negative values, use checked conversions, and treat values larger than the platform index width as effectively unbounded. Linear priority mapping now compares rounded floating-point values directly, so non-finite provider values cannot acquire a priority through a lossy cast.

### Remove allocations and clones without weakening concurrency tests

The nursery pass enables `derive_partial_eq_without_eq`, `future_not_send`, `literal_string_with_formatting_args`, `needless_collect`, `or_fun_call`, and `redundant_clone`. Most findings were direct ownership or formatting cleanup. The nontrivial collection findings were handled according to intent:

- plan pagination compares the second-page ID directly against the first page instead of materializing a temporary ID vector;
- fixed-size rate-limit reservations use arrays, which keep every reservation alive for the assertion;
- the repeated-connect test builds an array of scoped thread handles before joining them, preserving actual overlap rather than accidentally serializing the test.

### Simplify state transitions and shorten lock lifetimes

The final control-flow group (`branches_sharing_code`, `collection_is_never_read`, `unnecessary_struct_initialization`, and `useless_let_if_seq`) replaces mutable placeholder state with expressions where the value is produced. This is most useful in plan-step updates and restore installation: success, absence, and failure now flow through one expression instead of a value initialized for later reassignment.

Database and connection guards are explicitly released once their protected work is complete, before JSON rendering, CLI output, redirects, logging, or server startup checks. That narrows contention windows while leaving the returned data owned and usable.

### Keep the policy cross-platform

Several private filesystem helpers are no-ops on Windows but fallible on Unix. Targeted Windows-only expectations retain one portable, fallible signature for their callers while documenting why `unnecessary_wraps` does not apply on that target. This avoids duplicating call paths ahead of my planned shared-filesystem-helper refactor.

## Tests added or strengthened

- `get_propagates_database_errors` proves settings defaults apply only when the settings row is absent, not when the query fails.
- `derive_username_propagates_database_errors` proves a failed user lookup is not mistaken for an available username.
- `bot_is_connected_propagates_database_errors` proves connection checks distinguish database failure from a disconnected bot.
- `attachment_link_label_ignores_missing_entities_but_propagates_database_errors` preserves dangling-link rendering while surfacing actual lookup failures.
- `page_from_over_fetch_handles_signed_bounds` covers negative and oversized pagination limits without signed-to-unsigned wrapping.
- `board_oversized_max_per_column_shows_every_issue` proves an oversized display limit behaves as unbounded instead of truncating.
- the Linear priority mapping test now covers `NaN` and infinity and maps both to no priority.
- the text-attachment paging test now covers an offset at `i64::MAX` and preserves that requested offset in the response.
- the plan cursor test still proves consecutive pages do not overlap, now without a temporary ID collection.
- the password-change and login reservation tests use fixed arrays to prove all concurrent slots are held until the refusal is observed.
- `ensure_bot_is_idempotent_across_repeated_connects` now creates every scoped thread before joining, preserving the concurrency the test is intended to exercise while proving every caller receives the same bot.