### PR TITLE
fix(cli): harden credential storage and OAuth client caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,7 +1613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -1751,6 +1772,7 @@ dependencies = [
  "keyring",
  "libc",
  "mime_guess",
+ "proptest",
  "rand 0.8.5",
  "reqwest",
  "rmcp",
@@ -2238,10 +2260,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -2400,6 +2447,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2676,6 +2732,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3504,6 +3572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3615,6 +3689,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ fs2 = "0.4"
 libc = "0.2"
 
 [dev-dependencies]
+proptest = "1"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 # Scratch directories for tests. Replaces hand-rolled

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -220,7 +220,8 @@ impl FileStore {
 
     fn read_map(&self) -> std::io::Result<BTreeMap<String, String>> {
         match std::fs::read_to_string(&self.path) {
-            Ok(s) => serde_json::from_str(&s).map_err(std::io::Error::other),
+            Ok(s) => serde_json::from_str(&s)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error)),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(BTreeMap::new()),
             Err(error) => Err(error),
         }
@@ -241,7 +242,8 @@ impl FileStore {
         let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
         temporary.write_all(json.as_bytes())?;
         temporary.flush()?;
-        set_file_private(temporary.path());
+        temporary.as_file().sync_all()?;
+        set_file_private(temporary.as_file());
         temporary
             .persist(&self.path)
             .map(|_| ())
@@ -272,15 +274,15 @@ impl FileStore {
 }
 
 /// Best-effort chmod 0600 on the credentials file (unix only).
-fn set_file_private(path: &Path) {
+fn set_file_private(file: &std::fs::File) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
     }
     #[cfg(not(unix))]
     {
-        let _ = path;
+        let _ = file;
     }
 }
 
@@ -552,7 +554,7 @@ mod tests {
         fn malformed_file_content_is_never_replaced(payload in any::<String>()) {
             let tmp = tempfile::tempdir().unwrap();
             let path = tmp.path().join("credentials.json");
-            let original = format!("{{{payload}");
+            let original = format!("not-json:{payload}");
             std::fs::write(&path, original.as_bytes()).unwrap();
             let store = FileStore::new(path.clone());
 

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -169,8 +169,8 @@ fn default_client_file_path() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("lific").join("clients.json"))
 }
 
-fn client_store() -> Option<PlaintextCredentialFileStore> {
-    default_client_file_path().map(PlaintextCredentialFileStore::new)
+fn client_store() -> Option<OAuthClientRegistrationCache> {
+    default_client_file_path().map(OAuthClientRegistrationCache::new)
 }
 
 // The three operations are factored to take the store, like the credential
@@ -179,34 +179,29 @@ fn client_store() -> Option<PlaintextCredentialFileStore> {
 // reported to the login flow rather than silently discarded.
 
 fn store_client_id_in(
-    store: &PlaintextCredentialFileStore,
+    store: &OAuthClientRegistrationCache,
     base_url: &str,
     client_id: &str,
-) -> Result<(), PlaintextCredentialFileError> {
-    store.store_credential_for_server_key(&CredentialStoreKey::from_base_url(base_url), client_id)
+) -> Result<(), OAuthClientCacheError> {
+    store.remember(base_url, client_id)
 }
 
 fn load_client_id_from(
-    store: &PlaintextCredentialFileStore,
+    store: &OAuthClientRegistrationCache,
     base_url: &str,
-) -> Result<Option<String>, PlaintextCredentialFileError> {
-    store.load_credential_for_server_key(&CredentialStoreKey::from_base_url(base_url))
+) -> Result<Option<String>, OAuthClientCacheError> {
+    store.load(base_url)
 }
 
 fn forget_client_id_in(
-    store: &PlaintextCredentialFileStore,
+    store: &OAuthClientRegistrationCache,
     base_url: &str,
-) -> Result<(), PlaintextCredentialFileError> {
-    store
-        .delete_credential_for_server_key(&CredentialStoreKey::from_base_url(base_url))
-        .map(|_| ())
+) -> Result<(), OAuthClientCacheError> {
+    store.forget(base_url)
 }
 
 /// Remember the OAuth `client_id` registered with `base_url`.
-pub fn store_client_id(
-    base_url: &str,
-    client_id: &str,
-) -> Result<(), PlaintextCredentialFileError> {
+pub fn store_client_id(base_url: &str, client_id: &str) -> Result<(), OAuthClientCacheError> {
     if let Some(store) = client_store() {
         store_client_id_in(&store, base_url, client_id)
     } else {
@@ -215,7 +210,7 @@ pub fn store_client_id(
 }
 
 /// The `client_id` previously registered with `base_url`, if any.
-pub fn load_client_id(base_url: &str) -> Result<Option<String>, PlaintextCredentialFileError> {
+pub fn load_client_id(base_url: &str) -> Result<Option<String>, OAuthClientCacheError> {
     match client_store() {
         Some(store) => load_client_id_from(&store, base_url),
         None => Ok(None),
@@ -224,11 +219,76 @@ pub fn load_client_id(base_url: &str) -> Result<Option<String>, PlaintextCredent
 
 /// Drop the remembered `client_id` for `base_url`, after the server said it
 /// does not know it (reclaimed, or a rebuilt database).
-pub fn forget_client_id(base_url: &str) -> Result<(), PlaintextCredentialFileError> {
+pub fn forget_client_id(base_url: &str) -> Result<(), OAuthClientCacheError> {
     if let Some(store) = client_store() {
         forget_client_id_in(&store, base_url)
     } else {
         Ok(())
+    }
+}
+
+/// The public OAuth client-registration cache deliberately has different
+/// naming from the credential store. Its contents are public identifiers;
+/// malformed or unsafe data is still a hard error when read, but callers may
+/// choose to warn and continue after a successful remote registration.
+#[derive(Debug, Error)]
+pub enum OAuthClientCacheError {
+    #[error("OAuth client cache {path}: {detail}")]
+    Storage {
+        path: PathBuf,
+        detail: String,
+        #[source]
+        source: Box<PlaintextCredentialFileError>,
+    },
+}
+
+struct OAuthClientRegistrationCache {
+    store: PlaintextCredentialFileStore,
+}
+
+impl OAuthClientRegistrationCache {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            store: PlaintextCredentialFileStore::new(path),
+        }
+    }
+
+    fn load(&self, base_url: &str) -> Result<Option<String>, OAuthClientCacheError> {
+        self.store
+            .load_credential_for_server_key(&CredentialStoreKey::from_base_url(base_url))
+            .map_err(|source| self.error("could not load", source))
+    }
+
+    fn remember(&self, base_url: &str, client_id: &str) -> Result<(), OAuthClientCacheError> {
+        self.store
+            .store_credential_for_server_key(
+                &CredentialStoreKey::from_base_url(base_url),
+                client_id,
+            )
+            .map_err(|source| self.error("could not store", source))
+    }
+
+    fn forget(&self, base_url: &str) -> Result<(), OAuthClientCacheError> {
+        self.store
+            .delete_credential_for_server_key(&CredentialStoreKey::from_base_url(base_url))
+            .map(|_| ())
+            .map_err(|source| self.error("could not delete", source))
+    }
+
+    fn error(
+        &self,
+        operation: &str,
+        source: PlaintextCredentialFileError,
+    ) -> OAuthClientCacheError {
+        let source_detail = source
+            .to_string()
+            .replace("credential", "OAuth client cache");
+        let detail = format!("{operation}: {source_detail}");
+        OAuthClientCacheError::Storage {
+            path: self.store.path.clone(),
+            detail,
+            source: Box::new(source),
+        }
     }
 }
 
@@ -304,6 +364,7 @@ pub enum PlaintextCredentialFileError {
     DirectoryNotRegular { path: PathBuf },
     #[error("credential directory {path} is a symbolic link")]
     DirectorySymlink { path: PathBuf },
+    #[cfg(unix)]
     #[error("failed to apply private credential permissions to {path}: {source}")]
     Permissions {
         path: PathBuf,
@@ -334,6 +395,7 @@ pub enum PlaintextCredentialFileError {
         #[source]
         source: std::io::Error,
     },
+    #[cfg(unix)]
     #[error("failed to synchronize credential directory {path}: {source}")]
     DirectorySync {
         path: PathBuf,
@@ -373,6 +435,28 @@ impl PlaintextCredentialFileStore {
     fn read_existing_credentials_or_return_absent(
         &self,
     ) -> Result<Option<BTreeMap<String, String>>, PlaintextCredentialFileError> {
+        #[cfg(windows)]
+        match std::fs::symlink_metadata(&self.path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(PlaintextCredentialFileError::Symlink {
+                    path: self.path.clone(),
+                });
+            }
+            Ok(metadata) if !metadata.file_type().is_file() => {
+                return Err(PlaintextCredentialFileError::NotRegular {
+                    path: self.path.clone(),
+                });
+            }
+            Ok(_) => {}
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => {
+                return Err(PlaintextCredentialFileError::Read {
+                    path: self.path.clone(),
+                    source,
+                });
+            }
+        }
+
         let mut options = std::fs::OpenOptions::new();
         options.read(true);
         configure_no_follow(&mut options);
@@ -625,6 +709,10 @@ impl PlaintextCredentialFileStore {
 }
 
 /// Apply owner-only protection to an open credential or lock file.
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn set_open_credential_file_owner_only_permissions(
     file: &std::fs::File,
     path: &Path,
@@ -648,6 +736,10 @@ fn set_open_credential_file_owner_only_permissions(
 
 /// Sync the directory entry after publishing a credential file. File sync
 /// persists bytes; directory sync persists the name-to-inode replacement.
+#[cfg_attr(
+    not(unix),
+    expect(clippy::unnecessary_wraps, reason = "fallible on Unix")
+)]
 fn synchronize_credential_parent_directory(
     parent: &Path,
 ) -> Result<(), PlaintextCredentialFileError> {
@@ -794,17 +886,21 @@ pub fn load_with_source(
     }
 }
 
-/// Delete the stored credential for `base_url` from BOTH backends. Returns
-/// whether anything was removed from either.
+/// Delete the stored credential for `base_url` from BOTH backends.
+///
+/// The plaintext store is attempted first. That means a plaintext corruption
+/// or safety error returns before the keyring is changed. Keyring deletion is
+/// best-effort, so a successful result can still mean that only the plaintext
+/// copy was removed; the two backends are not a transaction.
 pub fn delete(base_url: &str) -> Result<bool, PlaintextCredentialFileError> {
     let key = CredentialStoreKey::from_base_url(base_url);
-    let kr = keyring_delete(key.as_str());
     let file = match default_file_path() {
         Some(path) => {
             PlaintextCredentialFileStore::new(path).delete_credential_for_server_key(&key)?
         }
         None => false,
     };
+    let kr = keyring_delete(key.as_str());
     Ok(kr || file)
 }
 
@@ -861,7 +957,7 @@ mod tests {
     #[test]
     fn a_client_id_round_trips_per_server_and_can_be_forgotten() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = PlaintextCredentialFileStore::new(tmp.path().join("clients.json"));
+        let store = OAuthClientRegistrationCache::new(tmp.path().join("clients.json"));
 
         assert_eq!(
             load_client_id_from(&store, "http://127.0.0.1:3998").unwrap(),
@@ -896,6 +992,32 @@ mod tests {
             Some("client-xyz".to_string()),
             "forgetting one server must not clear another"
         );
+    }
+
+    #[test]
+    fn client_cache_errors_name_the_public_cache_not_credentials() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("clients.json");
+        std::fs::write(&path, br#"{"http://a": broken}"#).unwrap();
+        let cache = OAuthClientRegistrationCache::new(path);
+
+        let error = cache.load("http://a").unwrap_err();
+
+        assert!(error.to_string().contains("OAuth client cache"));
+        assert!(error.to_string().contains("invalid JSON"));
+        assert!(!error.to_string().contains("credential file"));
+    }
+
+    proptest! {
+        #[test]
+        fn oauth_client_cache_round_trips_arbitrary_identifiers(client_id in any::<String>()) {
+            let tmp = tempfile::tempdir().unwrap();
+            let cache = OAuthClientRegistrationCache::new(tmp.path().join("clients.json"));
+
+            cache.remember("https://lific.example", &client_id).unwrap();
+
+            prop_assert_eq!(cache.load("https://lific.example").unwrap(), Some(client_id));
+        }
     }
 
     #[test]

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -38,6 +38,7 @@
 //! Service is gated `#[ignore]` (CI has none).
 
 use std::collections::BTreeMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Environment variable carrying an OAuth token, used in place of stored
@@ -217,40 +218,51 @@ impl FileStore {
         Self { path }
     }
 
-    fn read_map(&self) -> BTreeMap<String, String> {
+    fn read_map(&self) -> std::io::Result<BTreeMap<String, String>> {
         match std::fs::read_to_string(&self.path) {
-            Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
-            Err(_) => BTreeMap::new(),
+            Ok(s) => serde_json::from_str(&s).map_err(std::io::Error::other),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(BTreeMap::new()),
+            Err(error) => Err(error),
         }
     }
 
     fn write_map(&self, map: &BTreeMap<String, String>) -> std::io::Result<()> {
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)?;
-            // Tighten the parent dir to 0700 (best-effort; only meaningful on unix).
-            set_dir_private(parent);
-        }
+        let parent = self
+            .path
+            .parent()
+            .filter(|path| !path.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        std::fs::create_dir_all(parent)?;
+        // Tighten the parent dir to 0700 (best-effort; only meaningful on unix).
+        set_dir_private(parent);
         let json = serde_json::to_string_pretty(map).map_err(std::io::Error::other)?;
-        std::fs::write(&self.path, json)?;
-        set_file_private(&self.path);
-        Ok(())
+        // Write beside the destination and rename it into place. This keeps a
+        // malformed or otherwise unreadable existing file intact on failure.
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        temporary.write_all(json.as_bytes())?;
+        temporary.flush()?;
+        set_file_private(temporary.path());
+        temporary
+            .persist(&self.path)
+            .map(|_| ())
+            .map_err(|error| error.error)
     }
 
     /// Store `token` under `key`, creating the file if needed.
     pub fn store(&self, key: &str, token: &str) -> std::io::Result<()> {
-        let mut map = self.read_map();
+        let mut map = self.read_map()?;
         map.insert(key.to_string(), token.to_string());
         self.write_map(&map)
     }
 
     /// Load the token for `key`, if present.
     pub fn load(&self, key: &str) -> Option<String> {
-        self.read_map().get(key).cloned()
+        self.read_map().ok()?.get(key).cloned()
     }
 
     /// Remove `key`. Returns whether an entry was actually removed.
     pub fn delete(&self, key: &str) -> std::io::Result<bool> {
-        let mut map = self.read_map();
+        let mut map = self.read_map()?;
         let removed = map.remove(key).is_some();
         if removed {
             self.write_map(&map)?;
@@ -388,6 +400,7 @@ fn keyring_delete(key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     /// A file store in a fresh scratch directory. Hold onto the returned
     /// [`TempDir`]: dropping it removes the directory, which also happens
@@ -520,6 +533,82 @@ mod tests {
         store.store("http://a", "tok").unwrap();
         assert!(path.exists());
         assert_eq!(store.load("http://a").as_deref(), Some("tok"));
+    }
+
+    #[test]
+    fn file_store_rejects_malformed_existing_data_without_replacing_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("credentials.json");
+        let original = br#"{"http://a":"old-token", broken}"#;
+        std::fs::write(&path, original).unwrap();
+        let store = FileStore::new(path.clone());
+
+        assert!(store.store("http://a", "new-token").is_err());
+        assert_eq!(std::fs::read(path).unwrap(), original);
+    }
+
+    proptest! {
+        #[test]
+        fn malformed_file_content_is_never_replaced(payload in any::<String>()) {
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join("credentials.json");
+            let original = format!("{{{payload}");
+            std::fs::write(&path, original.as_bytes()).unwrap();
+            let store = FileStore::new(path.clone());
+
+            prop_assert!(store.store("http://a", "new-token").is_err());
+            prop_assert_eq!(std::fs::read(path).unwrap(), original.into_bytes());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_replaces_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target.json");
+        let link = tmp.path().join("credentials.json");
+        std::fs::write(&target, br#"{"http://a":"old-token"}"#).unwrap();
+        symlink(&target, &link).unwrap();
+
+        FileStore::new(link.clone())
+            .store("http://a", "new-token")
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target).unwrap(),
+            r#"{"http://a":"old-token"}"#
+        );
+        assert_eq!(
+            FileStore::new(link).load("http://a").as_deref(),
+            Some("new-token")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_replaces_hardlink_without_touching_other_name() {
+        use std::fs::hard_link;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let original = tmp.path().join("original.json");
+        let link = tmp.path().join("credentials.json");
+        std::fs::write(&original, br#"{"http://a":"old-token"}"#).unwrap();
+        hard_link(&original, &link).unwrap();
+
+        FileStore::new(link.clone())
+            .store("http://a", "new-token")
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(original).unwrap(),
+            r#"{"http://a":"old-token"}"#
+        );
+        assert_eq!(
+            FileStore::new(link).load("http://a").as_deref(),
+            Some("new-token")
+        );
     }
 
     // ── Origin binding for the env token (LIF-408) ───────────────────────

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -8,8 +8,9 @@
 //!    Manager (Windows) via the `keyring` crate. This is the preferred, secure
 //!    store.
 //! 2. **Plaintext file fallback** — `~/.config/lific/credentials.json`, a map
-//!    of `base_url → token`, written 0600 under a 0700 parent. Used when the
-//!    keyring is unavailable (headless box with no Secret Service, CI, etc.).
+//!    of `base_url → token`, written with owner-only protection under a
+//!    private parent. Used when the keyring is unavailable (headless box with
+//!    no Secret Service, CI, etc.).
 //!    A loud one-line warning is printed to stderr whenever this path is taken,
 //!    because the token lands on disk in the clear.
 //!
@@ -31,15 +32,19 @@
 //!
 //! ## Testability
 //!
-//! The file backend is factored behind [`FileStore`] with an injectable path,
+//! The file backend is factored behind [`PlaintextCredentialFileStore`] with an injectable path,
 //! so the round-trip / permission / precedence tests never touch the real
 //! keyring or the real `~/.config`. The keyring itself is only reachable
 //! through [`store`]/[`load`]/[`delete`]; any test that would hit a live Secret
 //! Service is gated `#[ignore]` (CI has none).
 
 use std::collections::BTreeMap;
-use std::io::Write;
+use std::ffi::OsString;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use thiserror::Error;
 
 /// Environment variable carrying an OAuth token, used in place of stored
 /// credentials when it is bound to the target origin (see [`env_token_for`]).
@@ -164,169 +169,585 @@ fn default_client_file_path() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("lific").join("clients.json"))
 }
 
-fn client_store() -> Option<FileStore> {
-    default_client_file_path().map(FileStore::new)
+fn client_store() -> Option<PlaintextCredentialFileStore> {
+    default_client_file_path().map(PlaintextCredentialFileStore::new)
 }
 
 // The three operations are factored to take the store, like the credential
 // file backend, so the round-trip is testable without touching a real
-// `~/.config`. All three are best-effort: losing this file only costs a
-// re-registration.
+// `~/.config`. A missing file is harmless; a present but unreadable file is
+// reported to the login flow rather than silently discarded.
 
-fn store_client_id_in(store: &FileStore, base_url: &str, client_id: &str) {
-    let _ = store.store(&normalize_base_url(base_url), client_id);
+fn store_client_id_in(
+    store: &PlaintextCredentialFileStore,
+    base_url: &str,
+    client_id: &str,
+) -> Result<(), PlaintextCredentialFileError> {
+    store.store_credential_for_server_key(&CredentialStoreKey::from_base_url(base_url), client_id)
 }
 
-fn load_client_id_from(store: &FileStore, base_url: &str) -> Option<String> {
-    store.load(&normalize_base_url(base_url))
+fn load_client_id_from(
+    store: &PlaintextCredentialFileStore,
+    base_url: &str,
+) -> Result<Option<String>, PlaintextCredentialFileError> {
+    store.load_credential_for_server_key(&CredentialStoreKey::from_base_url(base_url))
 }
 
-fn forget_client_id_in(store: &FileStore, base_url: &str) {
-    let _ = store.delete(&normalize_base_url(base_url));
+fn forget_client_id_in(
+    store: &PlaintextCredentialFileStore,
+    base_url: &str,
+) -> Result<(), PlaintextCredentialFileError> {
+    store
+        .delete_credential_for_server_key(&CredentialStoreKey::from_base_url(base_url))
+        .map(|_| ())
 }
 
 /// Remember the OAuth `client_id` registered with `base_url`.
-pub fn store_client_id(base_url: &str, client_id: &str) {
+pub fn store_client_id(
+    base_url: &str,
+    client_id: &str,
+) -> Result<(), PlaintextCredentialFileError> {
     if let Some(store) = client_store() {
-        store_client_id_in(&store, base_url, client_id);
+        store_client_id_in(&store, base_url, client_id)
+    } else {
+        Ok(())
     }
 }
 
 /// The `client_id` previously registered with `base_url`, if any.
-pub fn load_client_id(base_url: &str) -> Option<String> {
-    load_client_id_from(&client_store()?, base_url)
+pub fn load_client_id(base_url: &str) -> Result<Option<String>, PlaintextCredentialFileError> {
+    match client_store() {
+        Some(store) => load_client_id_from(&store, base_url),
+        None => Ok(None),
+    }
 }
 
 /// Drop the remembered `client_id` for `base_url`, after the server said it
 /// does not know it (reclaimed, or a rebuilt database).
-pub fn forget_client_id(base_url: &str) {
+pub fn forget_client_id(base_url: &str) -> Result<(), PlaintextCredentialFileError> {
     if let Some(store) = client_store() {
-        forget_client_id_in(&store, base_url);
+        forget_client_id_in(&store, base_url)
+    } else {
+        Ok(())
     }
 }
 
-// ── File backend ─────────────────────────────────────────────────────────
+// ── Plaintext credential file backend ───────────────────────────────────
 
-/// The JSON-on-disk fallback store, parameterized on its path so tests can
-/// point it at a tempdir.
-pub struct FileStore {
+/// Normalized key used to select one server's credential in the file.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CredentialStoreKey(String);
+
+impl CredentialStoreKey {
+    /// Normalize a server URL for use as a credential-file key.
+    pub fn from_base_url(base_url: &str) -> Self {
+        Self(normalize_base_url(base_url))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A failure while reading or mutating the plaintext credential file.
+#[derive(Debug, Error)]
+pub enum PlaintextCredentialFileError {
+    #[error("failed to read credential file {path}: {source}")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("credential file {path} is a symbolic link")]
+    Symlink { path: PathBuf },
+    #[error("credential lock {path} is a symbolic link")]
+    LockSymlink { path: PathBuf },
+    #[error("credential lock {path} is not a regular file")]
+    LockNotRegular { path: PathBuf },
+    #[error("credential lock {path} has multiple hard links")]
+    LockHardLinked { path: PathBuf },
+    #[error("credential file {path} is not a regular file")]
+    NotRegular { path: PathBuf },
+    #[error("credential file {path} has multiple hard links")]
+    HardLinked { path: PathBuf },
+    #[error("credential file {path} is not valid UTF-8: {source}")]
+    InvalidUtf8 {
+        path: PathBuf,
+        #[source]
+        source: std::string::FromUtf8Error,
+    },
+    #[error("credential file {path} contains invalid JSON: {source}")]
+    InvalidJson {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to open credential lock {path}: {source}")]
+    LockOpen {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to lock credential store {path}: {source}")]
+    Lock {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to secure credential directory {path}: {source}")]
+    SecureDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("credential directory {path} is not a directory")]
+    DirectoryNotRegular { path: PathBuf },
+    #[error("credential directory {path} is a symbolic link")]
+    DirectorySymlink { path: PathBuf },
+    #[error("failed to apply private credential permissions to {path}: {source}")]
+    Permissions {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to create credential staging file in {path}: {source}")]
+    StageOpen {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to write staged credential file for {path}: {source}")]
+    StageWrite {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to synchronize staged credential file for {path}: {source}")]
+    StageSync {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to publish credential file {path}: {source}")]
+    Publish {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to synchronize credential directory {path}: {source}")]
+    DirectorySync {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// JSON-on-disk fallback for credentials, parameterized on its path for tests.
+pub struct PlaintextCredentialFileStore {
     path: PathBuf,
 }
 
-impl FileStore {
+impl PlaintextCredentialFileStore {
+    /// Create a store backed by `path`. Reads and mutations use the path only
+    /// as a name; existing files are opened with no-follow semantics.
     pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
 
-    fn read_map(&self) -> std::io::Result<BTreeMap<String, String>> {
-        match std::fs::read_to_string(&self.path) {
-            Ok(s) => serde_json::from_str(&s)
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error)),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(BTreeMap::new()),
-            Err(error) => Err(error),
-        }
-    }
-
-    fn write_map(&self, map: &BTreeMap<String, String>) -> std::io::Result<()> {
-        let parent = self
-            .path
+    fn parent_directory(&self) -> &Path {
+        self.path
             .parent()
             .filter(|path| !path.as_os_str().is_empty())
-            .unwrap_or_else(|| Path::new("."));
-        std::fs::create_dir_all(parent)?;
-        // Tighten the parent dir to 0700 (best-effort; only meaningful on unix).
-        set_dir_private(parent);
-        let json = serde_json::to_string_pretty(map).map_err(std::io::Error::other)?;
-        // Write beside the destination and rename it into place. This keeps a
-        // malformed or otherwise unreadable existing file intact on failure.
-        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
-        temporary.write_all(json.as_bytes())?;
-        temporary.flush()?;
-        temporary.as_file().sync_all()?;
-        set_file_private(temporary.as_file());
-        temporary
-            .persist(&self.path)
-            .map(|_| ())
-            .map_err(|error| error.error)
+            .unwrap_or_else(|| Path::new("."))
     }
 
-    /// Store `token` under `key`, creating the file if needed.
-    pub fn store(&self, key: &str, token: &str) -> std::io::Result<()> {
-        let mut map = self.read_map()?;
-        map.insert(key.to_string(), token.to_string());
-        self.write_map(&map)
+    fn lock_path(&self) -> PathBuf {
+        let mut name = OsString::from(self.path.as_os_str());
+        name.push(".lock");
+        PathBuf::from(name)
     }
 
-    /// Load the token for `key`, if present.
-    pub fn load(&self, key: &str) -> Option<String> {
-        self.read_map().ok()?.get(key).cloned()
+    /// Read one complete credential generation, or report that the file is
+    /// absent. The descriptor supplies both metadata and bytes, so a final
+    /// path-component symlink or hard link is never followed or replaced.
+    fn read_existing_credentials_or_return_absent(
+        &self,
+    ) -> Result<Option<BTreeMap<String, String>>, PlaintextCredentialFileError> {
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true);
+        configure_no_follow(&mut options);
+        let mut file = match options.open(&self.path) {
+            Ok(file) => file,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) if is_symlink_open_error(&source) => {
+                return Err(PlaintextCredentialFileError::Symlink {
+                    path: self.path.clone(),
+                });
+            }
+            Err(source) => {
+                return Err(PlaintextCredentialFileError::Read {
+                    path: self.path.clone(),
+                    source,
+                });
+            }
+        };
+
+        #[cfg(windows)]
+        if std::fs::symlink_metadata(&self.path)
+            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            return Err(PlaintextCredentialFileError::Symlink {
+                path: self.path.clone(),
+            });
+        }
+
+        let metadata = file
+            .metadata()
+            .map_err(|source| PlaintextCredentialFileError::Read {
+                path: self.path.clone(),
+                source,
+            })?;
+        if !metadata.file_type().is_file() {
+            return Err(PlaintextCredentialFileError::NotRegular {
+                path: self.path.clone(),
+            });
+        }
+        if file_has_multiple_links(&metadata) {
+            return Err(PlaintextCredentialFileError::HardLinked {
+                path: self.path.clone(),
+            });
+        }
+
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|source| PlaintextCredentialFileError::Read {
+                path: self.path.clone(),
+                source,
+            })?;
+        let contents = String::from_utf8(bytes).map_err(|source| {
+            PlaintextCredentialFileError::InvalidUtf8 {
+                path: self.path.clone(),
+                source,
+            }
+        })?;
+        serde_json::from_str(&contents).map(Some).map_err(|source| {
+            PlaintextCredentialFileError::InvalidJson {
+                path: self.path.clone(),
+                source,
+            }
+        })
     }
 
-    /// Remove `key`. Returns whether an entry was actually removed.
-    pub fn delete(&self, key: &str) -> std::io::Result<bool> {
-        let mut map = self.read_map()?;
-        let removed = map.remove(key).is_some();
+    /// Create and restrict the immediate parent directory before any mutation.
+    /// Existing parents are tightened to owner-only Unix permissions; on
+    /// Windows the platform ACL/default security model remains authoritative.
+    fn secure_parent_directory(&self) -> Result<(), PlaintextCredentialFileError> {
+        let parent = self.parent_directory();
+        std::fs::create_dir_all(parent).map_err(|source| {
+            PlaintextCredentialFileError::SecureDirectory {
+                path: parent.to_owned(),
+                source,
+            }
+        })?;
+
+        let metadata = std::fs::symlink_metadata(parent).map_err(|source| {
+            PlaintextCredentialFileError::SecureDirectory {
+                path: parent.to_owned(),
+                source,
+            }
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(PlaintextCredentialFileError::DirectorySymlink {
+                path: parent.to_owned(),
+            });
+        }
+        if !metadata.file_type().is_dir() {
+            return Err(PlaintextCredentialFileError::DirectoryNotRegular {
+                path: parent.to_owned(),
+            });
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+            let mut options = std::fs::OpenOptions::new();
+            options.read(true).custom_flags(libc::O_NOFOLLOW);
+            let directory = options.open(parent).map_err(|source| {
+                PlaintextCredentialFileError::SecureDirectory {
+                    path: parent.to_owned(),
+                    source,
+                }
+            })?;
+            directory
+                .set_permissions(std::fs::Permissions::from_mode(0o700))
+                .map_err(|source| PlaintextCredentialFileError::SecureDirectory {
+                    path: parent.to_owned(),
+                    source,
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Open and exclusively lock the stable sibling lock file. The returned
+    /// file owns the lock; dropping it releases the lock after publication.
+    fn lock_for_mutation(&self) -> Result<std::fs::File, PlaintextCredentialFileError> {
+        let path = self.lock_path();
+        #[cfg(windows)]
+        if std::fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            return Err(PlaintextCredentialFileError::LockSymlink { path });
+        }
+
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create(true);
+        configure_no_follow(&mut options);
+        let file = options.open(&path).map_err(|source| {
+            if is_symlink_open_error(&source) {
+                PlaintextCredentialFileError::LockSymlink { path: path.clone() }
+            } else {
+                PlaintextCredentialFileError::LockOpen {
+                    path: path.clone(),
+                    source,
+                }
+            }
+        })?;
+        let metadata =
+            file.metadata()
+                .map_err(|source| PlaintextCredentialFileError::LockOpen {
+                    path: path.clone(),
+                    source,
+                })?;
+        if !metadata.file_type().is_file() {
+            return Err(PlaintextCredentialFileError::LockNotRegular { path });
+        }
+        if file_has_multiple_links(&metadata) {
+            return Err(PlaintextCredentialFileError::LockHardLinked { path });
+        }
+        set_open_credential_file_owner_only_permissions(&file, &path)?;
+        file.lock_exclusive()
+            .map_err(|source| PlaintextCredentialFileError::Lock { path, source })?;
+        Ok(file)
+    }
+
+    /// Read the current valid map, treating only an absent document as empty.
+    fn read_credential_map(
+        &self,
+    ) -> Result<BTreeMap<String, String>, PlaintextCredentialFileError> {
+        Ok(self
+            .read_existing_credentials_or_return_absent()?
+            .unwrap_or_default())
+    }
+
+    /// Load the credential for one normalized server key. `Ok(None)` means
+    /// only an absent file, a valid empty map, or an absent key; corruption,
+    /// links, permissions, and I/O failures remain errors.
+    pub fn load_credential_for_server_key(
+        &self,
+        key: &CredentialStoreKey,
+    ) -> Result<Option<String>, PlaintextCredentialFileError> {
+        Ok(self
+            .read_existing_credentials_or_return_absent()?
+            .and_then(|map| map.get(key.as_str()).cloned()))
+    }
+
+    /// Store a credential while holding a stable sibling lock across the
+    /// complete read-modify-write-publication transaction.
+    pub fn store_credential_for_server_key(
+        &self,
+        key: &CredentialStoreKey,
+        credential: &str,
+    ) -> Result<(), PlaintextCredentialFileError> {
+        self.secure_parent_directory()?;
+        let _lock = self.lock_for_mutation()?;
+        let mut map = self.read_credential_map()?;
+        map.insert(key.as_str().to_owned(), credential.to_owned());
+        self.atomically_publish_synchronized_credential_document(&map)
+    }
+
+    /// Delete a credential under the same lock used for stores. A valid map
+    /// with no matching key is a successful no-op; malformed or unsafe files
+    /// are errors and are left untouched.
+    pub fn delete_credential_for_server_key(
+        &self,
+        key: &CredentialStoreKey,
+    ) -> Result<bool, PlaintextCredentialFileError> {
+        self.secure_parent_directory()?;
+        let _lock = self.lock_for_mutation()?;
+        let mut map = self.read_credential_map()?;
+        let removed = map.remove(key.as_str()).is_some();
         if removed {
-            self.write_map(&map)?;
+            self.atomically_publish_synchronized_credential_document(&map)?;
         }
         Ok(removed)
     }
+
+    /// Serialize, protect, flush, atomically publish, and durably sync one
+    /// credential generation. The caller holds the sibling lock for the full
+    /// read/modify/stage/publish transaction.
+    fn atomically_publish_synchronized_credential_document(
+        &self,
+        map: &BTreeMap<String, String>,
+    ) -> Result<(), PlaintextCredentialFileError> {
+        let json = serde_json::to_vec_pretty(map).map_err(|source| {
+            PlaintextCredentialFileError::StageWrite {
+                path: self.path.clone(),
+                source: std::io::Error::other(source),
+            }
+        })?;
+        let parent = self.parent_directory();
+        let mut temporary = tempfile::NamedTempFile::new_in(parent).map_err(|source| {
+            PlaintextCredentialFileError::StageOpen {
+                path: parent.to_owned(),
+                source,
+            }
+        })?;
+        set_open_credential_file_owner_only_permissions(temporary.as_file(), temporary.path())?;
+        temporary.as_file_mut().write_all(&json).map_err(|source| {
+            PlaintextCredentialFileError::StageWrite {
+                path: self.path.clone(),
+                source,
+            }
+        })?;
+        temporary.as_file().sync_all().map_err(|source| {
+            PlaintextCredentialFileError::StageSync {
+                path: self.path.clone(),
+                source,
+            }
+        })?;
+        temporary
+            .persist(&self.path)
+            .map_err(|error| PlaintextCredentialFileError::Publish {
+                path: self.path.clone(),
+                source: error.error,
+            })?;
+        synchronize_credential_parent_directory(parent)
+    }
 }
 
-/// Best-effort chmod 0600 on the credentials file (unix only).
-fn set_file_private(file: &std::fs::File) {
+/// Apply owner-only protection to an open credential or lock file.
+fn set_open_credential_file_owner_only_permissions(
+    file: &std::fs::File,
+    path: &Path,
+) -> Result<(), PlaintextCredentialFileError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|source| PlaintextCredentialFileError::Permissions {
+                path: path.to_owned(),
+                source,
+            })?;
     }
     #[cfg(not(unix))]
     {
         let _ = file;
+        let _ = path;
     }
+    Ok(())
 }
 
-/// Best-effort chmod 0700 on the parent dir (unix only).
-fn set_dir_private(dir: &Path) {
+/// Sync the directory entry after publishing a credential file. File sync
+/// persists bytes; directory sync persists the name-to-inode replacement.
+fn synchronize_credential_parent_directory(
+    parent: &Path,
+) -> Result<(), PlaintextCredentialFileError> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+        std::fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|source| PlaintextCredentialFileError::DirectorySync {
+                path: parent.to_owned(),
+                source,
+            })?;
     }
     #[cfg(not(unix))]
     {
-        let _ = dir;
+        let _ = parent;
+    }
+    Ok(())
+}
+
+/// Configure the strongest stable final-component no-follow flag available
+/// on the target platform. Windows reparse points are rejected by handle
+/// metadata; ancestor replacement remains outside this path-level guarantee.
+fn configure_no_follow(options: &mut std::fs::OpenOptions) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // FILE_FLAG_OPEN_REPARSE_POINT: open a reparse point itself instead
+        // of traversing it. The handle is then rejected as a symlink below.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+}
+
+fn is_symlink_open_error(error: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        error.raw_os_error() == Some(libc::ELOOP)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = error;
+        false
+    }
+}
+
+fn file_has_multiple_links(metadata: &std::fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        metadata.nlink() != 1
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        false
     }
 }
 
 // ── Public API (keyring + file, with env override on load) ───────────────
 
+#[derive(Debug, Error)]
+pub enum CredentialStoreError {
+    #[error("cannot resolve the platform configuration directory")]
+    ConfigDirectoryUnavailable,
+    #[error(transparent)]
+    Plaintext(#[from] PlaintextCredentialFileError),
+}
+
 /// Store a token for `base_url`. Tries the keyring first; on any keyring error
 /// falls back to the plaintext file and prints a loud warning to stderr.
-pub fn store(base_url: &str, token: &str) -> Result<(), String> {
-    let key = normalize_base_url(base_url);
-    match keyring_store(&key, token) {
+pub fn store(base_url: &str, token: &str) -> Result<(), CredentialStoreError> {
+    let key = CredentialStoreKey::from_base_url(base_url);
+    match keyring_store(key.as_str(), token) {
         Ok(()) => Ok(()),
         Err(e) => {
-            let store = FileStore::new(
-                default_file_path().ok_or_else(|| "cannot resolve config dir".to_string())?,
+            let store = PlaintextCredentialFileStore::new(
+                default_file_path().ok_or(CredentialStoreError::ConfigDirectoryUnavailable)?,
             );
             eprintln!(
-                "warning: OS keyring unavailable ({e}); storing token in PLAINTEXT at {} (0600). \
+                "warning: OS keyring unavailable ({e}); storing token in PLAINTEXT at {} ({}). \
                  Set up a Secret Service/Keychain to secure it, or use {TOKEN_ENV} to avoid on-disk storage.",
-                store.path.display()
+                store.path.display(),
+                plaintext_protection_description()
             );
             store
-                .store(&key, token)
-                .map_err(|e| format!("failed to write credentials file: {e}"))
+                .store_credential_for_server_key(&key, token)
+                .map_err(CredentialStoreError::from)
         }
     }
 }
 
 /// Load a token for `base_url`. Precedence: `LIFIC_TOKEN` env (only when bound
 /// to `base_url`'s origin, see [`env_token_for`]) > keyring > file.
-pub fn load(base_url: &str) -> Option<String> {
-    load_with_source(base_url).map(|(token, _)| token)
+pub fn load(base_url: &str) -> Result<Option<String>, PlaintextCredentialFileError> {
+    load_with_source(base_url).map(|value| value.map(|(token, _)| token))
 }
 
 /// Describes where a loaded token came from, for `doctor`'s detail note.
@@ -349,32 +770,52 @@ impl TokenSource {
 
 /// Like [`load`] but also reports which backend supplied the token, so callers
 /// (doctor) can tell the user where it came from.
-pub fn load_with_source(base_url: &str) -> Option<(String, TokenSource)> {
+pub fn load_with_source(
+    base_url: &str,
+) -> Result<Option<(String, TokenSource)>, PlaintextCredentialFileError> {
     match env_token_for(
         std::env::var(TOKEN_ENV).ok().as_deref(),
         std::env::var(URL_ENV).ok().as_deref(),
         base_url,
     ) {
-        EnvToken::Bound(token) => return Some((token, TokenSource::Env)),
+        EnvToken::Bound(token) => return Ok(Some((token, TokenSource::Env))),
         EnvToken::Unbound => warn_env_token_unbound(base_url),
         EnvToken::Absent => {}
     }
-    let key = normalize_base_url(base_url);
-    if let Some(tok) = keyring_load(&key) {
-        return Some((tok, TokenSource::Keyring));
+    let key = CredentialStoreKey::from_base_url(base_url);
+    if let Some(tok) = keyring_load(key.as_str()) {
+        return Ok(Some((tok, TokenSource::Keyring)));
     }
-    default_file_path()
-        .and_then(|p| FileStore::new(p).load(&key))
-        .map(|tok| (tok, TokenSource::File))
+    match default_file_path() {
+        Some(path) => PlaintextCredentialFileStore::new(path)
+            .load_credential_for_server_key(&key)
+            .map(|token| token.map(|token| (token, TokenSource::File))),
+        None => Ok(None),
+    }
 }
 
 /// Delete the stored credential for `base_url` from BOTH backends. Returns
 /// whether anything was removed from either.
-pub fn delete(base_url: &str) -> bool {
-    let key = normalize_base_url(base_url);
-    let kr = keyring_delete(&key);
-    let file = default_file_path().is_some_and(|p| FileStore::new(p).delete(&key).unwrap_or(false));
-    kr || file
+pub fn delete(base_url: &str) -> Result<bool, PlaintextCredentialFileError> {
+    let key = CredentialStoreKey::from_base_url(base_url);
+    let kr = keyring_delete(key.as_str());
+    let file = match default_file_path() {
+        Some(path) => {
+            PlaintextCredentialFileStore::new(path).delete_credential_for_server_key(&key)?
+        }
+        None => false,
+    };
+    Ok(kr || file)
+}
+
+#[cfg(unix)]
+const fn plaintext_protection_description() -> &'static str {
+    "0600 file permissions"
+}
+
+#[cfg(not(unix))]
+const fn plaintext_protection_description() -> &'static str {
+    "platform file permissions"
 }
 
 // ── Keyring backend (thin wrappers so the public API stays backend-agnostic) ─
@@ -407,10 +848,10 @@ mod tests {
     /// A file store in a fresh scratch directory. Hold onto the returned
     /// [`TempDir`]: dropping it removes the directory, which also happens
     /// while a failed assertion unwinds.
-    fn tmp_store() -> (FileStore, tempfile::TempDir) {
+    fn tmp_store() -> (PlaintextCredentialFileStore, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("credentials.json");
-        (FileStore::new(path), tmp)
+        (PlaintextCredentialFileStore::new(path), tmp)
     }
 
     /// The remembered client id is what keeps `lific login` from registering
@@ -420,32 +861,38 @@ mod tests {
     #[test]
     fn a_client_id_round_trips_per_server_and_can_be_forgotten() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = FileStore::new(tmp.path().join("clients.json"));
+        let store = PlaintextCredentialFileStore::new(tmp.path().join("clients.json"));
 
-        assert_eq!(load_client_id_from(&store, "http://127.0.0.1:3998"), None);
+        assert_eq!(
+            load_client_id_from(&store, "http://127.0.0.1:3998").unwrap(),
+            None
+        );
 
-        store_client_id_in(&store, "http://127.0.0.1:3998", "client-abc");
+        store_client_id_in(&store, "http://127.0.0.1:3998", "client-abc").unwrap();
         // Same server, different spelling → same entry.
         assert_eq!(
-            load_client_id_from(&store, "http://127.0.0.1:3998/"),
+            load_client_id_from(&store, "http://127.0.0.1:3998/").unwrap(),
             Some("client-abc".to_string())
         );
 
         // A second server keeps its own id.
-        store_client_id_in(&store, "https://lific.example", "client-xyz");
+        store_client_id_in(&store, "https://lific.example", "client-xyz").unwrap();
         assert_eq!(
-            load_client_id_from(&store, "https://lific.example"),
+            load_client_id_from(&store, "https://lific.example").unwrap(),
             Some("client-xyz".to_string())
         );
         assert_eq!(
-            load_client_id_from(&store, "http://127.0.0.1:3998"),
+            load_client_id_from(&store, "http://127.0.0.1:3998").unwrap(),
             Some("client-abc".to_string())
         );
 
-        forget_client_id_in(&store, "http://127.0.0.1:3998/");
-        assert_eq!(load_client_id_from(&store, "http://127.0.0.1:3998"), None);
+        forget_client_id_in(&store, "http://127.0.0.1:3998/").unwrap();
         assert_eq!(
-            load_client_id_from(&store, "https://lific.example"),
+            load_client_id_from(&store, "http://127.0.0.1:3998").unwrap(),
+            None
+        );
+        assert_eq!(
+            load_client_id_from(&store, "https://lific.example").unwrap(),
             Some("client-xyz".to_string()),
             "forgetting one server must not clear another"
         );
@@ -477,39 +924,64 @@ mod tests {
     }
 
     #[test]
-    fn file_store_round_trip() {
+    fn plaintext_store_round_trip() {
         let (store, _g) = tmp_store();
-        assert_eq!(store.load("http://a"), None);
-        store.store("http://a", "tok-a").unwrap();
-        store.store("http://b", "tok-b").unwrap();
-        assert_eq!(store.load("http://a").as_deref(), Some("tok-a"));
-        assert_eq!(store.load("http://b").as_deref(), Some("tok-b"));
+        let a = CredentialStoreKey::from_base_url("http://a");
+        let b = CredentialStoreKey::from_base_url("http://b");
+        assert_eq!(store.load_credential_for_server_key(&a).unwrap(), None);
+        store.store_credential_for_server_key(&a, "tok-a").unwrap();
+        store.store_credential_for_server_key(&b, "tok-b").unwrap();
+        assert_eq!(
+            store.load_credential_for_server_key(&a).unwrap().as_deref(),
+            Some("tok-a")
+        );
+        assert_eq!(
+            store.load_credential_for_server_key(&b).unwrap().as_deref(),
+            Some("tok-b")
+        );
 
         // Overwrite existing key.
-        store.store("http://a", "tok-a2").unwrap();
-        assert_eq!(store.load("http://a").as_deref(), Some("tok-a2"));
+        store.store_credential_for_server_key(&a, "tok-a2").unwrap();
+        assert_eq!(
+            store.load_credential_for_server_key(&a).unwrap().as_deref(),
+            Some("tok-a2")
+        );
     }
 
     #[test]
-    fn file_store_delete_removes_only_target() {
+    fn plaintext_store_delete_removes_only_target() {
         let (store, _g) = tmp_store();
-        store.store("http://a", "tok-a").unwrap();
-        store.store("http://b", "tok-b").unwrap();
+        let a = CredentialStoreKey::from_base_url("http://a");
+        let b = CredentialStoreKey::from_base_url("http://b");
+        let missing = CredentialStoreKey::from_base_url("http://missing");
+        store.store_credential_for_server_key(&a, "tok-a").unwrap();
+        store.store_credential_for_server_key(&b, "tok-b").unwrap();
 
-        assert!(store.delete("http://a").unwrap(), "delete reports removal");
-        assert_eq!(store.load("http://a"), None);
-        assert_eq!(store.load("http://b").as_deref(), Some("tok-b"));
+        assert!(
+            store.delete_credential_for_server_key(&a).unwrap(),
+            "delete reports removal"
+        );
+        assert_eq!(store.load_credential_for_server_key(&a).unwrap(), None);
+        assert_eq!(
+            store.load_credential_for_server_key(&b).unwrap().as_deref(),
+            Some("tok-b")
+        );
 
         // Deleting a missing key is a no-op that reports false.
-        assert!(!store.delete("http://missing").unwrap());
+        assert!(!store.delete_credential_for_server_key(&missing).unwrap());
     }
 
     #[cfg(unix)]
     #[test]
-    fn file_store_writes_0600_file_and_0700_dir() {
+    fn plaintext_store_writes_0600_file_and_0700_dir() {
         use std::os::unix::fs::PermissionsExt;
         let (store, _g) = tmp_store();
-        store.store("http://a", "secret").unwrap();
+        store
+            .store_credential_for_server_key(
+                &CredentialStoreKey::from_base_url("http://a"),
+                "secret",
+            )
+            .unwrap();
 
         let file_mode = std::fs::metadata(&store.path).unwrap().permissions().mode() & 0o777;
         assert_eq!(file_mode, 0o600, "credentials file must be 0600");
@@ -523,7 +995,7 @@ mod tests {
     }
 
     #[test]
-    fn file_store_creates_missing_parent_dir() {
+    fn plaintext_store_creates_missing_parent_dir() {
         let tmp = tempfile::tempdir().unwrap();
         // Path two levels deep, neither of which exists yet.
         let path = tmp
@@ -531,41 +1003,208 @@ mod tests {
             .join("deep")
             .join("nested")
             .join("credentials.json");
-        let store = FileStore::new(path.clone());
-        store.store("http://a", "tok").unwrap();
+        let store = PlaintextCredentialFileStore::new(path.clone());
+        store
+            .store_credential_for_server_key(&CredentialStoreKey::from_base_url("http://a"), "tok")
+            .unwrap();
         assert!(path.exists());
-        assert_eq!(store.load("http://a").as_deref(), Some("tok"));
+        assert_eq!(
+            store
+                .load_credential_for_server_key(&CredentialStoreKey::from_base_url("http://a"))
+                .unwrap()
+                .as_deref(),
+            Some("tok")
+        );
     }
 
     #[test]
-    fn file_store_rejects_malformed_existing_data_without_replacing_it() {
+    fn malformed_credential_file_is_a_typed_read_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("credentials.json");
+        let original = br#"{"http://a": broken}"#;
+        std::fs::write(&path, original).unwrap();
+        let store = PlaintextCredentialFileStore::new(path.clone());
+        let key = CredentialStoreKey::from_base_url("http://a");
+
+        assert!(matches!(
+            store.load_credential_for_server_key(&key),
+            Err(PlaintextCredentialFileError::InvalidJson { .. })
+        ));
+        assert_eq!(std::fs::read(path).unwrap(), original);
+    }
+
+    #[test]
+    fn plaintext_store_rejects_malformed_existing_data_without_replacing_it() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("credentials.json");
         let original = br#"{"http://a":"old-token", broken}"#;
         std::fs::write(&path, original).unwrap();
-        let store = FileStore::new(path.clone());
+        let store = PlaintextCredentialFileStore::new(path.clone());
 
-        assert!(store.store("http://a", "new-token").is_err());
+        assert!(
+            store
+                .store_credential_for_server_key(
+                    &CredentialStoreKey::from_base_url("http://a"),
+                    "new-token"
+                )
+                .is_err()
+        );
         assert_eq!(std::fs::read(path).unwrap(), original);
     }
 
+    #[test]
+    fn invalid_credential_documents_are_errors_and_remain_unchanged() {
+        let cases: &[(&str, &[u8])] = &[
+            ("malformed syntax", br#"{"http://a": broken}"#),
+            ("truncated object", br#"{"http://a":"token""#),
+            ("wrong top-level type", br#"["token"]"#),
+            ("non-string value", br#"{"http://a":42}"#),
+            ("invalid UTF-8", b"{\xff"),
+        ];
+        for (name, original) in cases {
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join("credentials.json");
+            std::fs::write(&path, original).unwrap();
+            let store = PlaintextCredentialFileStore::new(path.clone());
+            let key = CredentialStoreKey::from_base_url("http://a");
+
+            assert!(
+                store.load_credential_for_server_key(&key).is_err(),
+                "{name}"
+            );
+            assert!(
+                store.store_credential_for_server_key(&key, "new").is_err(),
+                "{name}"
+            );
+            assert!(
+                store.delete_credential_for_server_key(&key).is_err(),
+                "{name}"
+            );
+            assert_eq!(std::fs::read(path).unwrap(), *original, "{name}");
+        }
+    }
+
+    #[test]
+    fn absent_empty_and_populated_documents_have_distinct_successful_results() {
+        let (store, _tmp) = tmp_store();
+        let key = CredentialStoreKey::from_base_url("http://a");
+        assert_eq!(store.load_credential_for_server_key(&key).unwrap(), None);
+
+        std::fs::write(&store.path, b"{}").unwrap();
+        assert_eq!(store.load_credential_for_server_key(&key).unwrap(), None);
+
+        store
+            .store_credential_for_server_key(&key, "token")
+            .unwrap();
+        assert_eq!(
+            store
+                .load_credential_for_server_key(&key)
+                .unwrap()
+                .as_deref(),
+            Some("token")
+        );
+    }
+
+    #[test]
+    fn credential_path_must_be_a_regular_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("credentials.json");
+        std::fs::create_dir(&path).unwrap();
+        let store = PlaintextCredentialFileStore::new(path.clone());
+        let key = CredentialStoreKey::from_base_url("http://a");
+
+        assert!(matches!(
+            store.load_credential_for_server_key(&key),
+            Err(PlaintextCredentialFileError::NotRegular { .. })
+        ));
+        assert!(matches!(
+            store.store_credential_for_server_key(&key, "new"),
+            Err(PlaintextCredentialFileError::NotRegular { .. })
+        ));
+        assert!(
+            path.is_dir(),
+            "a rejected directory must remain a directory"
+        );
+    }
+
     proptest! {
+        // Arbitrary Unicode exercises JSON escaping and round-trip behavior
+        // that a finite table of representative strings cannot cover.
+        #[test]
+        fn arbitrary_credential_text_round_trips(token in any::<String>()) {
+            let tmp = tempfile::tempdir().unwrap();
+            let store = PlaintextCredentialFileStore::new(tmp.path().join("credentials.json"));
+            let key = CredentialStoreKey::from_base_url("http://unicode");
+
+            store.store_credential_for_server_key(&key, &token).unwrap();
+            prop_assert_eq!(store.load_credential_for_server_key(&key).unwrap(), Some(token));
+        }
+
         #[test]
         fn malformed_file_content_is_never_replaced(payload in any::<String>()) {
             let tmp = tempfile::tempdir().unwrap();
             let path = tmp.path().join("credentials.json");
             let original = format!("not-json:{payload}");
             std::fs::write(&path, original.as_bytes()).unwrap();
-            let store = FileStore::new(path.clone());
+            let store = PlaintextCredentialFileStore::new(path.clone());
 
-            prop_assert!(store.store("http://a", "new-token").is_err());
+            prop_assert!(store.store_credential_for_server_key(&CredentialStoreKey::from_base_url("http://a"), "new-token").is_err());
             prop_assert_eq!(std::fs::read(path).unwrap(), original.into_bytes());
+        }
+    }
+
+    #[test]
+    fn concurrent_stores_preserve_both_credentials() {
+        use std::sync::{Arc, Barrier};
+
+        for _ in 0..16 {
+            let (store, _tmp) = tmp_store();
+            let barrier = Arc::new(Barrier::new(3));
+            let left = Arc::new(store);
+            let left_for_thread = Arc::clone(&left);
+            let right = Arc::clone(&left);
+            let left_barrier = Arc::clone(&barrier);
+            let right_barrier = Arc::clone(&barrier);
+            let left_thread = std::thread::spawn(move || {
+                left_barrier.wait();
+                left_for_thread.store_credential_for_server_key(
+                    &CredentialStoreKey::from_base_url("http://left"),
+                    "left-token",
+                )
+            });
+            let right_thread = std::thread::spawn(move || {
+                right_barrier.wait();
+                right.store_credential_for_server_key(
+                    &CredentialStoreKey::from_base_url("http://right"),
+                    "right-token",
+                )
+            });
+            barrier.wait();
+            left_thread.join().unwrap().unwrap();
+            right_thread.join().unwrap().unwrap();
+
+            assert_eq!(
+                left.load_credential_for_server_key(&CredentialStoreKey::from_base_url(
+                    "http://left"
+                ))
+                .unwrap()
+                .as_deref(),
+                Some("left-token")
+            );
+            assert_eq!(
+                left.load_credential_for_server_key(&CredentialStoreKey::from_base_url(
+                    "http://right"
+                ))
+                .unwrap()
+                .as_deref(),
+                Some("right-token")
+            );
         }
     }
 
     #[cfg(unix)]
     #[test]
-    fn atomic_write_replaces_symlink_without_touching_target() {
+    fn credential_store_rejects_symlink_without_touching_target() {
         use std::os::unix::fs::symlink;
 
         let tmp = tempfile::tempdir().unwrap();
@@ -574,43 +1213,52 @@ mod tests {
         std::fs::write(&target, br#"{"http://a":"old-token"}"#).unwrap();
         symlink(&target, &link).unwrap();
 
-        FileStore::new(link.clone())
-            .store("http://a", "new-token")
-            .unwrap();
+        let store = PlaintextCredentialFileStore::new(link.clone());
+        assert!(matches!(
+            store.store_credential_for_server_key(
+                &CredentialStoreKey::from_base_url("http://a"),
+                "new-token"
+            ),
+            Err(PlaintextCredentialFileError::Symlink { .. })
+        ));
+        assert!(matches!(
+            store.load_credential_for_server_key(&CredentialStoreKey::from_base_url("http://a")),
+            Err(PlaintextCredentialFileError::Symlink { .. })
+        ));
 
+        assert_eq!(std::fs::read_link(&link).unwrap(), target);
         assert_eq!(
-            std::fs::read_to_string(target).unwrap(),
+            std::fs::read_to_string(&target).unwrap(),
             r#"{"http://a":"old-token"}"#
-        );
-        assert_eq!(
-            FileStore::new(link).load("http://a").as_deref(),
-            Some("new-token")
         );
     }
 
     #[cfg(unix)]
     #[test]
-    fn atomic_write_replaces_hardlink_without_touching_other_name() {
+    fn credential_store_rejects_hardlink_without_touching_either_name() {
         use std::fs::hard_link;
 
         let tmp = tempfile::tempdir().unwrap();
         let original = tmp.path().join("original.json");
         let link = tmp.path().join("credentials.json");
-        std::fs::write(&original, br#"{"http://a":"old-token"}"#).unwrap();
+        let bytes = br#"{"http://a":"old-token"}"#;
+        std::fs::write(&original, bytes).unwrap();
         hard_link(&original, &link).unwrap();
 
-        FileStore::new(link.clone())
-            .store("http://a", "new-token")
-            .unwrap();
-
-        assert_eq!(
-            std::fs::read_to_string(original).unwrap(),
-            r#"{"http://a":"old-token"}"#
-        );
-        assert_eq!(
-            FileStore::new(link).load("http://a").as_deref(),
-            Some("new-token")
-        );
+        let store = PlaintextCredentialFileStore::new(link.clone());
+        assert!(matches!(
+            store.store_credential_for_server_key(
+                &CredentialStoreKey::from_base_url("http://a"),
+                "new-token"
+            ),
+            Err(PlaintextCredentialFileError::HardLinked { .. })
+        ));
+        assert!(matches!(
+            store.load_credential_for_server_key(&CredentialStoreKey::from_base_url("http://a")),
+            Err(PlaintextCredentialFileError::HardLinked { .. })
+        ));
+        assert_eq!(std::fs::read(&original).unwrap(), bytes);
+        assert_eq!(std::fs::read(&link).unwrap(), bytes);
     }
 
     // ── Origin binding for the env token (LIF-408) ───────────────────────
@@ -789,7 +1437,7 @@ mod tests {
 
         // SAFETY: guarded by the crate-wide LIFIC_TOKEN lock; restored below.
         unsafe { std::env::set_var(TOKEN_ENV, "env-tok") };
-        let got = load(target);
+        let got = load(target).unwrap();
         unsafe { std::env::remove_var(TOKEN_ENV) };
 
         assert_ne!(
@@ -804,7 +1452,7 @@ mod tests {
         let _lock = lock_lific_token_env_blocking();
         unsafe { std::env::set_var(TOKEN_ENV, "   ") };
         // An all-whitespace env var must not shadow real backends.
-        let got_source = load_with_source("http://noenv-empty");
+        let got_source = load_with_source("http://noenv-empty").unwrap();
         unsafe { std::env::remove_var(TOKEN_ENV) };
         // No token anywhere for this URL → None (env ignored).
         assert!(got_source.is_none() || got_source.unwrap().1 != TokenSource::Env);

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -204,8 +204,16 @@ pub async fn build_report_with_config_path(
     ) = match key {
         Some(k) => (Some(k.to_string()), None),
         None => match crate::cli::credentials::load_with_source(cred_base) {
-            Some((tok, src)) => (Some(tok), Some(src)),
-            None => (None, None),
+            Ok(Some((tok, src))) => (Some(tok), Some(src)),
+            Ok(None) => (None, None),
+            Err(error) => {
+                checks.push(Check::new(
+                    "credentials",
+                    Status::Fail,
+                    format!("failed to read stored credentials: {error}"),
+                ));
+                (None, None)
+            }
         },
     };
 

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -257,8 +257,12 @@ impl DeviceFlow for HttpDeviceFlow {
                 Err(DeviceAuthFailure::Other(e)) => return Err(e),
                 // Stale id: fall through and register a new one.
                 Err(DeviceAuthFailure::UnknownClient) => {
-                    crate::cli::credentials::forget_client_id(&self.base)
-                        .map_err(|error| error.to_string())?;
+                    if let Err(error) = crate::cli::credentials::forget_client_id(&self.base) {
+                        eprintln!(
+                            "warning: could not remove stale OAuth client cache entry for {}: {error}; continuing with a new registration",
+                            self.base
+                        );
+                    }
                 }
             }
         }
@@ -280,8 +284,12 @@ impl DeviceFlow for HttpDeviceFlow {
                 DeviceAuthFailure::Other(e) => e,
             });
         };
-        crate::cli::credentials::store_client_id(&self.base, &client_id)
-            .map_err(|error| error.to_string())?;
+        if let Err(error) = crate::cli::credentials::store_client_id(&self.base, &client_id) {
+            eprintln!(
+                "warning: could not cache OAuth client registration for {}: {error}; continuing with the registered client",
+                self.base
+            );
+        }
 
         self.device_authorization(&[("scope", "mcp"), ("client_id", &client_id)])
             .map_err(|e| match e {

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -249,13 +249,16 @@ impl DeviceFlow for HttpDeviceFlow {
         // one. A server can never reclaim a client that has minted a token,
         // so registering per login would leak one of its dynamic-client slots
         // every time, and spend one of this IP's ten hourly registrations.
-        if let Some(client_id) = crate::cli::credentials::load_client_id(&self.base) {
+        if let Some(client_id) = crate::cli::credentials::load_client_id(&self.base)
+            .map_err(|error| error.to_string())?
+        {
             match self.device_authorization(&[("scope", "mcp"), ("client_id", &client_id)]) {
                 Ok(resp) => return Ok(resp),
                 Err(DeviceAuthFailure::Other(e)) => return Err(e),
                 // Stale id: fall through and register a new one.
                 Err(DeviceAuthFailure::UnknownClient) => {
-                    crate::cli::credentials::forget_client_id(&self.base);
+                    crate::cli::credentials::forget_client_id(&self.base)
+                        .map_err(|error| error.to_string())?;
                 }
             }
         }
@@ -277,7 +280,8 @@ impl DeviceFlow for HttpDeviceFlow {
                 DeviceAuthFailure::Other(e) => e,
             });
         };
-        crate::cli::credentials::store_client_id(&self.base, &client_id);
+        crate::cli::credentials::store_client_id(&self.base, &client_id)
+            .map_err(|error| error.to_string())?;
 
         self.device_authorization(&[("scope", "mcp"), ("client_id", &client_id)])
             .map_err(|e| match e {
@@ -448,7 +452,7 @@ fn finish(args: &LoginArgs, base: &str, outcome: PollOutcome, json: bool) -> Res
                 }
                 return Ok(());
             }
-            crate::cli::credentials::store(base, &token)?;
+            crate::cli::credentials::store(base, &token).map_err(|error| error.to_string())?;
             if json {
                 println!(
                     "{}",
@@ -472,17 +476,17 @@ fn finish(args: &LoginArgs, base: &str, outcome: PollOutcome, json: bool) -> Res
 }
 
 /// `lific logout`: delete the stored credential and best-effort revoke it.
-pub fn run_logout(url: Option<&str>, cfg: &Config, json: bool) {
+pub fn run_logout(url: Option<&str>, cfg: &Config, json: bool) -> Result<(), String> {
     let base = resolve_base_url(url, cfg);
     // Grab the token first so we can revoke it before deleting.
-    let existing = crate::cli::credentials::load(&base);
+    let existing = crate::cli::credentials::load(&base).map_err(|error| error.to_string())?;
     if let Some(token) = &existing
         && let Ok(flow) = HttpDeviceFlow::new(&base)
     {
         // Best-effort; ignore revoke failures (server may be down).
         let _ = flow.revoke(token);
     }
-    let removed = crate::cli::credentials::delete(&base);
+    let removed = crate::cli::credentials::delete(&base).map_err(|error| error.to_string())?;
     if json {
         println!(
             "{}",
@@ -497,6 +501,7 @@ pub fn run_logout(url: Option<&str>, cfg: &Config, json: bool) {
     } else {
         crate::cli::ui::info(format!("No stored credential for {base}."));
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,14 @@ use std::path::PathBuf;
 #[error("--api-key was provided but empty")]
 pub(super) struct EmptyHttpCredential;
 
+#[derive(Debug, thiserror::Error)]
+pub(super) enum HttpCredentialError {
+    #[error(transparent)]
+    Empty(#[from] EmptyHttpCredential),
+    #[error("failed to load stored credential: {0}")]
+    Stored(#[from] credentials::PlaintextCredentialFileError),
+}
+
 #[must_use = "iterate over the non-empty CSV values"]
 pub(super) fn split_csv(value: &str) -> impl Iterator<Item = &str> {
     value
@@ -42,18 +50,18 @@ pub(super) fn owned_labels(value: Option<&str>) -> Option<Vec<String>> {
 #[must_use = "use the resolved HTTP credential"]
 pub(super) fn resolve_http_credential(
     explicit: Option<&str>,
-    stored: impl FnOnce() -> Option<String>,
-) -> Result<Option<String>, EmptyHttpCredential> {
+    stored: impl FnOnce() -> Result<Option<String>, credentials::PlaintextCredentialFileError>,
+) -> Result<Option<String>, HttpCredentialError> {
     match explicit {
         Some(value) => {
             let value = value.trim();
             if value.is_empty() {
-                Err(EmptyHttpCredential)
+                Err(HttpCredentialError::Empty(EmptyHttpCredential))
             } else {
                 Ok(Some(value.to_owned()))
             }
         }
-        None => Ok(stored()
+        None => Ok(stored()?
             .map(|value| value.trim().to_owned())
             .filter(|value| !value.is_empty())),
     }
@@ -1270,22 +1278,22 @@ mod tests {
     #[test]
     fn http_credential_prefers_explicit_and_ignores_blank_stored_values() {
         assert_eq!(
-            resolve_http_credential(Some(" explicit "), || Some("stored".into())),
-            Ok(Some("explicit".into()))
+            resolve_http_credential(Some(" explicit "), || Ok(Some("stored".into()))).unwrap(),
+            Some("explicit".into())
         );
         assert_eq!(
-            resolve_http_credential(None, || Some(" stored ".into())),
-            Ok(Some("stored".into()))
+            resolve_http_credential(None, || Ok(Some(" stored ".into()))).unwrap(),
+            Some("stored".into())
         );
         assert_eq!(
-            resolve_http_credential(None, || Some("  ".into())),
-            Ok(None)
+            resolve_http_credential(None, || Ok(Some("  ".into()))).unwrap(),
+            None
         );
     }
 
     #[test]
     fn http_credential_rejects_blank_explicit_value() {
-        let error = resolve_http_credential(Some("  "), || Some("stored".into())).unwrap_err();
+        let error = resolve_http_credential(Some("  "), || Ok(Some("stored".into()))).unwrap_err();
         assert_eq!(error.to_string(), "--api-key was provided but empty");
     }
 
@@ -1294,11 +1302,29 @@ mod tests {
         let mut loaded = false;
         let credential = resolve_http_credential(Some("explicit"), || {
             loaded = true;
-            Some("stored".into())
+            Ok(Some("stored".into()))
         });
 
         assert_eq!(credential.unwrap(), Some("explicit".into()));
         assert!(!loaded);
+    }
+
+    #[test]
+    fn http_credential_surfaces_stored_read_errors() {
+        let error = resolve_http_credential(None, || {
+            Err(credentials::PlaintextCredentialFileError::Read {
+                path: PathBuf::from("credentials.json"),
+                source: std::io::Error::other("permission denied"),
+            })
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, HttpCredentialError::Stored(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("failed to load stored credential")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,7 +356,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cli::login::run_logout(url.as_deref(), &cfg_clone, json)
             })
             .await
-            .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+            .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?
+            .map_err(|e| -> Box<dyn std::error::Error> { std::io::Error::other(e).into() })?;
             return Ok(());
         }
 


### PR DESCRIPTION
## Scope

This PR is the credential-safety slice of the CLI refactor. It keeps the existing credential formats and OAuth protocol intact while making local storage failures explicit and recovery-safe.

## Changes

- `src/cli/credentials.rs` now treats only a missing credential document as empty. Malformed JSON, invalid UTF-8, unreadable files, symlinks, hard links, non-regular files, unsafe locks, permission failures, and other I/O failures remain typed errors.
- Credential mutations use a stable sibling lock for the entire read-modify-write transaction, write to an owner-protected same-directory temporary file, `sync_all()` the staged bytes, atomically publish the replacement, and sync the parent directory on Unix.
- Credential load/store/delete errors propagate through normal CLI HTTP credential resolution, login, and logout instead of being mistaken for absent credentials.
- `lific doctor` reports stored-credential read failures as a failed diagnostic while continuing independent checks.
- OAuth `clients.json` is modeled as a separately named public client-registration cache. Corrupt or unsafe cache data remains a hard read error; a cache write after successful remote registration and stale-entry cleanup may warn and continue with the in-memory registration.
- Logout attempts fallible plaintext deletion before best-effort keyring deletion and documents that the two backends are not transactional.
- `proptest` is added for arbitrary credential/client-ID and malformed-document coverage.

## Branch-added tests

- `plaintext_store_round_trip`, `plaintext_store_delete_removes_only_target`, and `absent_empty_and_populated_documents_have_distinct_successful_results` define successful missing, empty, populated, normalized-key, overwrite, targeted-delete, and no-op-delete behavior.
- `malformed_credential_file_is_a_typed_read_error`, `plaintext_store_rejects_malformed_existing_data_without_replacing_it`, and `invalid_credential_documents_are_errors_and_remain_unchanged` cover malformed syntax, truncation, wrong JSON shapes, non-string values, and invalid UTF-8; every operation fails closed and preserves the original bytes.
- `malformed_file_content_is_never_replaced` property-tests arbitrary malformed payloads, including payloads containing JSON punctuation, and proves no malformed document is replaced.
- `arbitrary_credential_text_round_trips` property-tests arbitrary Unicode credential text through JSON serialization and loading.
- `credential_path_must_be_a_regular_file` proves a directory cannot be used as the credential file; `credential_store_rejects_symlink_without_touching_target` and `credential_store_rejects_hardlink_without_touching_either_name` prove unsafe link topologies are rejected without modifying linked data.
- `plaintext_store_writes_0600_file_and_0700_dir` and `plaintext_store_creates_missing_parent_dir` cover private filesystem creation and permissions.
- `concurrent_stores_preserve_both_credentials` repeats barrier-synchronized concurrent updates and proves the sibling lock prevents lost updates.
- `http_credential_surfaces_stored_read_errors` proves the shared HTTP credential resolver returns storage failures instead of unauthenticated fallback.
- `a_client_id_round_trips_per_server_and_can_be_forgotten` proves public OAuth client IDs remain isolated by normalized server URL; `client_cache_errors_name_the_public_cache_not_credentials` pins the public-cache error vocabulary; `oauth_client_cache_round_trips_arbitrary_identifiers` property-tests arbitrary client-ID serialization through the cache wrapper.
- Existing login, doctor, CLI, and HTTP tests were updated to exercise the new result types, preserve explicit-over-stored precedence, retain stale-client recovery, and keep logout/error propagation behavior.

The full Rust suite passes (2,069 tests). Clippy with `-D warnings`, formatting, `git diff --check`, and the repository pre-commit hooks pass.
