### PR TITLE
test(cli): add process-level CLI contract coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +494,17 @@ checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -887,6 +913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1097,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1753,6 +1794,7 @@ dependencies = [
  "anyhow",
  "api-keys-simplified",
  "argon2",
+ "assert_cmd",
  "axum",
  "base64",
  "chrono",
@@ -1772,6 +1814,7 @@ dependencies = [
  "keyring",
  "libc",
  "mime_guess",
+ "predicates",
  "proptest",
  "rand 0.8.5",
  "reqwest",
@@ -1947,6 +1990,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2229,6 +2278,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3195,6 +3274,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,8 @@ fs2 = "0.4"
 libc = "0.2"
 
 [dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
 proptest = "1"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -13,13 +13,9 @@ use std::path::Path;
 use std::time::SystemTime;
 
 fn main() {
-    // CI and clean checkouts may not have a built frontend yet. Create the
-    // embed directory up-front so the rust-embed derive can compile cleanly even
-    // when the web bundle has not been generated.
+    // `web/dist/.gitkeep` keeps the embed directory present in clean checkouts.
+    // Do not create it here: builds must not mutate the source tree.
     let dist = Path::new("web/dist");
-    if !dist.exists() {
-        std::fs::create_dir_all(dist).expect("create missing web/dist directory");
-    }
 
     // The built bundle: changing it must trigger a re-embed.
     println!("cargo:rerun-if-changed=web/dist");

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,14 @@ use std::path::Path;
 use std::time::SystemTime;
 
 fn main() {
+    // CI and clean checkouts may not have a built frontend yet. Create the
+    // embed directory up-front so the rust-embed derive can compile cleanly even
+    // when the web bundle has not been generated.
+    let dist = Path::new("web/dist");
+    if !dist.exists() {
+        std::fs::create_dir_all(dist).expect("create missing web/dist directory");
+    }
+
     // The built bundle: changing it must trigger a re-embed.
     println!("cargo:rerun-if-changed=web/dist");
     // The frontend sources: changing them cannot rebuild the bundle for us,
@@ -20,7 +28,6 @@ fn main() {
     // to point out that web/dist no longer matches web/src.
     println!("cargo:rerun-if-changed=web/src");
 
-    let dist = Path::new("web/dist");
     let src = Path::new("web/src");
 
     match (newest_mtime(dist), newest_mtime(src)) {

--- a/build.rs
+++ b/build.rs
@@ -47,6 +47,9 @@ fn newest_mtime(dir: &Path) -> Option<SystemTime> {
     let mut newest: Option<SystemTime> = None;
     let entries = std::fs::read_dir(dir).ok()?;
     for entry in entries.flatten() {
+        if entry.file_name() == ".gitkeep" {
+            continue;
+        }
         let path = entry.path();
         let candidate = if path.is_dir() {
             newest_mtime(&path)
@@ -60,4 +63,23 @@ fn newest_mtime(dir: &Path) -> Option<SystemTime> {
         }
     }
     newest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::newest_mtime;
+
+    #[test]
+    fn checkout_placeholder_is_not_a_built_frontend() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".gitkeep"), "").unwrap();
+        assert_eq!(newest_mtime(dir.path()), None);
+
+        let bundle = dir.path().join("index.html");
+        std::fs::write(&bundle, "fixture frontend").unwrap();
+        assert_eq!(
+            newest_mtime(dir.path()),
+            Some(std::fs::metadata(bundle).unwrap().modified().unwrap())
+        );
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2373,8 +2373,8 @@ mod tests {
         #[test]
         fn arbitrary_unknown_commands_are_rejected(argument in "[a-z]{1,32}") {
             let invalid = format!("unknown-{argument}");
-            let argv = vec!["lific".to_owned(), invalid];
-            prop_assert!(Cli::try_parse_from(argv).is_err());
+            let error = Cli::try_parse_from(["lific", invalid.as_str()]).err();
+            prop_assert_eq!(error.map(|error| error.kind()), Some(clap::error::ErrorKind::InvalidSubcommand));
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1345,6 +1345,7 @@ pub enum UserAction {
 mod tests {
     use super::*;
     use clap::Parser;
+    use proptest::prelude::*;
 
     #[test]
     fn owned_labels_preserve_values_and_discard_empty_items() {
@@ -2366,6 +2367,15 @@ mod tests {
     fn parse_global_config_flag() {
         let cli = Cli::try_parse_from(["lific", "--config", "/etc/lific.toml", "start"]).unwrap();
         assert_eq!(cli.config, Some(PathBuf::from("/etc/lific.toml")));
+    }
+
+    proptest! {
+        #[test]
+        fn arbitrary_unknown_commands_are_rejected(argument in "[a-z]{1,32}") {
+            let invalid = format!("unknown-{argument}");
+            let argv = vec!["lific".to_owned(), invalid];
+            prop_assert!(Cli::try_parse_from(argv).is_err());
+        }
     }
 
     #[test]

--- a/tests/build_contract.rs
+++ b/tests/build_contract.rs
@@ -1,0 +1,4 @@
+// Exercise the build script without creating frontend artifacts in the checkout.
+#[allow(dead_code)]
+#[path = "../build.rs"]
+mod build_script;

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -1,0 +1,72 @@
+//! Characterization tests for the CLI's process-level contract.
+//!
+//! These intentionally execute the binary instead of calling parser internals:
+//! the overhaul must preserve exit status and stdout/stderr routing as well as
+//! the parsed command shape.
+
+use std::process::{Command, Output};
+
+use proptest::prelude::*;
+
+fn lific(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_lific"))
+        .args(args)
+        .output()
+        .expect("the lific test binary should be runnable")
+}
+
+#[test]
+fn help_contract_exposes_the_stable_cli_surface() {
+    let output = lific(&["--help"]);
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let help = String::from_utf8(output.stdout).unwrap();
+    for expected in [
+        "Usage:",
+        "Commands:",
+        "start",
+        "mcp",
+        "login",
+        "logout",
+        "doctor",
+        "connect",
+        "completion",
+        "--config",
+        "--json",
+    ] {
+        assert!(help.contains(expected), "help is missing {expected:?}");
+    }
+}
+
+#[test]
+fn version_contract_is_stdout_only() {
+    let output = lific(&["--version"]);
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .starts_with("lific ")
+    );
+}
+
+#[test]
+fn completion_contract_is_stdout_only_and_contains_the_program_name() {
+    let output = lific(&["completion", "bash"]);
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert!(String::from_utf8(output.stdout).unwrap().contains("lific"));
+}
+
+proptest! {
+    #[test]
+    fn invalid_subcommands_never_emit_stdout(argument in "[a-z]{1,16}") {
+        let invalid = format!("unknown-{argument}");
+        let output = lific(&[invalid.as_str()]);
+
+        prop_assert!(!output.status.success());
+        prop_assert!(output.stdout.is_empty());
+        prop_assert!(!output.stderr.is_empty());
+    }
+}

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -27,26 +27,52 @@ fn lific(args: &[&str]) -> assert_cmd::assert::Assert {
 
 #[test]
 fn help_contract_exposes_the_stable_cli_surface() {
-    let mut assertion = lific(&["--help"])
-        .success()
-        .stderr(predicate::str::is_empty());
-    for expected in [
-        "Usage: lific [OPTIONS] <COMMAND>",
-        "  start",
-        "  mcp",
-        "  login",
-        "  logout",
-        "  doctor",
-        "  connect",
-        "  completion",
-        "--config <CONFIG>",
-        "--db <DB>",
-        "--json",
-        "--backend <BACKEND>",
-        "--url <URL>",
-        "--api-key <API_KEY>",
+    let output = lific_command().arg("--help").output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "help failed: status={:?}\nstdout={stdout}\nstderr={stderr}",
+        output.status.code()
+    );
+    assert!(stderr.is_empty(), "help wrote to stderr: {stderr}");
+    assert!(stdout.contains("Usage: lific"), "missing usage: {stdout}");
+
+    for command in [
+        "start",
+        "mcp",
+        "login",
+        "logout",
+        "doctor",
+        "connect",
+        "completion",
     ] {
-        assertion = assertion.stdout(predicate::str::contains(expected));
+        assert!(
+            stdout
+                .lines()
+                .any(|line| { line.split_whitespace().next() == Some(command) }),
+            "missing command {command:?} in help:\n{stdout}"
+        );
+    }
+
+    for option in [
+        "--config",
+        "--db",
+        "--json",
+        "--backend",
+        "--url",
+        "--api-key",
+    ] {
+        assert!(
+            stdout.lines().any(|line| {
+                let line = line.trim_start();
+                line == option
+                    || line
+                        .strip_prefix(option)
+                        .is_some_and(|rest| rest.starts_with([' ', '\t']))
+            }),
+            "missing option {option:?} in help:\n{stdout}"
+        );
     }
 }
 

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -4,8 +4,11 @@
 //! the overhaul must preserve exit status and stdout/stderr routing as well as
 //! the parsed command shape.
 
+use std::path::Path;
+
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use rusqlite::Connection;
 
 fn lific(args: &[&str]) -> assert_cmd::assert::Assert {
     cargo_bin_cmd!("lific").args(args).assert()
@@ -66,4 +69,42 @@ fn invalid_subcommands_never_emit_stdout() {
             .stdout(predicate::str::is_empty())
             .stderr(predicate::str::is_empty().not());
     }
+}
+
+#[test]
+fn doctor_process_contract_requires_explicit_repair() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("legacy.db");
+    let config_path = tmp.path().join("lific.toml");
+    std::fs::write(&config_path, "[backup]\nenabled = false\n").unwrap();
+    Connection::open(&db_path)
+        .unwrap()
+        .execute("CREATE TABLE marker (value TEXT NOT NULL)", [])
+        .unwrap();
+
+    let db = db_path.to_str().unwrap();
+    let config = config_path.to_str().unwrap();
+    lific(&["--config", config, "--db", db, "--json", "doctor"])
+        .failure()
+        .code(1)
+        .stdout(predicate::str::contains("\"status\": \"fail\""));
+    assert!(!migration_table_exists(&db_path));
+
+    lific(&[
+        "--config", config, "--db", db, "--json", "doctor", "--repair",
+    ])
+    .success()
+    .stdout(predicate::str::contains("\"status\": \"pass\""));
+    assert!(migration_table_exists(&db_path));
+}
+
+fn migration_table_exists(path: &Path) -> bool {
+    Connection::open(path)
+        .unwrap()
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_migrations'",
+            [],
+            |_| Ok(()),
+        )
+        .is_ok()
 }

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -10,31 +10,41 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use rusqlite::Connection;
 
+fn lific_command() -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("lific");
+    command
+        .env("NO_COLOR", "1")
+        .env("TERM", "dumb")
+        .env("COLUMNS", "120")
+        .env_remove("CLICOLOR_FORCE")
+        .env_remove("RUST_LOG");
+    command
+}
+
 fn lific(args: &[&str]) -> assert_cmd::assert::Assert {
-    cargo_bin_cmd!("lific").args(args).assert()
+    lific_command().args(args).assert()
 }
 
 #[test]
 fn help_contract_exposes_the_stable_cli_surface() {
     let mut assertion = lific(&["--help"])
         .success()
-        .code(0)
         .stderr(predicate::str::is_empty());
     for expected in [
         "Usage: lific [OPTIONS] <COMMAND>",
-        "Commands:\n  start       ",
-        "  mcp         ",
-        "  login       ",
-        "  logout      ",
-        "  doctor      ",
-        "  connect     ",
-        "  completion  ",
-        "      --config <CONFIG>\n",
-        "      --db <DB>\n",
-        "      --json\n",
-        "      --backend <BACKEND>\n",
-        "      --url <URL>\n",
-        "      --api-key <API_KEY>\n",
+        "  start",
+        "  mcp",
+        "  login",
+        "  logout",
+        "  doctor",
+        "  connect",
+        "  completion",
+        "--config <CONFIG>",
+        "--db <DB>",
+        "--json",
+        "--backend <BACKEND>",
+        "--url <URL>",
+        "--api-key <API_KEY>",
     ] {
         assertion = assertion.stdout(predicate::str::contains(expected));
     }
@@ -44,7 +54,6 @@ fn help_contract_exposes_the_stable_cli_surface() {
 fn version_contract_is_stdout_only() {
     lific(&["--version"])
         .success()
-        .code(0)
         .stdout(predicate::str::starts_with("lific "))
         .stderr(predicate::str::is_empty());
 }
@@ -54,7 +63,6 @@ fn completion_contract_is_stdout_only_and_contains_the_program_name() {
     for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
         lific(&["completion", shell])
             .success()
-            .code(0)
             .stdout(predicate::str::contains("lific"))
             .stderr(predicate::str::is_empty());
     }
@@ -122,7 +130,7 @@ fn doctor_process_contract_honors_database_override_after_config_failure() {
     ])
     .success();
 
-    let output = cargo_bin_cmd!("lific")
+    let output = lific_command()
         .current_dir(tmp.path())
         .args([
             "--config",

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -6,9 +6,23 @@
 
 use std::path::Path;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use rusqlite::Connection;
+
+fn private_tempdir() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    #[cfg(unix)]
+    {
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        perms.set_mode(0o700);
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+    }
+    dir
+}
 
 fn lific_command() -> assert_cmd::Command {
     let mut command = cargo_bin_cmd!("lific");
@@ -107,7 +121,7 @@ fn invalid_subcommands_never_emit_stdout() {
 
 #[test]
 fn doctor_process_contract_requires_explicit_repair() {
-    let tmp = tempfile::tempdir().unwrap();
+    let tmp = private_tempdir();
     let db_path = tmp.path().join("legacy.db");
     let config_path = tmp.path().join("lific.toml");
     std::fs::write(&config_path, "[backup]\nenabled = false\n").unwrap();
@@ -134,7 +148,7 @@ fn doctor_process_contract_requires_explicit_repair() {
 
 #[test]
 fn doctor_process_contract_honors_database_override_after_config_failure() {
-    let tmp = tempfile::tempdir().unwrap();
+    let tmp = private_tempdir();
     let db_path = tmp.path().join("override.db");
     let valid_config = tmp.path().join("valid.toml");
     let missing_config = tmp.path().join("missing.toml");

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -4,24 +4,18 @@
 //! the overhaul must preserve exit status and stdout/stderr routing as well as
 //! the parsed command shape.
 
-use std::process::{Command, Output};
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
 
-use proptest::prelude::*;
-
-fn lific(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_lific"))
-        .args(args)
-        .output()
-        .expect("the lific test binary should be runnable")
+fn lific(args: &[&str]) -> assert_cmd::assert::Assert {
+    cargo_bin_cmd!("lific").args(args).assert()
 }
 
 #[test]
 fn help_contract_exposes_the_stable_cli_surface() {
-    let output = lific(&["--help"]);
-    assert!(output.status.success());
-    assert!(output.stderr.is_empty());
-
-    let help = String::from_utf8(output.stdout).unwrap();
+    let mut assertion = lific(&["--help"])
+        .success()
+        .stderr(predicate::str::is_empty());
     for expected in [
         "Usage:",
         "Commands:",
@@ -35,38 +29,32 @@ fn help_contract_exposes_the_stable_cli_surface() {
         "--config",
         "--json",
     ] {
-        assert!(help.contains(expected), "help is missing {expected:?}");
+        assertion = assertion.stdout(predicate::str::contains(expected));
     }
 }
 
 #[test]
 fn version_contract_is_stdout_only() {
-    let output = lific(&["--version"]);
-    assert!(output.status.success());
-    assert!(output.stderr.is_empty());
-    assert!(
-        String::from_utf8(output.stdout)
-            .unwrap()
-            .starts_with("lific ")
-    );
+    lific(&["--version"])
+        .success()
+        .stdout(predicate::str::starts_with("lific "))
+        .stderr(predicate::str::is_empty());
 }
 
 #[test]
 fn completion_contract_is_stdout_only_and_contains_the_program_name() {
-    let output = lific(&["completion", "bash"]);
-    assert!(output.status.success());
-    assert!(output.stderr.is_empty());
-    assert!(String::from_utf8(output.stdout).unwrap().contains("lific"));
+    lific(&["completion", "bash"])
+        .success()
+        .stdout(predicate::str::contains("lific"))
+        .stderr(predicate::str::is_empty());
 }
 
-proptest! {
-    #[test]
-    fn invalid_subcommands_never_emit_stdout(argument in "[a-z]{1,16}") {
-        let invalid = format!("unknown-{argument}");
-        let output = lific(&[invalid.as_str()]);
-
-        prop_assert!(!output.status.success());
-        prop_assert!(output.stdout.is_empty());
-        prop_assert!(!output.stderr.is_empty());
+#[test]
+fn invalid_subcommands_never_emit_stdout() {
+    for argument in ["unknown", "unknown-command", "project?", "--not-a-command"] {
+        lific(&[argument])
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::is_empty().not());
     }
 }

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -15,6 +15,7 @@ fn lific(args: &[&str]) -> assert_cmd::assert::Assert {
 fn help_contract_exposes_the_stable_cli_surface() {
     let mut assertion = lific(&["--help"])
         .success()
+        .code(0)
         .stderr(predicate::str::is_empty());
     for expected in [
         "Usage: lific [OPTIONS] <COMMAND>",
@@ -40,16 +41,20 @@ fn help_contract_exposes_the_stable_cli_surface() {
 fn version_contract_is_stdout_only() {
     lific(&["--version"])
         .success()
+        .code(0)
         .stdout(predicate::str::starts_with("lific "))
         .stderr(predicate::str::is_empty());
 }
 
 #[test]
 fn completion_contract_is_stdout_only_and_contains_the_program_name() {
-    lific(&["completion", "bash"])
-        .success()
-        .stdout(predicate::str::contains("lific"))
-        .stderr(predicate::str::is_empty());
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        lific(&["completion", shell])
+            .success()
+            .code(0)
+            .stdout(predicate::str::contains("lific"))
+            .stderr(predicate::str::is_empty());
+    }
 }
 
 #[test]
@@ -57,6 +62,7 @@ fn invalid_subcommands_never_emit_stdout() {
     for argument in ["unknown", "unknown-command", "project?", "--not-a-command"] {
         lific(&[argument])
             .failure()
+            .code(2)
             .stdout(predicate::str::is_empty())
             .stderr(predicate::str::is_empty().not());
     }

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -17,17 +17,20 @@ fn help_contract_exposes_the_stable_cli_surface() {
         .success()
         .stderr(predicate::str::is_empty());
     for expected in [
-        "Usage:",
-        "Commands:",
-        "start",
-        "mcp",
-        "login",
-        "logout",
-        "doctor",
-        "connect",
-        "completion",
-        "--config",
-        "--json",
+        "Usage: lific [OPTIONS] <COMMAND>",
+        "Commands:\n  start       ",
+        "  mcp         ",
+        "  login       ",
+        "  logout      ",
+        "  doctor      ",
+        "  connect     ",
+        "  completion  ",
+        "      --config <CONFIG>\n",
+        "      --db <DB>\n",
+        "      --json\n",
+        "      --backend <BACKEND>\n",
+        "      --url <URL>\n",
+        "      --api-key <API_KEY>\n",
     ] {
         assertion = assertion.stdout(predicate::str::contains(expected));
     }

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -98,6 +98,63 @@ fn doctor_process_contract_requires_explicit_repair() {
     assert!(migration_table_exists(&db_path));
 }
 
+#[test]
+fn doctor_process_contract_honors_database_override_after_config_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("override.db");
+    let valid_config = tmp.path().join("valid.toml");
+    let missing_config = tmp.path().join("missing.toml");
+    std::fs::write(&valid_config, "[backup]\nenabled = false\n").unwrap();
+    Connection::open(&db_path)
+        .unwrap()
+        .execute("CREATE TABLE marker (value TEXT NOT NULL)", [])
+        .unwrap();
+
+    let db = db_path.to_str().unwrap();
+    lific(&[
+        "--config",
+        valid_config.to_str().unwrap(),
+        "--db",
+        db,
+        "--json",
+        "doctor",
+        "--repair",
+    ])
+    .success();
+
+    let output = cargo_bin_cmd!("lific")
+        .current_dir(tmp.path())
+        .args([
+            "--config",
+            missing_config.to_str().unwrap(),
+            "--db",
+            db,
+            "--json",
+            "doctor",
+            "--key",
+            "unused-test-key",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("doctor:"), "stderr: {stderr}");
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let check = |name: &str| {
+        report["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|check| check["name"] == name)
+            .unwrap()
+    };
+
+    assert_eq!(check("config")["status"], "fail");
+    assert_eq!(check("database")["status"], "pass");
+    assert!(check("database")["detail"].as_str().unwrap().contains(db));
+    assert!(!tmp.path().join("lific.db").exists());
+}
+
 fn migration_table_exists(path: &Path) -> bool {
     Connection::open(path)
         .unwrap()

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -5,6 +5,7 @@
 //! the parsed command shape.
 
 use std::path::Path;
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -26,13 +27,65 @@ fn private_tempdir() -> tempfile::TempDir {
 
 fn lific_command() -> assert_cmd::Command {
     let mut command = cargo_bin_cmd!("lific");
+    configure_command(&mut command);
     command
+}
+
+fn configure_command(command: &mut assert_cmd::Command) {
+    command.env_clear();
+    // Retain only platform/runtime loader configuration, including Cargo's
+    // library search path. Application settings and proxies stay isolated.
+    for name in [
+        #[cfg(windows)]
+        "PATH",
+        "SystemRoot",
+        "WINDIR",
+        "LD_LIBRARY_PATH",
+        "DYLD_LIBRARY_PATH",
+        "DYLD_FALLBACK_LIBRARY_PATH",
+    ] {
+        if let Some(value) = std::env::var_os(name) {
+            command.env(name, value);
+        }
+    }
+    command
+        .timeout(Duration::from_secs(20))
         .env("NO_COLOR", "1")
         .env("TERM", "dumb")
-        .env("COLUMNS", "120")
-        .env_remove("CLICOLOR_FORCE")
-        .env_remove("RUST_LOG");
+        .env("COLUMNS", "120");
+}
+
+fn doctor_command(dir: &Path) -> assert_cmd::Command {
+    let mut command = lific_command();
+    command.current_dir(dir);
+    for name in [
+        "HOME",
+        "USERPROFILE",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "APPDATA",
+        "LOCALAPPDATA",
+    ] {
+        command.env(name, dir);
+    }
+    // Never look up the operator's login token in the system keyring.
+    command.env("LIFIC_API_KEY", "unused-contract-test-key");
     command
+}
+
+#[test]
+fn command_environment_does_not_inherit_credentials_or_proxies() {
+    let mut command = cargo_bin_cmd!("lific");
+    command.env("LIFIC_TOKEN", "fixture-token");
+    command.env("HTTPS_PROXY", "http://proxy.invalid:1234");
+    configure_command(&mut command);
+    for name in ["LIFIC_TOKEN", "HTTPS_PROXY"] {
+        assert!(
+            command
+                .get_envs()
+                .all(|(key, value)| key != name || value.is_none())
+        );
+    }
 }
 
 fn lific(args: &[&str]) -> assert_cmd::assert::Assert {
@@ -41,16 +94,12 @@ fn lific(args: &[&str]) -> assert_cmd::assert::Assert {
 
 #[test]
 fn help_contract_exposes_the_stable_cli_surface() {
-    let output = lific_command().arg("--help").output().unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "help failed: status={:?}\nstdout={stdout}\nstderr={stderr}",
-        output.status.code()
-    );
-    assert!(stderr.is_empty(), "help wrote to stderr: {stderr}");
-    assert!(stdout.contains("Usage: lific"), "missing usage: {stdout}");
+    let assertion = lific(&["--help"])
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("Usage: lific"));
+    let stdout =
+        std::str::from_utf8(&assertion.get_output().stdout).expect("help must be valid UTF-8");
 
     for command in [
         "start",
@@ -94,7 +143,7 @@ fn help_contract_exposes_the_stable_cli_surface() {
 fn version_contract_is_stdout_only() {
     lific(&["--version"])
         .success()
-        .stdout(predicate::str::starts_with("lific "))
+        .stdout(format!("lific {}\n", env!("CARGO_PKG_VERSION")))
         .stderr(predicate::str::is_empty());
 }
 
@@ -124,7 +173,11 @@ fn doctor_process_contract_requires_explicit_repair() {
     let tmp = private_tempdir();
     let db_path = tmp.path().join("legacy.db");
     let config_path = tmp.path().join("lific.toml");
-    std::fs::write(&config_path, "[backup]\nenabled = false\n").unwrap();
+    std::fs::write(
+        &config_path,
+        "[server]\nhost = '127.0.0.1'\nport = 0\n[backup]\nenabled = false\n",
+    )
+    .unwrap();
     Connection::open(&db_path)
         .unwrap()
         .execute("CREATE TABLE marker (value TEXT NOT NULL)", [])
@@ -132,17 +185,26 @@ fn doctor_process_contract_requires_explicit_repair() {
 
     let db = db_path.to_str().unwrap();
     let config = config_path.to_str().unwrap();
-    lific(&["--config", config, "--db", db, "--json", "doctor"])
-        .failure()
+    let before = std::fs::read(&db_path).unwrap();
+    let assertion = doctor_command(tmp.path())
+        .args(["--config", config, "--db", db, "--json", "doctor"])
+        .assert()
         .code(1)
-        .stdout(predicate::str::contains("\"status\": \"fail\""));
+        .stderr(predicate::str::contains("doctor:"));
+    let report: serde_json::Value = serde_json::from_slice(&assertion.get_output().stdout).unwrap();
+    assert_eq!(report["ok"], false);
+    assert_eq!(std::fs::read(&db_path).unwrap(), before);
     assert!(!migration_table_exists(&db_path));
 
-    lific(&[
-        "--config", config, "--db", db, "--json", "doctor", "--repair",
-    ])
-    .success()
-    .stdout(predicate::str::contains("\"status\": \"pass\""));
+    let assertion = doctor_command(tmp.path())
+        .args([
+            "--config", config, "--db", db, "--json", "doctor", "--repair",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty());
+    let report: serde_json::Value = serde_json::from_slice(&assertion.get_output().stdout).unwrap();
+    assert_eq!(report["ok"], true);
     assert!(migration_table_exists(&db_path));
 }
 
@@ -152,26 +214,32 @@ fn doctor_process_contract_honors_database_override_after_config_failure() {
     let db_path = tmp.path().join("override.db");
     let valid_config = tmp.path().join("valid.toml");
     let missing_config = tmp.path().join("missing.toml");
-    std::fs::write(&valid_config, "[backup]\nenabled = false\n").unwrap();
+    std::fs::write(
+        &valid_config,
+        "[server]\nhost = '127.0.0.1'\nport = 0\n[backup]\nenabled = false\n",
+    )
+    .unwrap();
     Connection::open(&db_path)
         .unwrap()
         .execute("CREATE TABLE marker (value TEXT NOT NULL)", [])
         .unwrap();
 
     let db = db_path.to_str().unwrap();
-    lific(&[
-        "--config",
-        valid_config.to_str().unwrap(),
-        "--db",
-        db,
-        "--json",
-        "doctor",
-        "--repair",
-    ])
-    .success();
+    doctor_command(tmp.path())
+        .args([
+            "--config",
+            valid_config.to_str().unwrap(),
+            "--db",
+            db,
+            "--json",
+            "doctor",
+            "--repair",
+        ])
+        .assert()
+        .success();
+    assert!(migration_table_exists(&db_path));
 
-    let output = lific_command()
-        .current_dir(tmp.path())
+    let assertion = doctor_command(tmp.path())
         .args([
             "--config",
             missing_config.to_str().unwrap(),
@@ -182,12 +250,10 @@ fn doctor_process_contract_honors_database_override_after_config_failure() {
             "--key",
             "unused-test-key",
         ])
-        .output()
-        .unwrap();
-    assert_eq!(output.status.code(), Some(1));
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("doctor:"), "stderr: {stderr}");
-    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("doctor:"));
+    let report: serde_json::Value = serde_json::from_slice(&assertion.get_output().stdout).unwrap();
     let check = |name: &str| {
         report["checks"]
             .as_array()
@@ -199,17 +265,51 @@ fn doctor_process_contract_honors_database_override_after_config_failure() {
 
     assert_eq!(check("config")["status"], "fail");
     assert_eq!(check("database")["status"], "pass");
+    assert_eq!(check("server")["status"], "skipped");
+    assert_eq!(check("mcp")["status"], "skipped");
     assert!(check("database")["detail"].as_str().unwrap().contains(db));
     assert!(!tmp.path().join("lific.db").exists());
 }
 
 fn migration_table_exists(path: &Path) -> bool {
-    Connection::open(path)
+    Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
         .unwrap()
         .query_row(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_migrations'",
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_migrations')",
             [],
-            |_| Ok(()),
+            |row| row.get(0),
         )
-        .is_ok()
+        .expect("migration lookup must succeed")
+}
+
+#[test]
+fn invalid_config_never_repairs_an_implicit_database() {
+    let tmp = private_tempdir();
+    let missing = tmp.path().join("missing.toml");
+    for repair in [false, true] {
+        let mut command = doctor_command(tmp.path());
+        command
+            .arg("--config")
+            .arg(&missing)
+            .args(["--json", "doctor"]);
+        if repair {
+            command.arg("--repair");
+        }
+        let assertion = command
+            .assert()
+            .code(1)
+            .stderr(predicate::str::contains("doctor:"));
+        let report: serde_json::Value =
+            serde_json::from_slice(&assertion.get_output().stdout).unwrap();
+        assert_eq!(report["ok"], false);
+        for check in report["checks"].as_array().unwrap() {
+            let expected = if check["name"] == "config" {
+                "fail"
+            } else {
+                "skipped"
+            };
+            assert_eq!(check["status"], expected, "{check}");
+        }
+        assert_eq!(std::fs::read_dir(tmp.path()).unwrap().count(), 0);
+    }
 }

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -8,7 +8,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+dist/*
+!dist/.gitkeep
 dist-ssr
 *.local
 


### PR DESCRIPTION
CLI refactors need to preserve exit codes, stdout/stderr routing, and doctor's explicit repair behavior. This PR adds process tests using assert_cmd and predicates, plus parser-level property coverage.

Child processes use an allowlisted environment, bounded execution time, and private doctor directories. Runtime library paths are preserved, including Windows PATH; inherited credentials and proxies are removed. Doctor uses a dummy explicit credential and a loopback port-zero fixture so tests do not depend on the developer's server or keyring.

The branch-added tests cover:

- Help command entries and all six stable global options, without depending on indentation.
- Exact package version output and empty stderr.
- Completion output for Bash, Zsh, Fish, PowerShell, and Elvish.
- Invalid arguments returning exit code 2 with diagnostics only on stderr.
- Doctor leaving a non-Lific database unchanged until explicit repair, then creating the migration table. Verification opens SQLite read-only and reports query failures.
- A missing explicit config still permitting inspection of an explicit database, while server checks are skipped.
- Missing config without an explicit database skipping every dependent check and creating no files, even with --repair.
- Removal of credentials and proxy settings from child commands.
- Arbitrary unknown command suffixes producing InvalidSubcommand at the parser boundary.

A tracked web/dist placeholder permits clean-source Rust builds without creating directories in build.rs. A build-script regression test ensures that placeholder does not count as a built frontend or suppress the missing-bundle warning.

The full nextest run passed 2,266 tests; formatting and Clippy pass. Documentation builds with existing warnings. Windows execution remains covered by CI.