### PR TITLE
cli: prevent terminal control injection

### DIFF
--- a/src/cli/bind.rs
+++ b/src/cli/bind.rs
@@ -218,10 +218,14 @@ pub fn run_sql(
     if json {
         println!(
             "{}",
-            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+            crate::cli::term::json_string(&value)
+                .map_err(|error| { crate::error::LificError::Internal(error.to_string()) })?
         );
     } else {
-        print!("{}", human(&value));
+        print!(
+            "{}",
+            crate::cli::ui::sanitize_terminal_block(&human(&value))
+        );
     }
     Ok(())
 }
@@ -409,8 +413,8 @@ fn claim_aliases(
 
 fn alias_lines(out: &mut String, aliases: &[Value], annotate: bool) {
     for alias in aliases {
-        let kind = alias["kind"].as_str().unwrap_or("?");
-        let value = alias["value"].as_str().unwrap_or("?");
+        let kind = crate::cli::ui::sanitize_terminal_line(alias["kind"].as_str().unwrap_or("?"));
+        let value = crate::cli::ui::sanitize_terminal_line(alias["value"].as_str().unwrap_or("?"));
         let note = if !annotate {
             ""
         } else if alias["matched"].as_bool().unwrap_or(false) {
@@ -423,10 +427,18 @@ fn alias_lines(out: &mut String, aliases: &[Value], annotate: bool) {
 }
 
 fn named(project: &Value) -> String {
-    let identifier = project["identifier"].as_str().unwrap_or("?");
+    let identifier =
+        crate::cli::ui::sanitize_terminal_line(project["identifier"].as_str().unwrap_or("?"));
     match project["name"].as_str() {
-        Some(name) if name != identifier => format!("{identifier} ({name})"),
-        _ => identifier.to_owned(),
+        Some(name) => {
+            let name = crate::cli::ui::sanitize_terminal_line(name);
+            if name != identifier {
+                format!("{identifier} ({name})")
+            } else {
+                identifier
+            }
+        }
+        None => identifier,
     }
 }
 
@@ -478,7 +490,7 @@ pub fn human(value: &Value) -> String {
             let _ = writeln!(out, "Bind it with `lific bind PROJECT`.");
         }
     }
-    out
+    crate::cli::ui::sanitize_terminal_block(&out)
 }
 
 fn w(out: &mut String) {
@@ -754,6 +766,69 @@ mod tests {
         // conflict can only be settled by merging or deleting a binding.
         assert!(text.contains("/api/repos/merge"), "{text}");
         assert!(text.contains("re-run `lific bind`"), "{text}");
+    }
+
+    #[test]
+    fn hostile_stored_bind_names_are_inert_in_human_output() {
+        let pool = pool();
+        let name = "Lific\x1b]52;c;cHdu\x07\x1b[2J\u{009b}\u{202e}\u{2066}\u{200b}\u{feff}\r\n\t\u{0008}\u{007f}";
+        project(&pool, "LIF", name);
+        project(&pool, "OTH", name);
+        let aliases = repo_aliases_fixture();
+        bind_to(&pool, &aliases[..1], "LIF", false);
+        let bound = resolve_or_bind(&pool, &aliases, None, false).unwrap();
+        bind_to(&pool, &aliases[1..], "OTH", false);
+        let conflict = resolve_or_bind(&pool, &aliases, None, false).unwrap();
+
+        assert_eq!(bound["project"]["name"], name);
+        assert_eq!(conflict["projects"][0]["name"], name);
+        for (value, rows) in [(bound, 4), (conflict, 9)] {
+            let text = human(&value);
+            for control in [
+                '\x1b', '\x07', '\u{009b}', '\u{202e}', '\u{2066}', '\u{200b}', '\u{feff}', '\r',
+                '\t', '\u{0008}', '\u{007f}',
+            ] {
+                assert!(!text.contains(control), "unsafe output: {text:?}");
+            }
+            assert_eq!(
+                text.lines().count(),
+                rows,
+                "name must not create a new row: {text:?}"
+            );
+            let encoded = crate::cli::term::json_string(&value).unwrap();
+            assert_eq!(serde_json::from_str::<Value>(&encoded).unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn hostile_bind_response_fields_cannot_add_rows() {
+        let aliases = vec![alias("remote\n\t\x1b", "v1:host/repo\r\n\u{009b}\u{202e}")];
+        let project = json!({"identifier": "LIF\n\x1b", "name": "Name\n\u{202e}"});
+        for (value, rows) in [
+            (unbound_json(&aliases), 5),
+            (
+                bound_json(project.clone(), &aliases, &HashSet::new(), true),
+                4,
+            ),
+            (conflict_json(vec![project], &aliases), 7),
+        ] {
+            let text = human(&value);
+            for control in ['\x1b', '\u{009b}', '\u{202e}', '\r', '\t'] {
+                assert!(!text.contains(control), "unsafe output: {text:?}");
+            }
+            assert_eq!(
+                text.lines().count(),
+                rows,
+                "fields must not add rows: {text:?}"
+            );
+            assert!(
+                text.lines()
+                    .any(|line| line.contains("remote") && line.contains("v1:host/repo")),
+                "{text:?}"
+            );
+            let encoded = crate::cli::term::json_string(&value).unwrap();
+            assert_eq!(serde_json::from_str::<Value>(&encoded).unwrap(), value);
+        }
     }
 
     // ── identity, against real repositories ──────────────────

--- a/src/cli/connect/mod.rs
+++ b/src/cli/connect/mod.rs
@@ -53,6 +53,7 @@ pub mod writer;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
+use crate::cli::ui::TerminalDisplay;
 use crate::config::Config;
 use crate::db::DbPool;
 
@@ -316,12 +317,7 @@ fn interactive_picker(detected: &[DetectedClient], target: &str) -> Result<Vec<S
     let mut ordered: Vec<&DetectedClient> = detected.iter().filter(|c| c.detected).collect();
     ordered.extend(detected.iter().filter(|c| !c.detected));
 
-    let mut prompt = cliclack::multiselect(if any_installed {
-        format!("Which clients should connect to {target}?")
-    } else {
-        format!("No installed clients detected in this scope — pick any to configure for {target}:")
-    })
-    .required(true);
+    let mut prompt = cliclack::multiselect(picker_prompt(any_installed, target)).required(true);
     for c in &ordered {
         prompt = prompt.item(
             c.id.clone(),
@@ -344,6 +340,15 @@ fn interactive_picker(detected: &[DetectedClient], target: &str) -> Result<Vec<S
             format!("selection failed: {e}")
         }
     })
+}
+
+fn picker_prompt(any_installed: bool, target: &str) -> String {
+    let target = target.terminal_line();
+    if any_installed {
+        format!("Which clients should connect to {target}?")
+    } else {
+        format!("No installed clients detected in this scope — pick any to configure for {target}:")
+    }
 }
 
 // ── Transport selection (LIFIC-19) ───────────────────────────
@@ -643,10 +648,10 @@ pub fn run(
         match resolve_key_source(&args, pool) {
             Ok(src) => Some(src),
             Err(e) if args.stdio => {
-                eprintln!(
+                crate::cli::ui::stderr_line(format_args!(
                     "warning: skipping agent identity for stdio config ({e}); \
                      it will run as the operator until you reconnect with --user <name>."
-                );
+                ));
                 None
             }
             Err(e) => return Err(e),
@@ -947,7 +952,7 @@ fn print_json(result: &ConnectResult) {
             "action": a.action,
         })),
     });
-    println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    println!("{}", crate::cli::term::json_string(&out).unwrap());
 }
 
 fn print_human(result: &ConnectResult) {
@@ -1093,6 +1098,16 @@ mod tests {
         assert_eq!(target_url(&args, &cfg), "http://127.0.0.1:4000/mcp");
         args.stdio = true;
         assert!(target_url(&args, &cfg).ends_with("lific.db"));
+    }
+
+    #[test]
+    fn picker_prompt_neutralizes_control_sequences_in_target() {
+        let prompt = picker_prompt(true, "https://evil.test\x1b]8;;https://evil\x1b\\\u{202e}");
+        assert_eq!(
+            prompt,
+            "Which clients should connect to https://evil.test^[]8;;https://evil^[\\ ?"
+        );
+        assert!(!prompt.chars().any(char::is_control));
     }
 
     fn base(dir: &std::path::Path) -> PathBase {

--- a/src/cli/connect/mod.rs
+++ b/src/cli/connect/mod.rs
@@ -979,7 +979,7 @@ fn print_human(result: &ConnectResult) {
                 if let Some(snippet) = &o.manual_snippet {
                     ui::note(
                         format!("{} — merge this in manually", o.display),
-                        terminal_manual_snippet(snippet),
+                        terminal_manual_snippet(&o.format, snippet),
                     );
                 }
             }
@@ -1045,11 +1045,8 @@ fn print_human(result: &ConnectResult) {
     ui::outro("Restart your client(s) to pick up the new MCP server.");
 }
 
-fn terminal_manual_snippet(snippet: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(snippet)
-        .ok()
-        .and_then(|value| crate::cli::term::json_string(&value).ok())
-        .unwrap_or_else(|| crate::cli::ui::sanitize_terminal_block(snippet))
+fn terminal_manual_snippet(format: &str, snippet: &str) -> String {
+    writer::terminal_contents(format, snippet)
 }
 
 #[cfg(test)]
@@ -1132,13 +1129,32 @@ mod tests {
     }
   }
 }"#;
-        let rendered = terminal_manual_snippet(snippet);
+        let rendered = terminal_manual_snippet("json", snippet);
 
         assert!(!rendered.contains('\u{202e}'));
         let value: serde_json::Value = serde_json::from_str(snippet).unwrap();
         assert_eq!(
             serde_json::from_str::<serde_json::Value>(&rendered).unwrap(),
             value
+        );
+    }
+
+    #[test]
+    fn terminal_manual_format_snippets_preserve_toml_and_yaml_values() {
+        let toml = "# merge this\ncommand = \"a\u{200d}b\"\n";
+        let displayed_toml = terminal_manual_snippet("toml", toml);
+        assert!(!displayed_toml.contains('\u{200d}'));
+        assert_eq!(
+            toml::from_str::<toml::Value>(&displayed_toml).unwrap(),
+            toml::from_str::<toml::Value>(toml).unwrap()
+        );
+
+        let yaml = "command: \"a\u{200d}b\"\n";
+        let displayed_yaml = terminal_manual_snippet("yaml", yaml);
+        assert!(!displayed_yaml.contains('\u{200d}'));
+        assert_eq!(
+            serde_yaml::from_str::<serde_yaml::Value>(&displayed_yaml).unwrap(),
+            serde_yaml::from_str::<serde_yaml::Value>(yaml).unwrap()
         );
     }
 

--- a/src/cli/connect/mod.rs
+++ b/src/cli/connect/mod.rs
@@ -977,7 +977,10 @@ fn print_human(result: &ConnectResult) {
             (None, Some(err)) => {
                 ui::warn(format!("{} — skipped: {err}", o.display));
                 if let Some(snippet) = &o.manual_snippet {
-                    ui::note(format!("{} — merge this in manually", o.display), snippet);
+                    ui::note(
+                        format!("{} — merge this in manually", o.display),
+                        terminal_manual_snippet(snippet),
+                    );
                 }
             }
             (None, None) => {}
@@ -1007,7 +1010,10 @@ fn print_human(result: &ConnectResult) {
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or_default();
-            ui::note(path, contents.trim_end());
+            ui::note(
+                path,
+                writer::terminal_contents(&o.format, contents).trim_end(),
+            );
         }
     }
 
@@ -1037,6 +1043,13 @@ fn print_human(result: &ConnectResult) {
     }
 
     ui::outro("Restart your client(s) to pick up the new MCP server.");
+}
+
+fn terminal_manual_snippet(snippet: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(snippet)
+        .ok()
+        .and_then(|value| crate::cli::term::json_string(&value).ok())
+        .unwrap_or_else(|| crate::cli::ui::sanitize_terminal_block(snippet))
 }
 
 #[cfg(test)]
@@ -1108,6 +1121,25 @@ mod tests {
             "Which clients should connect to https://evil.test^[]8;;https://evil^[\\ ?"
         );
         assert!(!prompt.chars().any(char::is_control));
+    }
+
+    #[test]
+    fn terminal_manual_json_snippet_preserves_escaped_data() {
+        let snippet = r#"{
+  "mcp": {
+    "lific": {
+      "url": "https://host/\u202eforged"
+    }
+  }
+}"#;
+        let rendered = terminal_manual_snippet(snippet);
+
+        assert!(!rendered.contains('\u{202e}'));
+        let value: serde_json::Value = serde_json::from_str(snippet).unwrap();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&rendered).unwrap(),
+            value
+        );
     }
 
     fn base(dir: &std::path::Path) -> PathBase {

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -358,7 +358,7 @@ fn render_json(existing: &str, entry: &CompiledEntry) -> Result<String, WriteErr
     // Insert/replace only our own server entry, preserving siblings.
     top_map.insert(entry.name.clone(), entry.value.clone());
 
-    let mut out = serde_json::to_string_pretty(&root)
+    let mut out = crate::cli::term::json_string(&root)
         .map_err(|e| WriteError::new(format!("failed to serialize JSON: {e}")))?;
     out.push('\n');
     Ok(out)
@@ -369,7 +369,7 @@ fn manual_json_snippet(entry: &CompiledEntry) -> String {
     let snippet = serde_json::json!({
         entry.top_key.clone(): { entry.name.clone(): entry.value.clone() }
     });
-    serde_json::to_string_pretty(&snippet).unwrap_or_default()
+    crate::cli::term::json_string(&snippet).unwrap_or_default()
 }
 
 // ── TOML (Codex) ─────────────────────────────────────────────
@@ -660,7 +660,7 @@ mod tests {
         // Pre-existing config with another MCP server and unrelated top keys.
         std::fs::write(
             &path,
-            serde_json::to_string_pretty(&serde_json::json!({
+            crate::cli::term::json_string(&serde_json::json!({
                 "theme": "dark",
                 "mcp": {
                     "other": { "type": "remote", "url": "http://other" }
@@ -692,7 +692,7 @@ mod tests {
         let path = dir.join("opencode.json");
         std::fs::write(
             &path,
-            serde_json::to_string_pretty(&serde_json::json!({
+            crate::cli::term::json_string(&serde_json::json!({
                 "mcp": { "lific": { "type": "remote", "url": "http://stale" } }
             }))
             .unwrap(),

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -12,7 +12,7 @@
 //! YAML: `serde_yaml` round-trip (YAML comments are lost — this is called out
 //!       in the per-client notes surfaced to the user).
 
-use std::path::Path;
+use std::{ops::Range, path::Path};
 
 use super::clients::{CompiledEntry, Format};
 use crate::cli::{term, ui};
@@ -47,14 +47,248 @@ pub struct Rendered {
 /// through the terminal-safe JSON encoder so its displayed value remains
 /// lossless; TOML/YAML stay text-native so comments and layout are preserved.
 pub(crate) fn terminal_contents(format: &str, contents: &str) -> String {
-    if format == "json"
-        && let Ok(value) = serde_json::from_str::<serde_json::Value>(contents)
-        && let Ok(encoded) = term::json_string(&value)
-    {
-        return encoded;
+    match format {
+        "json" => {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(contents)
+                && let Ok(encoded) = term::json_string(&value)
+            {
+                return encoded;
+            }
+        }
+        "toml" => return terminal_toml(contents),
+        "yaml" => return terminal_yaml(contents),
+        _ => {}
     }
 
     ui::sanitize_terminal_block(contents)
+}
+
+fn terminal_toml(contents: &str) -> String {
+    let Ok(document) = contents.parse::<toml_edit::ImDocument<String>>() else {
+        return ui::sanitize_terminal_block(contents);
+    };
+
+    let mut replacements = Vec::new();
+    collect_toml_table(document.as_table(), &mut replacements);
+    apply_replacements(contents, replacements)
+}
+
+fn collect_toml_table(table: &toml_edit::Table, replacements: &mut Vec<Replacement>) {
+    for (key, item) in table.iter() {
+        if let Some((key, _)) = table.get_key_value(key) {
+            collect_toml_key(key, replacements);
+        }
+        collect_toml_item(item, replacements);
+    }
+}
+
+fn collect_toml_item(item: &toml_edit::Item, replacements: &mut Vec<Replacement>) {
+    match item {
+        toml_edit::Item::None => {}
+        toml_edit::Item::Value(value) => collect_toml_value(value, replacements),
+        toml_edit::Item::Table(table) => collect_toml_table(table, replacements),
+        toml_edit::Item::ArrayOfTables(tables) => {
+            for table in tables.iter() {
+                collect_toml_table(table, replacements);
+            }
+        }
+    }
+}
+
+fn collect_toml_value(value: &toml_edit::Value, replacements: &mut Vec<Replacement>) {
+    match value {
+        toml_edit::Value::String(string) => {
+            if has_terminal_controls(string.value())
+                && let Some(range) = string.span()
+            {
+                replacements.push(Replacement {
+                    range,
+                    text: toml_basic_string(string.value()),
+                });
+            }
+        }
+        toml_edit::Value::Array(array) => {
+            for value in array.iter() {
+                collect_toml_value(value, replacements);
+            }
+        }
+        toml_edit::Value::InlineTable(table) => {
+            for (key, value) in table.iter() {
+                if has_terminal_controls(key)
+                    && let Some((key, _)) = table.get_key_value(key)
+                    && let Some(repr) = key.as_repr()
+                    && let Some(range) = repr.span()
+                {
+                    replacements.push(Replacement {
+                        range,
+                        text: toml_basic_string(key),
+                    });
+                }
+                collect_toml_value(value, replacements);
+            }
+        }
+        toml_edit::Value::Integer(..)
+        | toml_edit::Value::Float(..)
+        | toml_edit::Value::Boolean(..)
+        | toml_edit::Value::Datetime(..) => {}
+    }
+}
+
+fn collect_toml_key(key: &toml_edit::Key, replacements: &mut Vec<Replacement>) {
+    if has_terminal_controls(key.get())
+        && let Some(repr) = key.as_repr()
+        && let Some(range) = repr.span()
+    {
+        replacements.push(Replacement {
+            range,
+            text: toml_basic_string(key.get()),
+        });
+    }
+}
+
+fn apply_replacements(contents: &str, mut replacements: Vec<Replacement>) -> String {
+    replacements.sort_by_key(|replacement| replacement.range.start);
+    let mut rendered = contents.to_owned();
+    for replacement in replacements.into_iter().rev() {
+        rendered.replace_range(replacement.range, &replacement.text);
+    }
+    ui::sanitize_terminal_block(&rendered)
+}
+
+struct Replacement {
+    range: Range<usize>,
+    text: String,
+}
+
+fn has_terminal_controls(value: &str) -> bool {
+    value.chars().any(ui::is_terminal_control)
+}
+
+fn toml_basic_string(value: &str) -> String {
+    let mut rendered = String::with_capacity(value.len() + 2);
+    rendered.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => rendered.push_str("\\\\"),
+            '"' => rendered.push_str("\\\""),
+            '\u{08}' => rendered.push_str("\\b"),
+            '\t' => rendered.push_str("\\t"),
+            '\n' => rendered.push_str("\\n"),
+            '\u{0c}' => rendered.push_str("\\f"),
+            '\r' => rendered.push_str("\\r"),
+            ch if ui::is_terminal_control(ch) => push_unicode_escape(&mut rendered, ch),
+            ch => rendered.push(ch),
+        }
+    }
+    rendered.push('"');
+    rendered
+}
+
+fn push_unicode_escape(rendered: &mut String, ch: char) {
+    use std::fmt::Write;
+
+    let value = ch as u32;
+    if value <= 0xffff {
+        write!(rendered, "\\u{value:04x}").expect("String write cannot fail");
+    } else {
+        write!(rendered, "\\U{value:08x}").expect("String write cannot fail");
+    }
+}
+
+fn terminal_yaml(contents: &str) -> String {
+    let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(contents) else {
+        return ui::sanitize_terminal_block(contents);
+    };
+    if !yaml_has_terminal_controls(&value) {
+        return ui::sanitize_terminal_block(contents);
+    }
+    render_yaml_value(&value, 0)
+}
+
+fn yaml_has_terminal_controls(value: &serde_yaml::Value) -> bool {
+    match value {
+        serde_yaml::Value::String(value) => has_terminal_controls(value),
+        serde_yaml::Value::Sequence(values) => values.iter().any(yaml_has_terminal_controls),
+        serde_yaml::Value::Mapping(values) => values.iter().any(|(key, value)| {
+            yaml_has_terminal_controls(key) || yaml_has_terminal_controls(value)
+        }),
+        serde_yaml::Value::Tagged(value) => yaml_has_terminal_controls(&value.value),
+        serde_yaml::Value::Null | serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_) => {
+            false
+        }
+    }
+}
+
+fn render_yaml_value(value: &serde_yaml::Value, indent: usize) -> String {
+    let padding = " ".repeat(indent);
+    match value {
+        serde_yaml::Value::Mapping(values) => values
+            .iter()
+            .map(|(key, value)| {
+                let key = yaml_scalar(key);
+                if yaml_is_scalar(value) {
+                    format!("{padding}{key}: {}\n", yaml_scalar(value))
+                } else {
+                    format!("{padding}{key}:\n{}", render_yaml_value(value, indent + 2))
+                }
+            })
+            .collect(),
+        serde_yaml::Value::Sequence(values) => values
+            .iter()
+            .map(|value| {
+                if yaml_is_scalar(value) {
+                    format!("{padding}- {}\n", yaml_scalar(value))
+                } else {
+                    format!("{padding}-\n{}", render_yaml_value(value, indent + 2))
+                }
+            })
+            .collect(),
+        _ => format!("{padding}{}\n", yaml_scalar(value)),
+    }
+}
+
+fn yaml_is_scalar(value: &serde_yaml::Value) -> bool {
+    matches!(
+        value,
+        serde_yaml::Value::Null
+            | serde_yaml::Value::Bool(_)
+            | serde_yaml::Value::Number(_)
+            | serde_yaml::Value::String(_)
+    )
+}
+
+fn yaml_scalar(value: &serde_yaml::Value) -> String {
+    match value {
+        serde_yaml::Value::String(value) => yaml_double_quoted(value),
+        _ => serde_yaml::to_string(value)
+            .unwrap_or_else(|_| "null\n".to_owned())
+            .trim_end()
+            .to_owned(),
+    }
+}
+
+fn yaml_double_quoted(value: &str) -> String {
+    let mut rendered = String::with_capacity(value.len() + 2);
+    rendered.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => rendered.push_str("\\\\"),
+            '"' => rendered.push_str("\\\""),
+            '\0' => rendered.push_str("\\0"),
+            '\u{07}' => rendered.push_str("\\a"),
+            '\u{08}' => rendered.push_str("\\b"),
+            '\t' => rendered.push_str("\\t"),
+            '\n' => rendered.push_str("\\n"),
+            '\u{0b}' => rendered.push_str("\\v"),
+            '\u{0c}' => rendered.push_str("\\f"),
+            '\r' => rendered.push_str("\\r"),
+            '\u{1b}' => rendered.push_str("\\e"),
+            ch if ui::is_terminal_control(ch) => push_unicode_escape(&mut rendered, ch),
+            ch => rendered.push(ch),
+        }
+    }
+    rendered.push('"');
+    rendered
 }
 
 /// Error from a writer that a caller should surface as a per-client failure
@@ -647,12 +881,34 @@ mod tests {
     }
 
     #[test]
-    fn terminal_text_encoding_preserves_non_json_layout() {
-        let contents = "# keep this comment\nkey = \"value\u{009b}\"\n";
+    fn terminal_toml_encoding_preserves_values_keys_and_comments() {
+        let contents = "# keep this comment\nunrelated = \"existing\"\n\"key\u{202e}\" = 'literal\u{200d}'\nbasic = \"a\u{200d}b\"\n";
         let displayed = terminal_contents("toml", contents);
         assert!(displayed.starts_with("# keep this comment\n"));
-        assert!(displayed.contains("key = \"value"));
+        assert!(!displayed.contains('\u{202e}'));
+        assert!(!displayed.contains('\u{200d}'));
+        assert_eq!(
+            toml::from_str::<toml::Value>(&displayed).unwrap(),
+            toml::from_str::<toml::Value>(contents).unwrap()
+        );
+    }
+
+    #[test]
+    fn terminal_yaml_encoding_preserves_values_through_its_rendering_path() {
+        let value = serde_json::json!({
+            "unrelated": "existing",
+            "command": "a\u{200d}b",
+            "nested": ["literal\u{202e}", "basic\u{009b}"]
+        });
+        let contents = serde_yaml::to_string(&value).unwrap();
+        let displayed = terminal_contents("yaml", &contents);
+        assert!(!displayed.contains('\u{202e}'));
+        assert!(!displayed.contains('\u{200d}'));
         assert!(!displayed.contains('\u{009b}'));
+        assert_eq!(
+            serde_yaml::from_str::<serde_yaml::Value>(&displayed).unwrap(),
+            serde_yaml::from_str::<serde_yaml::Value>(&contents).unwrap()
+        );
     }
 
     #[cfg(unix)]

--- a/src/cli/connect/writer.rs
+++ b/src/cli/connect/writer.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 
 use super::clients::{CompiledEntry, Format};
+use crate::cli::{term, ui};
 
 /// What a write did.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,6 +40,21 @@ impl Action {
 pub struct Rendered {
     pub contents: String,
     pub action: Action,
+}
+
+/// Encode rendered configuration for human terminal display without changing
+/// the configuration that will be written. JSON is parsed and re-serialized
+/// through the terminal-safe JSON encoder so its displayed value remains
+/// lossless; TOML/YAML stay text-native so comments and layout are preserved.
+pub(crate) fn terminal_contents(format: &str, contents: &str) -> String {
+    if format == "json"
+        && let Ok(value) = serde_json::from_str::<serde_json::Value>(contents)
+        && let Ok(encoded) = term::json_string(&value)
+    {
+        return encoded;
+    }
+
+    ui::sanitize_terminal_block(contents)
 }
 
 /// Error from a writer that a caller should surface as a per-client failure
@@ -358,7 +374,7 @@ fn render_json(existing: &str, entry: &CompiledEntry) -> Result<String, WriteErr
     // Insert/replace only our own server entry, preserving siblings.
     top_map.insert(entry.name.clone(), entry.value.clone());
 
-    let mut out = crate::cli::term::json_string(&root)
+    let mut out = serde_json::to_string_pretty(&root)
         .map_err(|e| WriteError::new(format!("failed to serialize JSON: {e}")))?;
     out.push('\n');
     Ok(out)
@@ -369,7 +385,7 @@ fn manual_json_snippet(entry: &CompiledEntry) -> String {
     let snippet = serde_json::json!({
         entry.top_key.clone(): { entry.name.clone(): entry.value.clone() }
     });
-    crate::cli::term::json_string(&snippet).unwrap_or_default()
+    serde_json::to_string_pretty(&snippet).unwrap_or_default()
 }
 
 // ── TOML (Codex) ─────────────────────────────────────────────
@@ -610,6 +626,35 @@ mod tests {
         assert_eq!(v["mcp"]["lific"]["type"], "remote");
     }
 
+    #[test]
+    fn terminal_json_encoding_preserves_values_and_escapes_controls() {
+        let mut value = serde_json::Map::new();
+        value.insert(
+            "key\u{009b}2J\u{202e}\u{200b}".to_owned(),
+            serde_json::json!("value\u{0001}\u{0085}\u{2066}\u{200d}"),
+        );
+        let contents = serde_json::to_string_pretty(&value).unwrap();
+
+        let displayed = terminal_contents("json", &contents);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&displayed).unwrap(),
+            serde_json::Value::Object(value)
+        );
+        assert!(!displayed.contains('\u{009b}'));
+        assert!(!displayed.contains('\u{202e}'));
+        assert!(!displayed.contains('\u{200b}'));
+        assert!(!displayed.contains('\u{200d}'));
+    }
+
+    #[test]
+    fn terminal_text_encoding_preserves_non_json_layout() {
+        let contents = "# keep this comment\nkey = \"value\u{009b}\"\n";
+        let displayed = terminal_contents("toml", contents);
+        assert!(displayed.starts_with("# keep this comment\n"));
+        assert!(displayed.contains("key = \"value"));
+        assert!(!displayed.contains('\u{009b}'));
+    }
+
     #[cfg(unix)]
     #[test]
     fn secret_config_is_owner_only_and_atomic() {
@@ -660,7 +705,7 @@ mod tests {
         // Pre-existing config with another MCP server and unrelated top keys.
         std::fs::write(
             &path,
-            crate::cli::term::json_string(&serde_json::json!({
+            serde_json::to_string_pretty(&serde_json::json!({
                 "theme": "dark",
                 "mcp": {
                     "other": { "type": "remote", "url": "http://other" }
@@ -692,7 +737,7 @@ mod tests {
         let path = dir.join("opencode.json");
         std::fs::write(
             &path,
-            crate::cli::term::json_string(&serde_json::json!({
+            serde_json::to_string_pretty(&serde_json::json!({
                 "mcp": { "lific": { "type": "remote", "url": "http://stale" } }
             }))
             .unwrap(),
@@ -727,6 +772,18 @@ mod tests {
         assert!(snippet.contains("lific"));
         // File must be byte-for-byte unchanged.
         assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn manual_json_snippet_preserves_machine_values() {
+        let entry = find_client("opencode")
+            .unwrap()
+            .compile(&ServerConfig::remote("https://host/\u{202e}forged", "key"));
+        let snippet = manual_json_snippet(&entry);
+        let value: serde_json::Value = serde_json::from_str(&snippet).unwrap();
+
+        assert_eq!(value["mcp"]["lific"]["url"], "https://host/\u{202e}forged");
+        assert!(snippet.contains('\u{202e}'));
     }
 
     #[test]

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -138,11 +138,11 @@ fn warn_env_token_unbound(target_url: &str) {
     if WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
         return;
     }
-    eprintln!(
+    crate::cli::ui::stderr_line(format_args!(
         "warning: {TOKEN_ENV} is set but not bound to {target_url}; ignoring it and using the \
          stored credential for that server instead. Set {URL_ENV} to that server to send the \
          env token there."
-    );
+    ));
 }
 
 /// Where the plaintext fallback file lives: `~/.config/lific/credentials.json`.
@@ -823,12 +823,12 @@ pub fn store(base_url: &str, token: &str) -> Result<(), CredentialStoreError> {
             let store = PlaintextCredentialFileStore::new(
                 default_file_path().ok_or(CredentialStoreError::ConfigDirectoryUnavailable)?,
             );
-            eprintln!(
+            crate::cli::ui::stderr_line(format_args!(
                 "warning: OS keyring unavailable ({e}); storing token in PLAINTEXT at {} ({}). \
                  Set up a Secret Service/Keychain to secure it, or use {TOKEN_ENV} to avoid on-disk storage.",
                 store.path.display(),
                 plaintext_protection_description()
-            );
+            ));
             store
                 .store_credential_for_server_key(&key, token)
                 .map_err(CredentialStoreError::from)

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -955,9 +955,15 @@ async fn check_public_url(client: &reqwest::Client, public_url: &str) -> Check {
 fn print_report(report: &Report, json: bool) {
     if json {
         // Machine output: stable shape for agents/scripts.
-        match serde_json::to_string_pretty(report) {
+        match crate::cli::term::json_string(report) {
             Ok(s) => println!("{s}"),
-            Err(e) => println!("{{\"error\":\"failed to serialize report: {e}\"}}"),
+            Err(e) => println!(
+                "{}",
+                crate::cli::term::json_string(&serde_json::json!({
+                    "error": format!("failed to serialize report: {e}"),
+                }))
+                .unwrap_or_default()
+            ),
         }
         return;
     }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -126,7 +126,7 @@ impl Output<'_> {
     /// enrichment can be asserted against the HTTP backend's without capturing
     /// stdout.
     fn emit(self, value: serde_json::Value) {
-        println!("{}", serde_json::to_string_pretty(&value).unwrap());
+        println!("{}", term::json_string(&value).unwrap());
     }
 
     /// Serialization of our own models cannot fail.

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -202,7 +202,7 @@ fn export(
 // ── Helpers ──────────────────────────────────────────────────
 
 fn print_json<T: serde::Serialize>(val: &T) {
-    println!("{}", serde_json::to_string_pretty(val).unwrap());
+    println!("{}", term::json_string(val).unwrap());
 }
 
 fn page_folder_id(

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -192,7 +192,7 @@ fn export(
 
     let written = crate::export::write_bundle_to_directory(&bundle, output)?;
     if json {
-        print_json(&written);
+        print_json(&written)?;
     } else {
         print!("{}", render::export_written(&written, output));
     }
@@ -201,8 +201,9 @@ fn export(
 
 // ── Helpers ──────────────────────────────────────────────────
 
-fn print_json<T: serde::Serialize>(val: &T) {
-    println!("{}", term::json_string(val).unwrap());
+fn print_json<T: serde::Serialize>(val: &T) -> Result<(), serde_json::Error> {
+    println!("{}", term::json_string(val)?);
+    Ok(())
 }
 
 fn page_folder_id(
@@ -846,7 +847,7 @@ fn module(
             drop(conn);
 
             if json {
-                print_json(&render::Deleted::named(name));
+                print_json(&render::Deleted::named(name))?;
             } else {
                 print!("{}", render::module_deleted(name));
             }
@@ -869,7 +870,7 @@ fn label(
             let labels = queries::list_labels(&conn, project_id)?;
 
             if json {
-                print_json(&labels);
+                print_json(&labels)?;
             } else {
                 print!("{}", render::label_list(&labels, project));
             }
@@ -893,7 +894,7 @@ fn label(
             drop(conn);
 
             if json {
-                print_json(&label);
+                print_json(&label)?;
             } else {
                 print!("{}", render::label_created(&label));
             }
@@ -919,7 +920,7 @@ fn label(
             drop(conn);
 
             if json {
-                print_json(&label);
+                print_json(&label)?;
             } else {
                 print!("{}", render::label_updated(&label));
             }
@@ -933,7 +934,7 @@ fn label(
             drop(conn);
 
             if json {
-                print_json(&render::Deleted::named(name));
+                print_json(&render::Deleted::named(name))?;
             } else {
                 print!("{}", render::label_deleted(name));
             }
@@ -956,7 +957,7 @@ fn folder(
             let folders = queries::list_folders(&conn, project_id)?;
 
             if json {
-                print_json(&folders);
+                print_json(&folders)?;
             } else {
                 print!("{}", render::folder_list(&folders, project));
             }
@@ -976,7 +977,7 @@ fn folder(
             drop(conn);
 
             if json {
-                print_json(&folder);
+                print_json(&folder)?;
             } else {
                 print!("{}", render::folder_created(&folder));
             }
@@ -1000,7 +1001,7 @@ fn folder(
             drop(conn);
 
             if json {
-                print_json(&folder);
+                print_json(&folder)?;
             } else {
                 print!("{}", render::folder_updated(name, &folder));
             }
@@ -1014,7 +1015,7 @@ fn folder(
             drop(conn);
 
             if json {
-                print_json(&render::Deleted::named(name));
+                print_json(&render::Deleted::named(name))?;
             } else {
                 print!("{}", render::folder_deleted(name));
             }

--- a/src/cli/git_hook.rs
+++ b/src/cli/git_hook.rs
@@ -140,10 +140,14 @@ pub fn run_sql(
     if json {
         println!(
             "{}",
-            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+            crate::cli::term::json_string(&value)
+                .map_err(|error| { crate::error::LificError::Internal(error.to_string()) })?
         );
     } else {
-        print!("{}", human(&value));
+        print!(
+            "{}",
+            crate::cli::ui::sanitize_terminal_block(&human(&value))
+        );
     }
     Ok(())
 }
@@ -218,22 +222,20 @@ pub fn human(value: &Value) -> String {
 
     let mut out = String::new();
     for identifier in acted {
-        let identifier = identifier.as_str().unwrap_or("?");
+        let identifier = crate::cli::ui::sanitize_terminal_line(identifier.as_str().unwrap_or("?"));
         let verb = if dry_run { "would close" } else { "closed" };
         let _ = writeln!(out, "  {verb} {identifier}");
     }
     for skip in skipped {
-        let _ = writeln!(
-            out,
-            "  skipped {} ({})",
-            skip["identifier"].as_str().unwrap_or("?"),
-            skip["reason"].as_str().unwrap_or("?")
-        );
+        let identifier =
+            crate::cli::ui::sanitize_terminal_line(skip["identifier"].as_str().unwrap_or("?"));
+        let reason = crate::cli::ui::sanitize_terminal_line(skip["reason"].as_str().unwrap_or("?"));
+        let _ = writeln!(out, "  skipped {identifier} ({reason})");
     }
 
     if acted.is_empty() && skipped.is_empty() {
         out.push_str("No issue references found in these commit messages.\n");
-        return out;
+        return crate::cli::ui::sanitize_terminal_block(&out);
     }
 
     let _ = writeln!(
@@ -243,7 +245,7 @@ pub fn human(value: &Value) -> String {
         if dry_run { "to close" } else { "closed" },
         skipped.len()
     );
-    out
+    crate::cli::ui::sanitize_terminal_block(&out)
 }
 
 #[cfg(test)]
@@ -447,6 +449,35 @@ mod tests {
         let text = human(&document(true, vec!["LIF-1".into()], Vec::new()));
         assert!(text.contains("would close LIF-1"), "{text}");
         assert!(text.contains("1 to close, 0 skipped."), "{text}");
+    }
+
+    #[test]
+    fn hostile_git_hook_http_fields_are_inert_in_human_output() {
+        let hostile = "\x1b]52;c;cHdu\x07\x1b[2J\u{009b}\u{202e}\u{2066}\u{200b}\u{feff}\r\n\t\u{0008}\u{007f}";
+        for key in ["closed", "would_close"] {
+            let value = json!({
+                key: [format!("LIF-1{hostile}")],
+                "skipped": [{
+                    "identifier": format!("LIF-2{hostile}"),
+                    "reason": format!("denied{hostile}")
+                }]
+            });
+            let text = human(&value);
+            for control in [
+                '\x1b', '\x07', '\u{009b}', '\u{202e}', '\u{2066}', '\u{200b}', '\u{feff}', '\r',
+                '\t', '\u{0008}', '\u{007f}',
+            ] {
+                assert!(!text.contains(control), "unsafe output: {text:?}");
+            }
+            assert_eq!(
+                text.lines().count(),
+                4,
+                "fields must not add rows: {text:?}"
+            );
+            assert!(text.lines().nth(1).unwrap().contains("denied"));
+            let encoded = crate::cli::term::json_string(&value).unwrap();
+            assert_eq!(serde_json::from_str::<Value>(&encoded).unwrap(), value);
+        }
     }
 
     // ── ranges, against a real repository ────────────────────

--- a/src/cli/http.rs
+++ b/src/cli/http.rs
@@ -65,7 +65,7 @@ pub async fn run(
     };
     let output = backend.execute(command, link_output).await?;
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        println!("{}", crate::cli::term::json_string(&output)?);
     } else {
         print!("{}", backend.human(command, &output).await);
     }
@@ -153,10 +153,10 @@ impl HttpBackend {
                 .host_str()
                 .is_some_and(|host| !is_loopback_host(host))
         {
-            eprintln!(
+            crate::cli::ui::stderr_line(format_args!(
                 "warning: connecting over unencrypted http to {}",
                 parsed.host_str().unwrap_or_default()
-            );
+            ));
         }
         Ok(Self {
             client: Client::builder()
@@ -225,7 +225,10 @@ impl HttpBackend {
     async fn human(&self, command: &Command, value: &Value) -> String {
         match self.render(command, value).await {
             Some(text) => text,
-            None => format!("{}\n", pretty(value)),
+            None => format!(
+                "{}\n",
+                crate::cli::ui::sanitize_terminal_block(&pretty(value))
+            ),
         }
     }
 
@@ -1489,16 +1492,7 @@ async fn read_error_body(mut response: reqwest::Response) -> Result<String, reqw
 }
 
 fn sanitize_error_detail(detail: &str) -> String {
-    detail
-        .chars()
-        .map(|character| {
-            if character.is_ascii_control() {
-                ' '
-            } else {
-                character
-            }
-        })
-        .collect()
+    crate::cli::ui::sanitize_terminal_line(detail)
 }
 
 /// How the server delivers an export, and so how this backend turns it back
@@ -1512,7 +1506,7 @@ enum ExportShape {
 }
 
 fn pretty(value: &Value) -> String {
-    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+    crate::cli::term::json_string(value).unwrap_or_else(|_| value.to_string())
 }
 
 #[cfg(test)]
@@ -2917,7 +2911,7 @@ mod tests {
         let error = error.to_string();
 
         assert!(error.starts_with(
-            "HTTP backend request failed (400 Bad Request): invalid page identifier: TST-DOC- [31m"
+            "HTTP backend request failed (400 Bad Request): invalid page identifier: TST-DOC-^[[31m"
         ));
         assert!(!error.chars().any(|character| character.is_ascii_control()));
         fixture.server.abort();
@@ -3259,10 +3253,10 @@ mod tests {
     }
 
     #[test]
-    fn sanitizes_ascii_control_characters_in_error_details() {
+    fn sanitizes_terminal_controls_in_error_details() {
         assert_eq!(
-            sanitize_error_detail("access\u{1b}[31m denied\n\t"),
-            "access [31m denied  "
+            sanitize_error_detail("access\u{1b}[31m denied\n\t\u{202e}"),
+            "access^[[31m denied   "
         );
     }
 
@@ -3676,11 +3670,14 @@ mod tests {
                 &Command::Project {
                     action: ProjectAction::List,
                 },
-                &json!({"unexpected": true}),
+                &json!({"unexpected": "safe\u{1b}[2J\u{202e}"}),
             )
             .await;
 
-        assert_eq!(rendered, "{\n  \"unexpected\": true\n}\n");
+        assert_eq!(
+            rendered,
+            "{\n  \"unexpected\": \"safe\\u001b[2J\\u202e\"\n}\n"
+        );
     }
 
     #[test]

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -203,7 +203,7 @@ fn run_jira(
 /// Render the summary for humans (or JSON when piped).
 pub fn print_summary(summary: &ImportSummary, json: bool) {
     if json {
-        println!("{}", serde_json::to_string_pretty(summary).unwrap());
+        println!("{}", crate::cli::term::json_string(summary).unwrap());
         return;
     }
     println!();

--- a/src/cli/instance.rs
+++ b/src/cli/instance.rs
@@ -3,7 +3,7 @@
 //! The settings row in the database is authoritative; TOML only seeds it on
 //! first touch (LIF-210).
 
-use crate::cli::{InstanceAction, term};
+use crate::cli::{InstanceAction, term, ui};
 use crate::config::Config;
 use crate::db;
 
@@ -99,35 +99,41 @@ pub fn run(
             "login_message": settings.login_message,
             "users": { "total": total, "admins": admins },
         });
-        println!("{}", serde_json::to_string_pretty(&out)?);
+        println!("{}", crate::cli::term::json_string(&out)?);
     } else {
-        println!("Instance");
-        println!(
+        ui::line("Instance");
+        ui::line(format!(
             "  name:          {}",
             settings.instance_name.as_deref().unwrap_or("(unnamed)")
-        );
-        println!("  version:       {version}");
-        println!("  database:      {}", cfg.database.path.display());
-        println!("  bind:          {}:{}", cfg.server.host, cfg.server.port);
-        println!(
+        ));
+        ui::line(format!("  version:       {version}"));
+        ui::line(format!("  database:      {}", cfg.database.path.display()));
+        ui::line(format!(
+            "  bind:          {}:{}",
+            cfg.server.host, cfg.server.port
+        ));
+        ui::line(format!(
             "  public url:    {}",
             cfg.server.public_url.as_deref().unwrap_or("(not set)")
-        );
-        println!(
+        ));
+        ui::line(format!(
             "  signups:       {}",
             if settings.allow_signup {
                 "open"
             } else {
                 "closed"
             }
-        );
-        println!("  signup domains:{domains}");
-        println!("  session days:  {}", settings.session_lifetime_days);
-        println!(
+        ));
+        ui::line(format!("  signup domains:{domains}"));
+        ui::line(format!(
+            "  session days:  {}",
+            settings.session_lifetime_days
+        ));
+        ui::line(format!(
             "  login message: {}",
             settings.login_message.as_deref().unwrap_or("(none)")
-        );
-        println!("  users:         {total} ({admins} admin)");
+        ));
+        ui::line(format!("  users:         {total} ({admins} admin)"));
     }
     Ok(())
 }

--- a/src/cli/key.rs
+++ b/src/cli/key.rs
@@ -44,7 +44,7 @@ pub fn run(
                     "key": key,
                     "user": assigned,
                 });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 let title = if let Some(ref username) = assigned {
                     format!(
@@ -73,18 +73,18 @@ pub fn run(
                         })
                     })
                     .collect();
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else if keys.is_empty() {
-                println!("No API keys configured.");
+                ui::line("No API keys configured.");
             } else {
-                println!("{} API key(s):", keys.len());
+                ui::line(format!("{} API key(s):", keys.len()));
                 for k in &keys {
                     let status = if k.revoked { "REVOKED" } else { "active" };
                     let expiry = k.expires_at.as_deref().unwrap_or("never");
-                    println!(
+                    ui::line(format!(
                         "  {} | {} | created {} | expires {}",
                         k.name, status, k.created_at, expiry
-                    );
+                    ));
                 }
             }
         }
@@ -92,7 +92,7 @@ pub fn run(
             auth::revoke_api_key(&pool, &name)?;
             if json {
                 let out = serde_json::json!({ "revoked": name });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 ui::step(format!("Revoked key '{name}'"));
             }
@@ -101,7 +101,7 @@ pub fn run(
             let key = auth::rotate_api_key(&pool, &manager, &name)?;
             if json {
                 let out = serde_json::json!({ "name": name, "key": key });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 ui::note(
                     format!("Key '{name}' rotated — save it now, it will not be shown again"),
@@ -117,7 +117,7 @@ pub fn run(
             db::queries::users::assign_key_to_user(&conn, &name, u.id)?;
             if json {
                 let out = serde_json::json!({ "name": name, "user": user });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 ui::step(format!("Assigned key '{name}' to user '{user}'"));
             }

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -258,10 +258,10 @@ impl DeviceFlow for HttpDeviceFlow {
                 // Stale id: fall through and register a new one.
                 Err(DeviceAuthFailure::UnknownClient) => {
                     if let Err(error) = crate::cli::credentials::forget_client_id(&self.base) {
-                        eprintln!(
+                        crate::cli::ui::stderr_line(format_args!(
                             "warning: could not remove stale OAuth client cache entry for {}: {error}; continuing with a new registration",
                             self.base
-                        );
+                        ));
                     }
                 }
             }
@@ -285,10 +285,10 @@ impl DeviceFlow for HttpDeviceFlow {
             });
         };
         if let Err(error) = crate::cli::credentials::store_client_id(&self.base, &client_id) {
-            eprintln!(
+            crate::cli::ui::stderr_line(format_args!(
                 "warning: could not cache OAuth client registration for {}: {error}; continuing with the registered client",
                 self.base
-            );
+            ));
         }
 
         self.device_authorization(&[("scope", "mcp"), ("client_id", &client_id)])
@@ -400,7 +400,7 @@ pub fn run_login_with_flow<F: DeviceFlow>(
         let payload = non_interactive_json(&resp, base);
         println!(
             "{}",
-            serde_json::to_string_pretty(&payload).unwrap_or_default()
+            crate::cli::term::json_string(&payload).unwrap_or_default()
         );
         return Ok(());
     }
@@ -447,7 +447,7 @@ fn finish(args: &LoginArgs, base: &str, outcome: PollOutcome, json: bool) -> Res
                 if json {
                     println!(
                         "{}",
-                        serde_json::to_string_pretty(&serde_json::json!({
+                        crate::cli::term::json_string(&serde_json::json!({
                             "status": "approved",
                             "stored": false,
                             "access_token": token,
@@ -464,7 +464,7 @@ fn finish(args: &LoginArgs, base: &str, outcome: PollOutcome, json: bool) -> Res
             if json {
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&serde_json::json!({
+                    crate::cli::term::json_string(&serde_json::json!({
                         "status": "approved",
                         "stored": true,
                         "url": base,
@@ -498,7 +498,7 @@ pub fn run_logout(url: Option<&str>, cfg: &Config, json: bool) -> Result<(), Str
     if json {
         println!(
             "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
+            crate::cli::term::json_string(&serde_json::json!({
                 "url": base,
                 "removed": removed,
             }))

--- a/src/cli/member.rs
+++ b/src/cli/member.rs
@@ -34,16 +34,19 @@ pub fn run(
                         })
                     })
                     .collect();
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else if members.is_empty() {
-                println!(
+                ui::line(format!(
                     "No members on '{project}'. Grant access with `lific member add \
                      --project {project} --user <name>`."
-                );
+                ));
             } else {
-                println!("{} member(s) of {}:", members.len(), project);
+                ui::line(format!("{} member(s) of {}:", members.len(), project));
                 for m in &members {
-                    println!("  {} | {} | since {}", m.username, m.role, m.created_at);
+                    ui::line(format!(
+                        "  {} | {} | since {}",
+                        m.username, m.role, m.created_at
+                    ));
                 }
             }
         }
@@ -77,7 +80,7 @@ pub fn run(
                         "granted": granted,
                         "already_member": skipped,
                     });
-                    println!("{}", serde_json::to_string_pretty(&out)?);
+                    println!("{}", crate::cli::term::json_string(&out)?);
                 } else {
                     ui::step(format!(
                         "Granted '{}' {role} access to {} project(s){}",
@@ -106,7 +109,7 @@ pub fn run(
                         "user": u.username,
                         "role": member.role.as_str(),
                     });
-                    println!("{}", serde_json::to_string_pretty(&out)?);
+                    println!("{}", crate::cli::term::json_string(&out)?);
                 } else {
                     ui::step(format!(
                         "Added '{}' to {ident} as {}",
@@ -131,7 +134,7 @@ pub fn run(
                     "user": u.username,
                     "role": member.role.as_str(),
                 });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 ui::step(format!(
                     "'{}' is now {} on {project}",
@@ -151,7 +154,7 @@ pub fn run(
                     "user": u.username,
                     "removed": true,
                 });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 ui::step(format!("Removed '{}' from {project}", u.username));
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -121,7 +121,7 @@ pub struct Cli {
     pub backend: BackendKind,
 
     /// Base URL for the HTTP backend (also read from LIFIC_URL).
-    #[arg(long, global = true, env = "LIFIC_URL")]
+    #[arg(long, global = true, env = "LIFIC_URL", hide_env_values = true)]
     pub url: Option<String>,
 
     /// API key for the HTTP backend (also read from LIFIC_API_KEY; login

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -650,7 +650,7 @@ pub enum ImportAction {
 
         /// GitHub token (falls back to GITHUB_TOKEN). Optional for public
         /// repos, but strongly recommended to avoid the 60 req/hr anon limit.
-        #[arg(long, env = "GITHUB_TOKEN")]
+        #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
         token: Option<String>,
 
         /// Lific status for open issues.
@@ -682,7 +682,7 @@ pub enum ImportAction {
         project: String,
 
         /// Linear personal API key (falls back to LINEAR_API_KEY).
-        #[arg(long, env = "LINEAR_API_KEY")]
+        #[arg(long, env = "LINEAR_API_KEY", hide_env_values = true)]
         token: Option<String>,
 
         /// Username who should own the import bot.
@@ -709,11 +709,11 @@ pub enum ImportAction {
         project: String,
 
         /// Jira account email (falls back to JIRA_EMAIL).
-        #[arg(long, env = "JIRA_EMAIL")]
+        #[arg(long, env = "JIRA_EMAIL", hide_env_values = true)]
         email: Option<String>,
 
         /// Jira API token (falls back to JIRA_API_TOKEN).
-        #[arg(long, env = "JIRA_API_TOKEN")]
+        #[arg(long, env = "JIRA_API_TOKEN", hide_env_values = true)]
         token: Option<String>,
 
         /// Username who should own the import bot.
@@ -1485,6 +1485,59 @@ mod tests {
         assert_eq!(cli.backend, BackendKind::Http);
         assert_eq!(cli.url.as_deref(), Some("https://tracker.example.test"));
         assert_eq!(cli.api_key.as_deref(), Some("key-123"));
+    }
+
+    #[test]
+    fn import_credentials_use_environment_fallback_and_explicit_precedence() {
+        let _env = test_env::EnvGuard::set(&[
+            ("GITHUB_TOKEN", Some("github-from-env")),
+            ("LINEAR_API_KEY", Some("linear-from-env")),
+            ("JIRA_EMAIL", Some("jira@example.test")),
+            ("JIRA_API_TOKEN", Some("jira-from-env")),
+        ]);
+
+        let github = Cli::try_parse_from([
+            "lific",
+            "import",
+            "github",
+            "--repo",
+            "owner/repo",
+            "--project",
+            "LIF",
+        ])
+        .unwrap();
+        let Command::Import {
+            action: ImportAction::Github { token, .. },
+        } = github.command
+        else {
+            panic!("expected GitHub import");
+        };
+        assert_eq!(token.as_deref(), Some("github-from-env"));
+
+        let jira = Cli::try_parse_from([
+            "lific",
+            "import",
+            "jira",
+            "--site",
+            "example",
+            "--jira-project",
+            "PROJ",
+            "--project",
+            "LIF",
+            "--email",
+            "explicit@example.test",
+            "--token",
+            "explicit-token",
+        ])
+        .unwrap();
+        let Command::Import {
+            action: ImportAction::Jira { email, token, .. },
+        } = jira.command
+        else {
+            panic!("expected Jira import");
+        };
+        assert_eq!(email.as_deref(), Some("explicit@example.test"));
+        assert_eq!(token.as_deref(), Some("explicit-token"));
     }
 
     /// Value clap's `env` fallback will supply for `var` when the matching

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@ pub mod mcp_instances;
 pub mod mcp_proxy;
 pub mod member;
 pub mod render;
+pub(crate) mod runtime;
 pub mod service;
 pub mod term;
 #[cfg(test)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1401,7 +1401,7 @@ pub enum UserAction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use proptest::prelude::*;
 
     #[test]
@@ -1538,6 +1538,26 @@ mod tests {
         };
         assert_eq!(email.as_deref(), Some("explicit@example.test"));
         assert_eq!(token.as_deref(), Some("explicit-token"));
+    }
+
+    #[test]
+    fn every_environment_backed_argument_hides_its_value() {
+        fn assert_hidden(command: &clap::Command) {
+            for argument in command.get_arguments() {
+                if argument.get_env().is_some() {
+                    assert!(
+                        argument.is_hide_env_values_set(),
+                        "environment-backed argument {:?} exposes its value",
+                        argument.get_id()
+                    );
+                }
+            }
+            for subcommand in command.get_subcommands() {
+                assert_hidden(subcommand);
+            }
+        }
+
+        assert_hidden(&Cli::command());
     }
 
     /// Value clap's `env` fallback will supply for `var` when the matching

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -18,14 +18,30 @@
 //! the project archive locally) and deletes (both backends print the
 //! [`Deleted`] below).
 
-use std::fmt::Write as _;
+use std::fmt::{Display, Write as _};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::cli::ui::TerminalDisplay;
 use crate::db::models::{
     Comment, Folder, Issue, Label, Module, Page, Priority, Project, SearchResult, Status,
 };
+
+trait TerminalWrite {
+    fn line(&mut self, text: impl Display);
+    fn block(&mut self, text: impl Display);
+}
+
+impl TerminalWrite for String {
+    fn line(&mut self, text: impl Display) {
+        let _ = writeln!(self, "{}", text.terminal_line());
+    }
+
+    fn block(&mut self, text: impl Display) {
+        let _ = writeln!(self, "{}", text.terminal_block());
+    }
+}
 
 /// What a `delete` prints under `--json`.
 ///
@@ -111,18 +127,18 @@ fn first_line_suffix(text: &str) -> String {
 pub fn issue_list(issues: &[Issue], module_name: ModuleName<'_>) -> String {
     let mut out = String::new();
     if issues.is_empty() {
-        w!(out, "No issues found.");
+        out.line("No issues found.");
         return out;
     }
-    w!(out, "{} issue(s):\n", issues.len());
+    out.line(format_args!("{} issue(s):", issues.len()));
+    out.push('\n');
     for issue in issues {
         let module = issue
             .module_id
             .and_then(module_name)
             .map(|name| format!(" ({name})"))
             .unwrap_or_default();
-        w!(
-            out,
+        out.line(format_args!(
             "  {:<8} {} | {} | {}{}{}",
             issue.identifier,
             fmt_status(issue.status),
@@ -130,55 +146,64 @@ pub fn issue_list(issues: &[Issue], module_name: ModuleName<'_>) -> String {
             issue.title,
             bracketed_labels(&issue.labels),
             module
-        );
+        ));
     }
     out
 }
 
 pub fn issue_detail(issue: &Issue, module_name: ModuleName<'_>) -> String {
     let mut out = String::new();
-    w!(out, "{} - {}", issue.identifier, issue.title);
-    w!(out, "  Status:   {}", issue.status);
-    w!(out, "  Priority: {}", issue.priority);
+    out.line(format_args!("{} - {}", issue.identifier, issue.title));
+    out.line(format_args!("  Status:   {}", issue.status));
+    out.line(format_args!("  Priority: {}", issue.priority));
     if !issue.labels.is_empty() {
-        w!(out, "  Labels:   {}", issue.labels.join(", "));
+        out.line(format_args!("  Labels:   {}", issue.labels.join(", ")));
     }
     if let Some(name) = issue.module_id.and_then(module_name) {
-        w!(out, "  Module:   {name}");
+        out.line(format_args!("  Module:   {name}"));
     }
     if !issue.blocks.is_empty() {
-        w!(out, "  Blocks:   {}", issue.blocks.join(", "));
+        out.line(format_args!("  Blocks:   {}", issue.blocks.join(", ")));
     }
     if !issue.blocked_by.is_empty() {
-        w!(out, "  Blocked:  {}", issue.blocked_by.join(", "));
+        out.line(format_args!("  Blocked:  {}", issue.blocked_by.join(", ")));
     }
     if !issue.relates_to.is_empty() {
-        w!(out, "  Relates:  {}", issue.relates_to.join(", "));
+        out.line(format_args!("  Relates:  {}", issue.relates_to.join(", ")));
     }
     if !issue.duplicates.is_empty() {
-        w!(out, "  Dupes:    {}", issue.duplicates.join(", "));
+        out.line(format_args!("  Dupes:    {}", issue.duplicates.join(", ")));
     }
     if !issue.duplicated_by.is_empty() {
-        w!(out, "  DupedBy:  {}", issue.duplicated_by.join(", "));
+        out.line(format_args!(
+            "  DupedBy:  {}",
+            issue.duplicated_by.join(", ")
+        ));
     }
     if !issue.description.is_empty() {
-        w!(out);
-        w!(out, "{}", issue.description);
+        out.push('\n');
+        out.block(&issue.description);
     }
     out
 }
 
 pub fn issue_created(issue: &Issue) -> String {
     let mut out = String::new();
-    w!(out, "Created {}: {}", issue.identifier, issue.title);
+    out.line(format_args!(
+        "Created {}: {}",
+        issue.identifier, issue.title
+    ));
     out
 }
 
 pub fn issue_updated(issue: &Issue) -> String {
     let mut out = String::new();
-    w!(out, "Updated {}: {}", issue.identifier, issue.title);
-    w!(out, "  Status:   {}", issue.status);
-    w!(out, "  Priority: {}", issue.priority);
+    out.line(format_args!(
+        "Updated {}: {}",
+        issue.identifier, issue.title
+    ));
+    out.line(format_args!("  Status:   {}", issue.status));
+    out.line(format_args!("  Priority: {}", issue.priority));
     out
 }
 
@@ -187,51 +212,47 @@ pub fn issue_updated(issue: &Issue) -> String {
 pub fn project_list(projects: &[Project]) -> String {
     let mut out = String::new();
     if projects.is_empty() {
-        w!(out, "No projects.");
+        out.line("No projects.");
         return out;
     }
-    w!(out, "{} project(s):\n", projects.len());
+    out.line(format_args!("{} project(s):", projects.len()));
+    out.push('\n');
     for project in projects {
-        w!(
-            out,
+        out.line(format_args!(
             "  {:<5} {}{}",
             project.identifier,
             project.name,
             first_line_suffix(&project.description)
-        );
+        ));
     }
     out
 }
 
 pub fn project_detail(project: &Project) -> String {
     let mut out = String::new();
-    w!(out, "{} - {}", project.identifier, project.name);
+    out.line(format_args!("{} - {}", project.identifier, project.name));
     if !project.description.is_empty() {
-        w!(out);
-        w!(out, "{}", project.description);
+        out.push('\n');
+        out.block(&project.description);
     }
     out
 }
 
 pub fn project_created(project: &Project) -> String {
     let mut out = String::new();
-    w!(
-        out,
+    out.line(format_args!(
         "Created project {} ({})",
-        project.name,
-        project.identifier
-    );
+        project.name, project.identifier
+    ));
     out
 }
 
 pub fn project_updated(project: &Project) -> String {
     let mut out = String::new();
-    w!(
-        out,
+    out.line(format_args!(
         "Updated project {} ({})",
-        project.name,
-        project.identifier
-    );
+        project.name, project.identifier
+    ));
     out
 }
 
@@ -240,10 +261,11 @@ pub fn project_updated(project: &Project) -> String {
 pub fn page_list(pages: &[Page]) -> String {
     let mut out = String::new();
     if pages.is_empty() {
-        w!(out, "No pages found.");
+        out.line("No pages found.");
         return out;
     }
-    w!(out, "{} page(s):\n", pages.len());
+    out.line(format_args!("{} page(s):", pages.len()));
+    out.push('\n');
     for page in pages {
         let preview = if page.content.is_empty() {
             "(empty)".to_string()
@@ -255,40 +277,45 @@ pub fn page_list(pages: &[Page]) -> String {
                 first_line.to_string()
             }
         };
-        w!(
-            out,
+        out.line(format_args!(
             "  {:<12} {} - {}{}",
             page.identifier,
             page.title,
             preview,
             bracketed_labels(&page.labels)
-        );
+        ));
     }
     out
 }
 
 pub fn page_detail(page: &Page) -> String {
     let mut out = String::new();
-    w!(out, "{} - {}", page.identifier, page.title);
+    out.line(format_args!("{} - {}", page.identifier, page.title));
     if !page.labels.is_empty() {
-        w!(out, "  Labels: {}", page.labels.join(", "));
+        out.line(format_args!("  Labels: {}", page.labels.join(", ")));
     }
     if !page.content.is_empty() {
-        w!(out);
-        w!(out, "{}", page.content);
+        out.push('\n');
+        out.block(&page.content);
     }
     out
 }
 
 pub fn page_created(page: &Page) -> String {
     let mut out = String::new();
-    w!(out, "Created page {}: {}", page.identifier, page.title);
+    out.line(format_args!(
+        "Created page {}: {}",
+        page.identifier, page.title
+    ));
     out
 }
 
 pub fn page_updated(page: &Page) -> String {
     let mut out = String::new();
-    w!(out, "Updated page {}: {}", page.identifier, page.title);
+    out.line(format_args!(
+        "Updated page {}: {}",
+        page.identifier, page.title
+    ));
     out
 }
 
@@ -297,19 +324,17 @@ pub fn page_updated(page: &Page) -> String {
 pub fn search_results(results: &[SearchResult]) -> String {
     let mut out = String::new();
     if results.is_empty() {
-        w!(out, "No results found.");
+        out.line("No results found.");
         return out;
     }
-    w!(out, "{} result(s):\n", results.len());
+    out.line(format_args!("{} result(s):", results.len()));
+    out.push('\n');
     for result in results {
         let identifier = result.identifier.as_deref().unwrap_or("?");
-        w!(
-            out,
+        out.line(format_args!(
             "  {:<12} [{}] {}",
-            identifier,
-            result.result_type,
-            result.title
-        );
+            identifier, result.result_type, result.title
+        ));
         if !result.snippet.is_empty() {
             // Clean up snippet for terminal display
             let snippet = result.snippet.replace("**", "").replace('\n', " ");
@@ -318,7 +343,7 @@ pub fn search_results(results: &[SearchResult]) -> String {
             } else {
                 snippet
             };
-            w!(out, "              {}", snippet);
+            out.line(format_args!("              {snippet}"));
         }
     }
     out
@@ -357,22 +382,24 @@ pub fn comment_list(
 ) -> String {
     let mut out = String::new();
     if comments.is_empty() {
-        w!(out, "No comments on {}.", identifier);
+        out.line(format_args!("No comments on {identifier}."));
         return out;
     }
-    w!(out, "{} comment(s) on {}:\n", comments.len(), identifier);
+    out.line(format_args!(
+        "{} comment(s) on {}:",
+        comments.len(),
+        identifier
+    ));
+    out.push('\n');
     for comment in comments {
-        w!(
-            out,
+        out.line(format_args!(
             "  {} ({}) - {}:",
-            comment.author_display_name,
-            comment.author,
-            comment.created_at
-        );
+            comment.author_display_name, comment.author, comment.created_at
+        ));
         for line in comment.content.lines() {
-            w!(out, "    {line}");
+            out.line(format_args!("    {line}"));
         }
-        w!(out);
+        out.push('\n');
     }
     match continuation {
         CommentContinuation::End => {}
@@ -392,13 +419,11 @@ pub fn comment_list(
 
 pub fn comment_added(comment: &Comment, identifier: &str) -> String {
     let mut out = String::new();
-    w!(
-        out,
+    out.line(format_args!(
         "Added comment to {} by {}:",
-        identifier,
-        comment.author
-    );
-    w!(out, "  {}", comment.content);
+        identifier, comment.author
+    ));
+    out.block(format_args!("  {}", comment.content));
     out
 }
 
@@ -407,43 +432,43 @@ pub fn comment_added(comment: &Comment, identifier: &str) -> String {
 pub fn module_list(modules: &[Module], project: &str) -> String {
     let mut out = String::new();
     if modules.is_empty() {
-        w!(out, "No modules in {}.", project);
+        out.line(format_args!("No modules in {project}."));
         return out;
     }
-    w!(out, "{} module(s) in {}:\n", modules.len(), project);
+    out.line(format_args!("{} module(s) in {}:", modules.len(), project));
+    out.push('\n');
     for module in modules {
-        w!(
-            out,
+        out.line(format_args!(
             "  {:<20} [{}]{}",
             module.name,
             module.status,
             first_line_suffix(&module.description)
-        );
+        ));
     }
     out
 }
 
 pub fn module_created(module: &Module, project: &str) -> String {
     let mut out = String::new();
-    w!(
-        out,
+    out.line(format_args!(
         "Created module '{}' [{}] in {}",
-        module.name,
-        module.status,
-        project
-    );
+        module.name, module.status, project
+    ));
     out
 }
 
 pub fn module_updated(module: &Module) -> String {
     let mut out = String::new();
-    w!(out, "Updated module '{}' [{}]", module.name, module.status);
+    out.line(format_args!(
+        "Updated module '{}' [{}]",
+        module.name, module.status
+    ));
     out
 }
 
 pub fn module_deleted(name: &str) -> String {
     let mut out = String::new();
-    w!(out, "Deleted module '{}'", name);
+    out.line(format_args!("Deleted module '{name}'"));
     out
 }
 
@@ -452,31 +477,38 @@ pub fn module_deleted(name: &str) -> String {
 pub fn label_list(labels: &[Label], project: &str) -> String {
     let mut out = String::new();
     if labels.is_empty() {
-        w!(out, "No labels in {}.", project);
+        out.line(format_args!("No labels in {project}."));
         return out;
     }
-    w!(out, "{} label(s) in {}:\n", labels.len(), project);
+    out.line(format_args!("{} label(s) in {}:", labels.len(), project));
+    out.push('\n');
     for label in labels {
-        w!(out, "  {} ({})", label.name, label.color);
+        out.line(format_args!("  {} ({})", label.name, label.color));
     }
     out
 }
 
 pub fn label_created(label: &Label) -> String {
     let mut out = String::new();
-    w!(out, "Created label '{}' ({})", label.name, label.color);
+    out.line(format_args!(
+        "Created label '{}' ({})",
+        label.name, label.color
+    ));
     out
 }
 
 pub fn label_updated(label: &Label) -> String {
     let mut out = String::new();
-    w!(out, "Updated label '{}' ({})", label.name, label.color);
+    out.line(format_args!(
+        "Updated label '{}' ({})",
+        label.name, label.color
+    ));
     out
 }
 
 pub fn label_deleted(name: &str) -> String {
     let mut out = String::new();
-    w!(out, "Deleted label '{}'", name);
+    out.line(format_args!("Deleted label '{name}'"));
     out
 }
 
@@ -485,36 +517,35 @@ pub fn label_deleted(name: &str) -> String {
 pub fn folder_list(folders: &[Folder], project: &str) -> String {
     let mut out = String::new();
     if folders.is_empty() {
-        w!(out, "No folders in {}.", project);
+        out.line(format_args!("No folders in {project}."));
         return out;
     }
-    w!(out, "{} folder(s) in {}:\n", folders.len(), project);
+    out.line(format_args!("{} folder(s) in {}:", folders.len(), project));
+    out.push('\n');
     for folder in folders {
-        w!(out, "  {}", folder.name);
+        out.line(format_args!("  {}", folder.name));
     }
     out
 }
 
 pub fn folder_created(folder: &Folder) -> String {
     let mut out = String::new();
-    w!(out, "Created folder '{}'", folder.name);
+    out.line(format_args!("Created folder '{}'", folder.name));
     out
 }
 
 pub fn folder_updated(previous_name: &str, folder: &Folder) -> String {
     let mut out = String::new();
-    w!(
-        out,
+    out.line(format_args!(
         "Renamed folder '{}' -> '{}'",
-        previous_name,
-        folder.name
-    );
+        previous_name, folder.name
+    ));
     out
 }
 
 pub fn folder_deleted(name: &str) -> String {
     let mut out = String::new();
-    w!(out, "Deleted folder '{}'", name);
+    out.line(format_args!("Deleted folder '{name}'"));
     out
 }
 
@@ -522,14 +553,13 @@ pub fn folder_deleted(name: &str) -> String {
 
 pub fn export_written(written: &[PathBuf], output: &Path) -> String {
     let mut out = String::new();
-    w!(
-        out,
+    out.line(format_args!(
         "Exported {} file(s) to {}",
         written.len(),
         output.display()
-    );
+    ));
     for path in written {
-        w!(out, "  {}", path.display());
+        out.line(format_args!("  {}", path.display()));
     }
     out
 }
@@ -676,5 +706,85 @@ mod tests {
             "TST-1 - Fix the bug\n  Status:   active\n  Priority: urgent\n  \
              Blocks:   TST-2\n  DupedBy:  TST-3\n\nDetails\n"
         );
+    }
+
+    #[test]
+    fn stored_controls_cannot_escape_renderer_lines_or_blocks() {
+        let mut one = issue("TST-1", Status::Active, Priority::High);
+        one.title = "forged\nSUCCESS\x1b]52;c;YQ==\x07\u{202e}".into();
+        one.description = "line one\nline two\x1b[2J".into();
+
+        let rendered = issue_detail(&one, &|_| None);
+
+        assert!(rendered.starts_with("TST-1 - forged SUCCESS^[]52;c;YQ==  \n"));
+        assert!(rendered.ends_with("line one\nline two^[[2J\n"));
+    }
+
+    #[test]
+    fn stored_controls_are_inert_in_project_page_and_comment_renderers() {
+        let project = Project {
+            id: 1,
+            name: "project\x1b]8;;https://evil\x1b\\".into(),
+            identifier: "TST".into(),
+            description: "description\u{009b}2J".into(),
+            emoji: None,
+            lead_user_id: None,
+            sort_order: 0,
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+        let page = Page {
+            id: 1,
+            seq: 0,
+            project_id: Some(1),
+            sequence: Some(1),
+            identifier: "TST-DOC-1".into(),
+            folder_id: None,
+            title: "page\u{0008}".into(),
+            content: "body\x1b]52;c;YQ==\x07".into(),
+            sort_order: 0.0,
+            status: "active".into(),
+            pinned: false,
+            created_at: String::new(),
+            updated_at: String::new(),
+            labels: vec!["label\u{202e}".into()],
+        };
+        let comment = Comment {
+            id: 1,
+            seq: 0,
+            issue_id: Some(1),
+            page_id: None,
+            user_id: 1,
+            author: "author\x1b[2J".into(),
+            author_display_name: "display\u{2066}".into(),
+            content: "comment\rforged\tline".into(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+
+        for rendered in [
+            project_detail(&project),
+            page_detail(&page),
+            comment_list(&[comment], "TST-1", CommentContinuation::End),
+        ] {
+            assert!(
+                !rendered.chars().any(|character| character.is_control()
+                    && character != '\n'
+                    && character != '\t')
+            );
+        }
+    }
+
+    #[test]
+    fn json_output_preserves_control_characters_as_escaped_data() {
+        let mut one = issue("TST-1", Status::Active, Priority::High);
+        one.title = "stored\x1b]52;c;YQ==\x07".into();
+
+        let encoded = serde_json::to_string(&one).unwrap();
+        assert!(encoded.contains("\\u001b"));
+        assert!(encoded.contains("\\u0007"));
+
+        let decoded: Issue = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.title, one.title);
     }
 }

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -726,6 +726,7 @@ mod tests {
             id: 1,
             name: "project\x1b]8;;https://evil\x1b\\".into(),
             identifier: "TST".into(),
+            is_public: false,
             description: "description\u{009b}2J".into(),
             emoji: None,
             lead_user_id: None,

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -122,6 +122,19 @@ fn first_line_suffix(text: &str) -> String {
     }
 }
 
+fn truncate_with_ellipsis(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_owned();
+    }
+    let end = text
+        .char_indices()
+        .take_while(|(index, _)| *index <= limit)
+        .map(|(index, _)| index)
+        .last()
+        .unwrap_or(0);
+    format!("{}...", &text[..end])
+}
+
 // ── Issue ────────────────────────────────────────────────────
 
 pub fn issue_list(issues: &[Issue], module_name: ModuleName<'_>) -> String {
@@ -271,11 +284,7 @@ pub fn page_list(pages: &[Page]) -> String {
             "(empty)".to_string()
         } else {
             let first_line = page.content.lines().next().unwrap_or("");
-            if first_line.len() > 60 {
-                format!("{}...", &first_line[..60])
-            } else {
-                first_line.to_string()
-            }
+            truncate_with_ellipsis(first_line, 60)
         };
         out.line(format_args!(
             "  {:<12} {} - {}{}",
@@ -338,11 +347,7 @@ pub fn search_results(results: &[SearchResult]) -> String {
         if !result.snippet.is_empty() {
             // Clean up snippet for terminal display
             let snippet = result.snippet.replace("**", "").replace('\n', " ");
-            let snippet = if snippet.len() > 80 {
-                format!("{}...", &snippet[..80])
-            } else {
-                snippet
-            };
+            let snippet = truncate_with_ellipsis(&snippet, 80);
             out.line(format_args!("              {snippet}"));
         }
     }
@@ -567,6 +572,7 @@ pub fn export_written(written: &[PathBuf], output: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     fn issue(identifier: &str, status: Status, priority: Priority) -> Issue {
         Issue {
@@ -607,6 +613,95 @@ mod tests {
             created_at: "2026-01-01 00:00:00".into(),
             updated_at: "2026-01-01 00:00:00".into(),
             seq: 1,
+        }
+    }
+
+    #[test]
+    fn truncates_previews_at_utf8_boundaries() {
+        assert_eq!(truncate_with_ellipsis("", 60), "");
+        assert_eq!(truncate_with_ellipsis(&"a".repeat(60), 60), "a".repeat(60));
+        assert_eq!(
+            truncate_with_ellipsis(&format!("{}é", "a".repeat(59)), 60),
+            format!("{}...", "a".repeat(59))
+        );
+        assert_eq!(
+            truncate_with_ellipsis(&format!("{}€", "a".repeat(58)), 60),
+            format!("{}...", "a".repeat(58))
+        );
+        assert_eq!(
+            truncate_with_ellipsis(&format!("{}🦀", "a".repeat(56)), 60),
+            format!("{}🦀", "a".repeat(56))
+        );
+
+        let page = Page {
+            id: 1,
+            project_id: None,
+            sequence: Some(1),
+            identifier: "TST-DOC-1".into(),
+            folder_id: None,
+            title: "title".into(),
+            content: format!("{}é", "a".repeat(59)),
+            sort_order: 0.0,
+            status: "active".into(),
+            pinned: false,
+            created_at: String::new(),
+            updated_at: String::new(),
+            seq: 1,
+            labels: Vec::new(),
+        };
+        assert!(page_list(&[page]).contains(&format!("{}...", "a".repeat(59))));
+
+        let result = SearchResult {
+            result_type: "issue".into(),
+            id: 1,
+            identifier: Some("TST-1".into()),
+            title: "title".into(),
+            snippet: format!("{}é", "a".repeat(79)),
+            project_id: None,
+            parent_page_id: None,
+        };
+        assert!(search_results(&[result]).contains(&format!("{}...", "a".repeat(79))));
+    }
+
+    proptest! {
+        #[test]
+        fn arbitrary_unicode_page_and_search_previews_never_panic(
+            text in proptest::collection::vec(any::<char>(), 0..256)
+                .prop_map(String::from_iter)
+        ) {
+            let page = Page {
+                id: 1,
+                project_id: None,
+                sequence: Some(1),
+                identifier: "TST-DOC-1".into(),
+                folder_id: None,
+                title: "title".into(),
+                content: text.clone(),
+                sort_order: 0.0,
+                status: "active".into(),
+                pinned: false,
+                created_at: String::new(),
+                updated_at: String::new(),
+                seq: 1,
+                labels: Vec::new(),
+            };
+            let result = SearchResult {
+                result_type: "issue".into(),
+                id: 1,
+                identifier: Some("TST-1".into()),
+                title: "title".into(),
+                snippet: text,
+                project_id: None,
+                parent_page_id: None,
+            };
+
+            for rendered in [page_list(&[page]), search_results(&[result])] {
+                prop_assert!(rendered.is_char_boundary(rendered.len()));
+                let safe = rendered.chars().all(|ch| {
+                    !crate::cli::ui::is_terminal_control(ch) || ch == '\n' || ch == '\t'
+                });
+                prop_assert!(safe);
+            }
         }
     }
 

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -1,0 +1,227 @@
+//! Command execution policy derived from the parsed CLI command.
+//!
+//! Keeping these decisions together prevents the top-level runner from having
+//! several independent command lists that can drift when a new subcommand is
+//! added.
+
+use super::{Command, ServiceAction};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommandKind {
+    Data,
+    Doctor,
+    Completion,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DatabaseRequirement {
+    None,
+    Existing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackendSupport {
+    LocalOnly,
+    LocalAndHttp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SigpipePolicy {
+    Restore,
+    KeepIgnored,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CommandPlan {
+    kind: CommandKind,
+    database: DatabaseRequirement,
+    backend: BackendSupport,
+    sigpipe: SigpipePolicy,
+}
+
+impl CommandPlan {
+    #[must_use]
+    pub(crate) const fn is_data(self) -> bool {
+        matches!(self.kind, CommandKind::Data)
+    }
+
+    #[must_use]
+    pub(crate) const fn is_doctor(self) -> bool {
+        matches!(self.kind, CommandKind::Doctor)
+    }
+
+    #[must_use]
+    pub(crate) const fn is_completion(self) -> bool {
+        matches!(self.kind, CommandKind::Completion)
+    }
+
+    #[must_use]
+    pub(crate) const fn requires_existing_database(self) -> bool {
+        matches!(self.database, DatabaseRequirement::Existing)
+    }
+
+    #[must_use]
+    pub(crate) const fn supports_http(self) -> bool {
+        matches!(self.backend, BackendSupport::LocalAndHttp)
+    }
+
+    #[must_use]
+    pub(crate) const fn restores_sigpipe(self) -> bool {
+        matches!(self.sigpipe, SigpipePolicy::Restore)
+    }
+}
+
+#[must_use]
+pub(crate) fn plan(command: &Command) -> CommandPlan {
+    let data = CommandPlan {
+        kind: CommandKind::Data,
+        database: DatabaseRequirement::Existing,
+        backend: BackendSupport::LocalAndHttp,
+        sigpipe: SigpipePolicy::Restore,
+    };
+
+    match command {
+        Command::Issue { .. }
+        | Command::Project { .. }
+        | Command::Page { .. }
+        | Command::Export { .. }
+        | Command::Search { .. }
+        | Command::Comment { .. }
+        | Command::Module { .. }
+        | Command::Label { .. }
+        | Command::Folder { .. }
+        | Command::Bind { .. }
+        | Command::GitHook { .. } => data,
+        Command::Doctor { .. } => CommandPlan {
+            kind: CommandKind::Doctor,
+            database: DatabaseRequirement::None,
+            backend: BackendSupport::LocalOnly,
+            sigpipe: SigpipePolicy::Restore,
+        },
+        Command::Completion { .. } => CommandPlan {
+            kind: CommandKind::Completion,
+            database: DatabaseRequirement::None,
+            backend: BackendSupport::LocalOnly,
+            sigpipe: SigpipePolicy::Restore,
+        },
+        Command::Init { .. }
+        | Command::Login { .. }
+        | Command::Logout { .. }
+        | Command::Connect { .. }
+        | Command::AgentsMd { .. }
+        | Command::Import { .. } => no_database(),
+        Command::Mcp {
+            remote, instances, ..
+        } => CommandPlan {
+            kind: CommandKind::Other,
+            database: if *remote || instances.is_some() {
+                DatabaseRequirement::None
+            } else {
+                DatabaseRequirement::Existing
+            },
+            backend: BackendSupport::LocalOnly,
+            sigpipe: SigpipePolicy::KeepIgnored,
+        },
+        Command::Start {
+            init_if_missing, ..
+        } => CommandPlan {
+            kind: CommandKind::Other,
+            database: if *init_if_missing {
+                DatabaseRequirement::None
+            } else {
+                DatabaseRequirement::Existing
+            },
+            backend: BackendSupport::LocalOnly,
+            sigpipe: SigpipePolicy::KeepIgnored,
+        },
+        Command::Service { action } => CommandPlan {
+            kind: CommandKind::Other,
+            database: if matches!(action, ServiceAction::Install) {
+                DatabaseRequirement::Existing
+            } else {
+                DatabaseRequirement::None
+            },
+            backend: BackendSupport::LocalOnly,
+            sigpipe: SigpipePolicy::Restore,
+        },
+        Command::ProjectArchive { .. }
+        | Command::Dump { .. }
+        | Command::Restore { .. }
+        | Command::Instance { .. }
+        | Command::Key { .. }
+        | Command::User { .. }
+        | Command::Member { .. } => existing_local(),
+    }
+}
+
+const fn no_database() -> CommandPlan {
+    CommandPlan {
+        kind: CommandKind::Other,
+        database: DatabaseRequirement::None,
+        backend: BackendSupport::LocalOnly,
+        sigpipe: SigpipePolicy::Restore,
+    }
+}
+
+const fn existing_local() -> CommandPlan {
+    CommandPlan {
+        kind: CommandKind::Other,
+        database: DatabaseRequirement::Existing,
+        backend: BackendSupport::LocalOnly,
+        sigpipe: SigpipePolicy::Restore,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_commands_share_local_and_http_policy() {
+        let plan = plan(&Command::Bind {
+            project: None,
+            create: false,
+        });
+        assert!(plan.is_data());
+        assert!(plan.requires_existing_database());
+        assert!(plan.supports_http());
+        assert!(plan.restores_sigpipe());
+    }
+
+    #[test]
+    fn service_database_requirement_depends_on_action() {
+        assert!(
+            plan(&Command::Service {
+                action: ServiceAction::Install,
+            })
+            .requires_existing_database()
+        );
+        assert!(
+            !plan(&Command::Service {
+                action: ServiceAction::Status,
+            })
+            .requires_existing_database()
+        );
+    }
+
+    #[test]
+    fn remote_mcp_and_first_boot_skip_database_guard() {
+        assert!(
+            !plan(&Command::Mcp {
+                remote: true,
+                url: None,
+                instances: None,
+            })
+            .requires_existing_database()
+        );
+        assert!(
+            !plan(&Command::Start {
+                port: None,
+                host: None,
+                init_if_missing: true,
+            })
+            .requires_existing_database()
+        );
+    }
+}

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -439,10 +439,11 @@ fn run_ok(cmd: &str, args: &[&str]) -> Result<(), String> {
     if out.status.success() {
         Ok(())
     } else {
+        let detail = crate::cli::ui::sanitize_terminal_line(&String::from_utf8_lossy(&out.stderr));
         Err(format!(
             "`{cmd} {}` failed: {}",
             args.join(" "),
-            String::from_utf8_lossy(&out.stderr).trim()
+            detail.trim()
         ))
     }
 }

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -20,7 +20,7 @@
 //! Process-spawning lives in thin wrappers that the commands share.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// The service name / launchd label. One service per user by design: Lific's
 /// target persona runs a single personal instance.
@@ -309,8 +309,10 @@ pub fn install(manager: Manager, plan: &ServicePlan) -> Result<InstallReport, St
             // refused; that's fine — report, don't fail.
             let linger = Command::new("loginctl")
                 .arg("enable-linger")
-                .output()
-                .is_ok_and(|output| output.status.success());
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .is_ok_and(|status| status.success());
             Ok(InstallReport {
                 manager: manager.label().into(),
                 definition: path.display().to_string(),
@@ -378,8 +380,10 @@ pub fn status(manager: Manager) -> Result<StatusReport, String> {
     let active = match manager {
         Manager::SystemdUser => Command::new("systemctl")
             .args(["--user", "is-active", "--quiet", SYSTEMD_UNIT_NAME])
-            .output()
-            .is_ok_and(|output| output.status.success()),
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success()),
         Manager::Launchd => Command::new("launchctl")
             .args(["print", &format!("{}/{LAUNCHD_LABEL}", launchd_domain()?)])
             .output()

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -92,16 +92,8 @@ fn reject_control_paths<'a>(paths: impl IntoIterator<Item = &'a Path>) -> Result
 }
 
 fn path_contains_control(path: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        use std::os::unix::ffi::OsStrExt;
-        path.to_str().is_none() || path.as_os_str().as_bytes().iter().any(u8::is_ascii_control)
-    }
-    #[cfg(not(unix))]
-    {
-        path.to_str()
-            .is_none_or(|value| value.chars().any(char::is_control))
-    }
+    path.to_str()
+        .is_none_or(|value| value.chars().any(char::is_control))
 }
 
 /// Detect the available service manager. Returns None in environments without
@@ -317,8 +309,8 @@ pub fn install(manager: Manager, plan: &ServicePlan) -> Result<InstallReport, St
             // refused; that's fine — report, don't fail.
             let linger = Command::new("loginctl")
                 .arg("enable-linger")
-                .status()
-                .is_ok_and(|s| s.success());
+                .output()
+                .is_ok_and(|output| output.status.success());
             Ok(InstallReport {
                 manager: manager.label().into(),
                 definition: path.display().to_string(),
@@ -386,8 +378,8 @@ pub fn status(manager: Manager) -> Result<StatusReport, String> {
     let active = match manager {
         Manager::SystemdUser => Command::new("systemctl")
             .args(["--user", "is-active", "--quiet", SYSTEMD_UNIT_NAME])
-            .status()
-            .is_ok_and(|s| s.success()),
+            .output()
+            .is_ok_and(|output| output.status.success()),
         Manager::Launchd => Command::new("launchctl")
             .args(["print", &format!("{}/{LAUNCHD_LABEL}", launchd_domain()?)])
             .output()
@@ -505,6 +497,17 @@ mod tests {
             "unit was:\n{unit}"
         );
         assert!(unit.contains("/home/u/$data%%dir"), "unit was:\n{unit}");
+    }
+
+    #[test]
+    fn service_paths_reject_every_c0_and_c1_control_on_all_platforms() {
+        for control in ('\0'..='\u{009f}').filter(|ch| ch.is_control()) {
+            let path = PathBuf::from(format!("config{control}.toml"));
+            assert!(
+                reject_control_paths([path.as_path()]).is_err(),
+                "{control:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -12,7 +12,113 @@
 //!    A confirmation prompt that blocks forever in CI is a hang; instead we
 //!    error and name the flag that bypasses the prompt non-interactively.
 
-use std::io::IsTerminal;
+use std::io::{self, IsTerminal, Write};
+
+use crate::cli::ui::TerminalDisplay;
+
+/// A tracing writer that makes every formatted event safe for a terminal.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct SanitizedStderr;
+
+pub(crate) fn sanitized_stderr() -> SanitizedStderr {
+    SanitizedStderr
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SanitizedStderr {
+    type Writer = SanitizedWriter<io::Stderr>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        SanitizedWriter {
+            inner: io::stderr(),
+            pending: Vec::new(),
+        }
+    }
+}
+
+pub(crate) struct SanitizedWriter<W> {
+    inner: W,
+    pending: Vec<u8>,
+}
+
+impl<W: Write> Write for SanitizedWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.pending.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if !self.pending.is_empty() {
+            let line = std::mem::take(&mut self.pending);
+            let text = String::from_utf8_lossy(&line);
+            let has_trailing_newline = text.ends_with('\n');
+            let text = text.strip_suffix('\n').unwrap_or(&text);
+            let safe = crate::cli::ui::sanitize_terminal_line(text);
+            self.inner.write_all(safe.as_bytes())?;
+            if has_trailing_newline {
+                self.inner.write_all(b"\n")?;
+            }
+        }
+        self.inner.flush()
+    }
+}
+
+/// Serialize JSON for terminal-visible stdout without changing its parsed value.
+///
+/// Serde escapes C0 controls, but leaves C1 and Unicode formatting controls
+/// literal. Escape those only while they are inside JSON strings; structural
+/// pretty-print whitespace remains valid JSON formatting.
+pub fn json_string<T: serde::Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    let serialized = serde_json::to_string_pretty(value)?;
+    let mut output = String::with_capacity(serialized.len());
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in serialized.chars() {
+        if !in_string {
+            output.push(ch);
+            in_string = ch == '"';
+            continue;
+        }
+
+        if escaped {
+            output.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => {
+                output.push(ch);
+                escaped = true;
+            }
+            '"' => {
+                output.push(ch);
+                in_string = false;
+            }
+            ch if json_terminal_control(ch) => {
+                use std::fmt::Write;
+                write!(output, "\\u{:04x}", ch as u32).expect("String write cannot fail");
+            }
+            _ => output.push(ch),
+        }
+    }
+
+    Ok(output)
+}
+
+fn json_terminal_control(ch: char) -> bool {
+    ch.is_control()
+        || ch == '\u{007f}'
+        || matches!(
+            ch,
+            '\u{061c}'
+                | '\u{200b}'..='\u{200f}'
+                | '\u{2028}'..='\u{202e}'
+                | '\u{2060}'
+                | '\u{2066}'..='\u{206f}'
+                | '\u{feff}'
+        )
+}
 
 /// Whether stdout is connected to an interactive terminal.
 pub fn stdout_is_tty() -> bool {
@@ -69,7 +175,7 @@ pub fn confirm_inner<R: std::io::BufRead, W: std::io::Write>(
         ));
     }
 
-    let _ = write!(writer, "{prompt} [y/N] ");
+    let _ = write!(writer, "{} [y/N] ", prompt.terminal_line());
     let _ = writer.flush();
 
     let mut line = String::new();
@@ -110,7 +216,7 @@ pub fn prompt_text_inner<R: std::io::BufRead, W: std::io::Write>(
             "interactive input required; re-run with {bypass_flag} to supply it non-interactively"
         ));
     }
-    let _ = write!(writer, "{prompt} ");
+    let _ = write!(writer, "{} ", prompt.terminal_line());
     let _ = writer.flush();
 
     let mut line = String::new();
@@ -127,6 +233,66 @@ pub fn prompt_text_inner<R: std::io::BufRead, W: std::io::Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    fn assert_json_strings_contain_no_terminal_controls(encoded: &str) {
+        let mut in_string = false;
+        let mut escaped = false;
+        for ch in encoded.chars() {
+            if !in_string {
+                if ch == '"' {
+                    in_string = true;
+                }
+                continue;
+            }
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match ch {
+                '\\' => escaped = true,
+                '"' => in_string = false,
+                _ => assert!(!json_terminal_control(ch), "literal control {ch:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn json_string_escapes_terminal_controls_losslessly() {
+        let value = serde_json::json!({
+            "text": "\u{001b}]52;c;clipboard\u{0007}\u{009b}2J\u{007f}\u{202e}\u{200b}\u{feff}"
+        });
+        let encoded = json_string(&value).unwrap();
+
+        assert!(encoded.contains("\\u009b"));
+        assert!(encoded.contains("\\u007f"));
+        assert!(encoded.contains("\\u202e"));
+        assert!(encoded.contains("\\ufeff"));
+
+        let without_layout = encoded.replace('\n', "");
+        assert!(!without_layout.chars().any(json_terminal_control));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&encoded).unwrap(),
+            value
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn json_string_round_trips_arbitrary_text_without_literal_controls(
+            text in proptest::collection::vec(any::<char>(), 0..256)
+                .prop_map(String::from_iter)
+        ) {
+            let value = serde_json::json!({"text": text});
+            let encoded = json_string(&value).unwrap();
+
+            prop_assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&encoded).unwrap(),
+                value
+            );
+            assert_json_strings_contain_no_terminal_controls(&encoded);
+        }
+    }
 
     #[test]
     fn wants_json_explicit_flag_always_wins() {
@@ -169,6 +335,75 @@ mod tests {
         let mut out: Vec<u8> = Vec::new();
         let ok = confirm_inner("Proceed?", "--yes", true, &mut input, &mut out).unwrap();
         assert!(ok);
+    }
+
+    #[test]
+    fn prompts_neutralize_terminal_controls() {
+        let mut input: &[u8] = b"y\n";
+        let mut out: Vec<u8> = Vec::new();
+        confirm_inner(
+            "Delete \u{001b}]52;c;clipboard\u{0007}?",
+            "--yes",
+            true,
+            &mut input,
+            &mut out,
+        )
+        .unwrap();
+        let rendered = String::from_utf8(out).unwrap();
+        assert_eq!(rendered, "Delete ^[]52;c;clipboard ? [y/N] ");
+        assert!(
+            rendered
+                .lines()
+                .all(|line| !line.chars().any(char::is_control))
+        );
+    }
+
+    #[test]
+    fn tracing_writer_neutralizes_control_sequences() {
+        use std::io::Write;
+
+        let mut writer = SanitizedWriter {
+            inner: Vec::new(),
+            pending: Vec::new(),
+        };
+        writer
+            .write_all("path: evil\nforged\x1b]8;;https://evil\x1b\\\u{009b}2J\n".as_bytes())
+            .unwrap();
+        writer.flush().unwrap();
+        let rendered = String::from_utf8(writer.inner).unwrap();
+        assert_eq!(rendered, "path: evil forged^[]8;;https://evil^[\\ 2J\n");
+        assert!(
+            rendered
+                .lines()
+                .all(|line| !line.chars().any(char::is_control))
+        );
+    }
+
+    #[test]
+    fn cli_json_sinks_do_not_bypass_terminal_encoder() {
+        for path in [
+            "src/main.rs",
+            "src/cli/exec.rs",
+            "src/cli/http.rs",
+            "src/cli/instance.rs",
+            "src/cli/member.rs",
+            "src/cli/user.rs",
+            "src/cli/key.rs",
+            "src/cli/import.rs",
+            "src/cli/doctor.rs",
+            "src/cli/login.rs",
+            "src/cli/connect/mod.rs",
+            "src/cli/connect/writer.rs",
+        ] {
+            let source = std::fs::read_to_string(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path),
+            )
+            .unwrap();
+            assert!(
+                !source.contains("serde_json::to_string_pretty"),
+                "{path} must use term::json_string for terminal JSON"
+            );
+        }
     }
 
     #[test]

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -31,18 +31,35 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SanitizedStderr {
         SanitizedWriter {
             inner: io::stderr(),
             pending: Vec::new(),
+            truncated: false,
         }
     }
 }
 
+const MAX_PENDING_BYTES: usize = 64 * 1024;
+const TRUNCATION_MARKER: &[u8] = b" ... [truncated]\n";
+
 pub(crate) struct SanitizedWriter<W: Write> {
     inner: W,
     pending: Vec<u8>,
+    truncated: bool,
 }
 
 impl<W: Write> Write for SanitizedWriter<W> {
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        self.pending.extend_from_slice(bytes);
+        if self.truncated {
+            return Ok(bytes.len());
+        }
+
+        let remaining = MAX_PENDING_BYTES.saturating_sub(self.pending.len());
+        let take = bytes.len().min(remaining);
+        self.pending.extend_from_slice(&bytes[..take]);
+        if take < bytes.len() {
+            self.pending
+                .truncate(MAX_PENDING_BYTES.saturating_sub(TRUNCATION_MARKER.len()));
+            self.pending.extend_from_slice(TRUNCATION_MARKER);
+            self.truncated = true;
+        }
         Ok(bytes.len())
     }
 
@@ -102,15 +119,21 @@ pub fn json_string<T: serde::Serialize>(value: &T) -> Result<String, serde_json:
                 output.push(ch);
                 in_string = false;
             }
-            ch if json_terminal_control(ch) => {
-                use std::fmt::Write;
-                write!(output, "\\u{:04x}", ch as u32).expect("String write cannot fail");
-            }
+            ch if json_terminal_control(ch) => escape_json_char(&mut output, ch),
             _ => output.push(ch),
         }
     }
 
     Ok(output)
+}
+
+fn escape_json_char(output: &mut String, ch: char) {
+    use std::fmt::Write;
+
+    let mut units = [0; 2];
+    for unit in ch.encode_utf16(&mut units) {
+        write!(output, "\\u{unit:04x}").expect("String write cannot fail");
+    }
 }
 
 fn json_terminal_control(ch: char) -> bool {
@@ -190,12 +213,14 @@ pub fn confirm_inner<R: std::io::BufRead, W: std::io::Write>(
 /// pass to supply the value without a prompt. Returns the trimmed input; errors
 /// on empty input or no-TTY.
 pub fn prompt_text(prompt: &str, bypass_flag: &str) -> Result<String, String> {
+    // Prompts are diagnostics/input guidance, never command data. Keep them
+    // off stdout so redirected or explicit JSON output remains parseable.
     prompt_text_inner(
         prompt,
         bypass_flag,
         stdin_is_tty(),
         &mut std::io::stdin().lock(),
-        &mut std::io::stdout(),
+        &mut std::io::stderr(),
     )
 }
 
@@ -251,6 +276,7 @@ mod tests {
                 let mut writer = SanitizedWriter {
                     inner: &mut output,
                     pending: Vec::new(),
+                    truncated: false,
                 };
                 for chunk in event.as_bytes().chunks(chunk_size) {
                     writer.write_all(chunk).unwrap();
@@ -274,9 +300,30 @@ mod tests {
         let mut writer = SanitizedWriter {
             inner: &mut [][..],
             pending: Vec::new(),
+            truncated: false,
         };
         writer.write_all(b"event").unwrap();
         assert_eq!(writer.flush().unwrap_err().kind(), io::ErrorKind::WriteZero);
+    }
+
+    #[test]
+    fn tracing_writer_bounds_large_events() {
+        let mut output = Vec::new();
+        let mut writer = SanitizedWriter {
+            inner: &mut output,
+            pending: Vec::new(),
+            truncated: false,
+        };
+
+        writer
+            .write_all(&vec![b'x'; MAX_PENDING_BYTES * 2])
+            .unwrap();
+        assert_eq!(writer.pending.len(), MAX_PENDING_BYTES);
+        assert!(writer.truncated);
+        writer.flush().unwrap();
+
+        drop(writer);
+        assert!(output.ends_with(TRUNCATION_MARKER));
     }
 
     fn assert_json_strings_contain_no_terminal_controls(encoded: &str) {
@@ -420,6 +467,7 @@ mod tests {
             .with_writer(move || SanitizedWriter {
                 inner: capture.try_clone().unwrap(),
                 pending: Vec::new(),
+                truncated: false,
             })
             .finish();
 
@@ -444,6 +492,7 @@ mod tests {
         let mut writer = SanitizedWriter {
             inner: Vec::new(),
             pending: Vec::new(),
+            truncated: false,
         };
         writer
             .write_all("path: evil\nforged\x1b]8;;https://evil\x1b\\\u{009b}2J\n".as_bytes())
@@ -472,7 +521,6 @@ mod tests {
             "src/cli/doctor.rs",
             "src/cli/login.rs",
             "src/cli/connect/mod.rs",
-            "src/cli/connect/writer.rs",
             "src/cli/bind.rs",
             "src/cli/git_hook.rs",
             "src/cli/service.rs",

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -35,7 +35,7 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SanitizedStderr {
     }
 }
 
-pub(crate) struct SanitizedWriter<W> {
+pub(crate) struct SanitizedWriter<W: Write> {
     inner: W,
     pending: Vec<u8>,
 }
@@ -52,13 +52,20 @@ impl<W: Write> Write for SanitizedWriter<W> {
             let text = String::from_utf8_lossy(&line);
             let has_trailing_newline = text.ends_with('\n');
             let text = text.strip_suffix('\n').unwrap_or(&text);
-            let safe = crate::cli::ui::sanitize_terminal_line(text);
-            self.inner.write_all(safe.as_bytes())?;
+            let mut safe = crate::cli::ui::sanitize_terminal_line(text);
             if has_trailing_newline {
-                self.inner.write_all(b"\n")?;
+                safe.push('\n');
             }
+            self.inner.write_all(safe.as_bytes())?;
         }
         self.inner.flush()
+    }
+}
+// tracing drops its per-event writer without flushing it. Publish the complete
+// event here so embedded newlines and split UTF-8 cannot escape sanitization.
+impl<W: Write> Drop for SanitizedWriter<W> {
+    fn drop(&mut self) {
+        let _ = self.flush();
     }
 }
 
@@ -107,17 +114,7 @@ pub fn json_string<T: serde::Serialize>(value: &T) -> Result<String, serde_json:
 }
 
 fn json_terminal_control(ch: char) -> bool {
-    ch.is_control()
-        || ch == '\u{007f}'
-        || matches!(
-            ch,
-            '\u{061c}'
-                | '\u{200b}'..='\u{200f}'
-                | '\u{2028}'..='\u{202e}'
-                | '\u{2060}'
-                | '\u{2066}'..='\u{206f}'
-                | '\u{feff}'
-        )
+    crate::cli::ui::is_terminal_control(ch)
 }
 
 /// Whether stdout is connected to an interactive terminal.
@@ -235,6 +232,53 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    proptest! {
+        #[test]
+        fn tracing_writer_preserves_chunked_unicode_and_publishes_once(
+            text in proptest::collection::vec(any::<char>(), 0..256)
+                .prop_map(String::from_iter),
+            chunk_size in 1usize..16,
+            explicit_flush in any::<bool>(),
+            trailing_newline in any::<bool>(),
+        ) {
+            let mut event = text;
+            // The formatter owns the final newline, not the untrusted field.
+            if trailing_newline {
+                event.push('\n');
+            }
+            let mut output = Vec::new();
+            {
+                let mut writer = SanitizedWriter {
+                    inner: &mut output,
+                    pending: Vec::new(),
+                };
+                for chunk in event.as_bytes().chunks(chunk_size) {
+                    writer.write_all(chunk).unwrap();
+                }
+                if explicit_flush {
+                    writer.flush().unwrap();
+                    writer.flush().unwrap();
+                }
+            }
+            let expected = if let Some(body) = event.strip_suffix('\n') {
+                format!("{}\n", body.terminal_line())
+            } else {
+                event.terminal_line().to_string()
+            };
+            prop_assert_eq!(String::from_utf8(output).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn tracing_writer_propagates_explicit_flush_errors() {
+        let mut writer = SanitizedWriter {
+            inner: &mut [][..],
+            pending: Vec::new(),
+        };
+        writer.write_all(b"event").unwrap();
+        assert_eq!(writer.flush().unwrap_err().kind(), io::ErrorKind::WriteZero);
+    }
+
     fn assert_json_strings_contain_no_terminal_controls(encoded: &str) {
         let mut in_string = false;
         let mut escaped = false;
@@ -260,7 +304,7 @@ mod tests {
     #[test]
     fn json_string_escapes_terminal_controls_losslessly() {
         let value = serde_json::json!({
-            "text": "\u{001b}]52;c;clipboard\u{0007}\u{009b}2J\u{007f}\u{202e}\u{200b}\u{feff}"
+            "text": "\u{001b}]52;c;clipboard\u{0007}\u{009b}2J\u{007f}\u{202e}\u{200b}\u{feff}\u{00ad}\u{180e}\u{2061}\u{fff9}"
         });
         let encoded = json_string(&value).unwrap();
 
@@ -268,6 +312,10 @@ mod tests {
         assert!(encoded.contains("\\u007f"));
         assert!(encoded.contains("\\u202e"));
         assert!(encoded.contains("\\ufeff"));
+        assert!(encoded.contains("\\u00ad"));
+        assert!(encoded.contains("\\u180e"));
+        assert!(encoded.contains("\\u2061"));
+        assert!(encoded.contains("\\ufff9"));
 
         let without_layout = encoded.replace('\n', "");
         assert!(!without_layout.chars().any(json_terminal_control));
@@ -359,6 +407,37 @@ mod tests {
     }
 
     #[test]
+    fn tracing_subscriber_publishes_sanitized_events_without_explicit_flush() {
+        use std::io::{Read, Seek};
+
+        let mut output = tempfile::tempfile().unwrap();
+        let capture = output.try_clone().unwrap();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_target(false)
+            .with_level(false)
+            .with_writer(move || SanitizedWriter {
+                inner: capture.try_clone().unwrap(),
+                pending: Vec::new(),
+            })
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("path: café\nforged\x1b]52;c;clipboard\x07\u{009b}2J\u{202e}");
+            tracing::warn!("still logging");
+        });
+
+        output.rewind().unwrap();
+        let mut rendered = String::new();
+        output.read_to_string(&mut rendered).unwrap();
+        assert_eq!(
+            rendered,
+            "path: café forged\\x1b]52;c;clipboard\\x07\\u{9b}2J \nstill logging\n"
+        );
+    }
+
+    #[test]
     fn tracing_writer_neutralizes_control_sequences() {
         use std::io::Write;
 
@@ -370,7 +449,7 @@ mod tests {
             .write_all("path: evil\nforged\x1b]8;;https://evil\x1b\\\u{009b}2J\n".as_bytes())
             .unwrap();
         writer.flush().unwrap();
-        let rendered = String::from_utf8(writer.inner).unwrap();
+        let rendered = String::from_utf8(std::mem::take(&mut writer.inner)).unwrap();
         assert_eq!(rendered, "path: evil forged^[]8;;https://evil^[\\ 2J\n");
         assert!(
             rendered
@@ -394,15 +473,25 @@ mod tests {
             "src/cli/login.rs",
             "src/cli/connect/mod.rs",
             "src/cli/connect/writer.rs",
+            "src/cli/bind.rs",
+            "src/cli/git_hook.rs",
+            "src/cli/service.rs",
         ] {
             let source = std::fs::read_to_string(
                 std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path),
             )
             .unwrap();
-            assert!(
-                !source.contains("serde_json::to_string_pretty"),
-                "{path} must use term::json_string for terminal JSON"
-            );
+            for forbidden in [
+                "serde_json::to_string_pretty",
+                "serde_json::to_string(",
+                "serde_json::to_writer",
+                "serde_json::to_vec",
+            ] {
+                assert!(
+                    !source.contains(forbidden),
+                    "{path} must use term::json_string for terminal JSON"
+                );
+            }
         }
     }
 

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -35,6 +35,16 @@ pub(crate) fn logging_filter(
     tracing_subscriber::EnvFilter::try_new(format!("lific={configured_level}")).map_err(Into::into)
 }
 
+/// Initialize the stderr-only subscriber used by the server and MCP modes.
+pub(crate) fn init_logging(configured_level: &str) -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(logging_filter(configured_level)?)
+        .with_ansi(false)
+        .with_writer(sanitized_stderr())
+        .init();
+    Ok(())
+}
+
 /// A tracing writer that makes every formatted event safe for a terminal.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct SanitizedStderr;

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -16,6 +16,25 @@ use std::io::{self, IsTerminal, Write};
 
 use crate::cli::ui::TerminalDisplay;
 
+/// Build the filter without allowing a parse failure to print the configured
+/// directive before the sanitized tracing writer is installed.
+pub(crate) fn logging_filter(
+    configured_level: &str,
+) -> Result<tracing_subscriber::EnvFilter, Box<dyn std::error::Error>> {
+    if let Ok(filter) = tracing_subscriber::EnvFilter::try_from_default_env() {
+        return Ok(filter);
+    }
+
+    if !matches!(
+        configured_level,
+        "trace" | "debug" | "info" | "warn" | "error"
+    ) {
+        return Err(format!("invalid configured log level: {configured_level}").into());
+    }
+
+    tracing_subscriber::EnvFilter::try_new(format!("lific={configured_level}")).map_err(Into::into)
+}
+
 /// A tracing writer that makes every formatted event safe for a terminal.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct SanitizedStderr;

--- a/src/cli/term.rs
+++ b/src/cli/term.rs
@@ -25,14 +25,15 @@ pub(crate) fn logging_filter(
         return Ok(filter);
     }
 
-    if !matches!(
-        configured_level,
-        "trace" | "debug" | "info" | "warn" | "error"
-    ) {
-        return Err(format!("invalid configured log level: {configured_level}").into());
-    }
-
-    tracing_subscriber::EnvFilter::try_new(format!("lific={configured_level}")).map_err(Into::into)
+    let level = configured_level
+        .parse::<tracing_subscriber::filter::LevelFilter>()
+        .map_err(|_| {
+            format!(
+                "invalid configured log level: {}",
+                crate::cli::ui::sanitize_terminal_line(configured_level)
+            )
+        })?;
+    tracing_subscriber::EnvFilter::try_new(format!("lific={level}")).map_err(Into::into)
 }
 
 /// Initialize the stderr-only subscriber used by the server and MCP modes.

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -16,10 +16,12 @@
 //!   `warn`/`error` for problems, `note` for blocks the user must read (keys,
 //!   snippets, next steps), `intro`/`outro` bracketing every session.
 
+use std::fmt::{self, Display};
+
 /// Begin a command session: prints the `┌ <title>` header.
 pub fn intro(title: &str) {
     let _ = cliclack::intro(
-        console::style(format!(" {title} "))
+        console::style(format!(" {} ", title.terminal_line()))
             .on_cyan()
             .black()
             .to_string(),
@@ -28,51 +30,205 @@ pub fn intro(title: &str) {
 
 /// A completed step: `◇ <msg>`.
 pub fn step(msg: impl std::fmt::Display) {
-    let _ = cliclack::log::success(msg);
+    let _ = cliclack::log::success(msg.terminal_line());
 }
 
 /// A neutral informational line: `● <msg>`.
 pub fn info(msg: impl std::fmt::Display) {
-    let _ = cliclack::log::info(msg);
+    let _ = cliclack::log::info(msg.terminal_line());
 }
 
 /// A warning line: `▲ <msg>`.
 pub fn warn(msg: impl std::fmt::Display) {
-    let _ = cliclack::log::warning(msg);
+    let _ = cliclack::log::warning(msg.terminal_line());
 }
 
 /// An error line: `■ <msg>`.
 pub fn error(msg: impl std::fmt::Display) {
-    let _ = cliclack::log::error(msg);
+    let _ = cliclack::log::error(msg.terminal_line());
 }
 
 /// A skipped/dimmed line: `◌ <msg>` (rendered via a plain step with dim text).
 pub fn skipped(msg: impl std::fmt::Display) {
-    let _ = cliclack::log::step(console::style(msg).dim().to_string());
+    let _ = cliclack::log::step(console::style(msg.terminal_line()).dim().to_string());
 }
 
 /// A boxed note block with a title — for content the user must actually read
 /// (API keys, manual snippets, next steps).
 pub fn note(title: impl std::fmt::Display, body: impl std::fmt::Display) {
-    let _ = cliclack::note(title, body);
+    let _ = cliclack::note(title.terminal_line(), body.terminal_block());
 }
 
 /// End the session on a success: `└ <msg>`.
 pub fn outro(msg: impl std::fmt::Display) {
-    let _ = cliclack::outro(msg);
+    let _ = cliclack::outro(msg.terminal_line());
 }
 
 /// End the session on a failure: `└ <msg>` in red.
 pub fn outro_cancel(msg: impl std::fmt::Display) {
-    let _ = cliclack::outro_cancel(msg);
+    let _ = cliclack::outro_cancel(msg.terminal_line());
 }
 
-/// Style helper: dim secondary text (paths, hints) consistently.
+/// A plain human-readable line for commands that intentionally do not use a
+/// cliclack session.
+pub fn line(msg: impl std::fmt::Display) {
+    println!("{}", msg.terminal_line());
+}
+
+/// A plain sanitized human-readable line for diagnostics that belong on stderr.
+pub fn stderr_line(msg: impl std::fmt::Display) {
+    eprintln!("{}", msg.terminal_line());
+}
+
+/// Sanitize secondary text (paths, hints) for composition into a UI message.
+///
+/// Styling is deliberately applied only by the final cliclack call. Returning
+/// ANSI from a composable string would make the outer terminal sanitizer
+/// display escape bytes literally.
 pub fn dim(s: impl std::fmt::Display) -> String {
-    console::style(s).dim().to_string()
+    s.terminal_line().to_string()
 }
 
-/// Style helper: emphasize a command the user should run.
+/// Sanitize a command for composition into a UI message.
 pub fn command(s: impl std::fmt::Display) -> String {
-    console::style(s).cyan().to_string()
+    s.terminal_line().to_string()
+}
+
+pub(crate) fn sanitize_terminal_line(s: &str) -> String {
+    s.terminal_line().to_string()
+}
+
+pub(crate) fn sanitize_terminal_block(s: &str) -> String {
+    s.terminal_block().to_string()
+}
+
+pub(crate) trait TerminalDisplay: Display + Sized {
+    fn terminal_line(self) -> impl Display {
+        Terminal {
+            value: self,
+            preserve_layout: false,
+        }
+    }
+
+    fn terminal_block(self) -> impl Display {
+        Terminal {
+            value: self,
+            preserve_layout: true,
+        }
+    }
+}
+
+impl<T: Display> TerminalDisplay for T {}
+
+struct Terminal<T> {
+    value: T,
+    preserve_layout: bool,
+}
+
+impl<T: Display> Display for Terminal<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = if formatter.alternate() {
+            format!("{:#}", self.value)
+        } else {
+            self.value.to_string()
+        };
+        formatter.pad(&sanitize_terminal_text(&value, self.preserve_layout))
+    }
+}
+
+fn sanitize_terminal_text(input: &str, preserve_layout: bool) -> String {
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '\n' | '\t' if preserve_layout => output.push(ch),
+            '\x1b' => output.push_str("^["),
+            ch if ch.is_control()
+                || matches!(
+                    ch,
+                    '\u{061c}'
+                        | '\u{200b}'..='\u{200f}'
+                        | '\u{2028}'..='\u{202e}'
+                        | '\u{2060}'
+                        | '\u{2066}'..='\u{206f}'
+                        | '\u{feff}'
+                ) =>
+            {
+                output.push(' ');
+            }
+            _ => output.push(ch),
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TerminalDisplay;
+    use proptest::prelude::*;
+
+    fn terminal_formatting_control(ch: char) -> bool {
+        ch.is_control()
+            || matches!(
+                ch,
+                '\u{061c}'
+                    | '\u{200b}'..='\u{200f}'
+                    | '\u{2028}'..='\u{202e}'
+                    | '\u{2060}'
+                    | '\u{2066}'..='\u{206f}'
+                    | '\u{feff}'
+            )
+    }
+
+    #[test]
+    fn block_controls_are_neutralized_without_flattening_layout() {
+        assert_eq!(
+            "name\x1b[2J\r\x07\u{85}\u{202e}\u{2066}\nnext\tline\x7f"
+                .terminal_block()
+                .to_string(),
+            "name^[[2J     \nnext\tline "
+        );
+    }
+
+    #[test]
+    fn line_controls_cannot_forge_another_status_line() {
+        assert_eq!(
+            "title\n[ok]\tuser\u{061c}\u{200f}\u{2028}\u{206f}"
+                .terminal_line()
+                .to_string(),
+            "title [ok] user    "
+        );
+    }
+
+    #[test]
+    fn line_values_neutralize_osc8_c1_csi_and_backspace() {
+        let rendered = "label\x1b]8;;https://evil\x1b\\click\x1b]8;;\x1b\\\u{009b}2J\u{0008}"
+            .terminal_line()
+            .to_string();
+
+        assert_eq!(rendered, "label^[]8;;https://evil^[\\click^[]8;;^[\\ 2J ");
+        assert!(!rendered.chars().any(char::is_control));
+    }
+
+    proptest! {
+        #[test]
+        fn line_sanitization_never_emits_terminal_controls(
+            input in proptest::collection::vec(any::<char>(), 0..256)
+                .prop_map(String::from_iter)
+        ) {
+            let rendered = input.terminal_line().to_string();
+            prop_assert!(rendered.chars().all(|ch| !terminal_formatting_control(ch)));
+        }
+
+        #[test]
+        fn block_sanitization_only_preserves_layout_controls(
+            input in proptest::collection::vec(any::<char>(), 0..256)
+                .prop_map(String::from_iter)
+        ) {
+            let rendered = input.terminal_block().to_string();
+            let safe = rendered.chars().all(|ch| {
+                !terminal_formatting_control(ch) || ch == '\n' || ch == '\t'
+            });
+            prop_assert!(safe);
+        }
+    }
 }

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -102,6 +102,26 @@ pub(crate) fn sanitize_terminal_block(s: &str) -> String {
     s.terminal_block().to_string()
 }
 
+/// Whether a character can alter or obscure terminal output.
+pub(crate) fn is_terminal_control(ch: char) -> bool {
+    ch.is_control()
+        || matches!(
+            ch,
+            '\u{00ad}'
+                | '\u{061c}'
+                | '\u{06dd}'
+                | '\u{070f}'
+                | '\u{0890}'..='\u{0891}'
+                | '\u{180e}'
+                | '\u{200b}'..='\u{200f}'
+                | '\u{2028}'..='\u{202e}'
+                | '\u{2060}'..='\u{2064}'
+                | '\u{2066}'..='\u{206f}'
+                | '\u{feff}'
+                | '\u{fff9}'..='\u{fffb}'
+        )
+}
+
 pub(crate) trait TerminalDisplay: Display + Sized {
     fn terminal_line(self) -> impl Display {
         Terminal {
@@ -142,19 +162,7 @@ fn sanitize_terminal_text(input: &str, preserve_layout: bool) -> String {
         match ch {
             '\n' | '\t' if preserve_layout => output.push(ch),
             '\x1b' => output.push_str("^["),
-            ch if ch.is_control()
-                || matches!(
-                    ch,
-                    '\u{061c}'
-                        | '\u{200b}'..='\u{200f}'
-                        | '\u{2028}'..='\u{202e}'
-                        | '\u{2060}'
-                        | '\u{2066}'..='\u{206f}'
-                        | '\u{feff}'
-                ) =>
-            {
-                output.push(' ');
-            }
+            ch if is_terminal_control(ch) => output.push(' '),
             _ => output.push(ch),
         }
     }
@@ -163,21 +171,8 @@ fn sanitize_terminal_text(input: &str, preserve_layout: bool) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::TerminalDisplay;
+    use super::{TerminalDisplay, is_terminal_control};
     use proptest::prelude::*;
-
-    fn terminal_formatting_control(ch: char) -> bool {
-        ch.is_control()
-            || matches!(
-                ch,
-                '\u{061c}'
-                    | '\u{200b}'..='\u{200f}'
-                    | '\u{2028}'..='\u{202e}'
-                    | '\u{2060}'
-                    | '\u{2066}'..='\u{206f}'
-                    | '\u{feff}'
-            )
-    }
 
     #[test]
     fn block_controls_are_neutralized_without_flattening_layout() {
@@ -187,6 +182,12 @@ mod tests {
                 .to_string(),
             "name^[[2J     \nnext\tline "
         );
+    }
+
+    #[test]
+    fn default_ignorable_controls_are_neutralized() {
+        let controls = "\u{00ad}\u{061c}\u{06dd}\u{070f}\u{0890}\u{180e}\u{2061}\u{fff9}";
+        assert_eq!(controls.terminal_line().to_string(), "        ");
     }
 
     #[test]
@@ -216,7 +217,7 @@ mod tests {
                 .prop_map(String::from_iter)
         ) {
             let rendered = input.terminal_line().to_string();
-            prop_assert!(rendered.chars().all(|ch| !terminal_formatting_control(ch)));
+            prop_assert!(rendered.chars().all(|ch| !is_terminal_control(ch)));
         }
 
         #[test]
@@ -226,7 +227,7 @@ mod tests {
         ) {
             let rendered = input.terminal_block().to_string();
             let safe = rendered.chars().all(|ch| {
-                !terminal_formatting_control(ch) || ch == '\n' || ch == '\t'
+                !is_terminal_control(ch) || ch == '\n' || ch == '\t'
             });
             prop_assert!(safe);
         }

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -108,10 +108,12 @@ pub(crate) fn is_terminal_control(ch: char) -> bool {
         || matches!(
             ch,
             '\u{00ad}'
+                | '\u{0600}'..='\u{0605}'
                 | '\u{061c}'
                 | '\u{06dd}'
                 | '\u{070f}'
                 | '\u{0890}'..='\u{0891}'
+                | '\u{08e2}'
                 | '\u{180e}'
                 | '\u{200b}'..='\u{200f}'
                 | '\u{2028}'..='\u{202e}'
@@ -119,6 +121,13 @@ pub(crate) fn is_terminal_control(ch: char) -> bool {
                 | '\u{2066}'..='\u{206f}'
                 | '\u{feff}'
                 | '\u{fff9}'..='\u{fffb}'
+                | '\u{110bd}'
+                | '\u{110cd}'
+                | '\u{13430}'..='\u{1343f}'
+                | '\u{1bca0}'..='\u{1bcaf}'
+                | '\u{1d173}'..='\u{1d17a}'
+                | '\u{e0001}'
+                | '\u{e0020}'..='\u{e007f}'
         )
 }
 
@@ -186,7 +195,13 @@ mod tests {
 
     #[test]
     fn default_ignorable_controls_are_neutralized() {
-        let controls = "\u{00ad}\u{061c}\u{06dd}\u{070f}\u{0890}\u{180e}\u{2061}\u{fff9}";
+        let controls = "\u{00ad}\u{061c}\u{06dd}\u{070f}\u{0890}\u{180e}\u{2061}\u{fff9}\u{e0061}";
+        assert_eq!(controls.terminal_line().to_string(), "         ");
+    }
+
+    #[test]
+    fn supplementary_unicode_format_controls_are_neutralized() {
+        let controls = "\u{0600}\u{08e2}\u{110bd}\u{13430}\u{1bca0}\u{1d173}\u{e0001}\u{e0061}";
         assert_eq!(controls.terminal_line().to_string(), "        ");
     }
 

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -63,7 +63,7 @@ pub fn run(
                     "is_admin": user.is_admin,
                     "is_bot": user.is_bot,
                 });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 let role = if user.is_admin { " (admin)" } else { "" };
                 ui::step(format!(
@@ -91,11 +91,11 @@ pub fn run(
                         })
                     })
                     .collect();
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else if users.is_empty() {
-                println!("No users.");
+                ui::line("No users.");
             } else {
-                println!("{} user(s):", users.len());
+                ui::line(format!("{} user(s):", users.len()));
                 for u in &users {
                     let flags = match (u.is_admin, u.is_bot) {
                         (true, true) => " [admin, bot]",
@@ -103,10 +103,10 @@ pub fn run(
                         (false, true) => " [bot]",
                         (false, false) => "",
                     };
-                    println!(
+                    ui::line(format!(
                         "  {} | {} | {}{} | created {}",
                         u.id, u.username, u.email, flags, u.created_at
-                    );
+                    ));
                 }
             }
         }
@@ -149,7 +149,7 @@ pub fn run(
                     "sessions_cleared": true,
                     "credentials_revoked": true,
                 });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 ui::step(format!(
                     "Password updated for '{}' {}",
@@ -166,7 +166,7 @@ pub fn run(
             db::queries::users::set_admin(&conn, &username, true)?;
             if json {
                 let out = serde_json::json!({ "promoted": username });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 ui::step(format!("Promoted '{username}' to admin."));
             }
@@ -176,7 +176,7 @@ pub fn run(
             db::queries::users::set_admin(&conn, &username, false)?;
             if json {
                 let out = serde_json::json!({ "demoted": username });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", crate::cli::term::json_string(&out)?);
             } else {
                 ui::step(format!("Demoted '{username}' from admin."));
             }

--- a/src/first_boot.rs
+++ b/src/first_boot.rs
@@ -694,14 +694,14 @@ mod tests {
     #[test]
     fn only_start_with_the_flag_is_exempt_from_the_existing_database_guard() {
         let with_flag = Cli::parse_from(["lific", "start", "--init-if-missing"]);
-        assert!(!crate::needs_existing_database(&with_flag.command));
+        assert!(!crate::cli::runtime::plan(&with_flag.command).requires_existing_database());
 
         let without_flag = Cli::parse_from(["lific", "start"]);
-        assert!(crate::needs_existing_database(&without_flag.command));
+        assert!(crate::cli::runtime::plan(&without_flag.command).requires_existing_database());
 
         // The flag belongs to `start` alone; nothing else changes shape.
         let mcp = Cli::parse_from(["lific", "mcp"]);
-        assert!(crate::needs_existing_database(&mcp.command));
+        assert!(crate::cli::runtime::plan(&mcp.command).requires_existing_database());
         assert!(matches!(with_flag.command, Command::Start { .. }));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,86 +34,6 @@ use cli::ui::TerminalDisplay;
 use cli::{BackendKind, Cli, Command, ServiceAction};
 use config::Config;
 
-// Commands that operate directly on the database (no server required)
-fn is_crud_command(cmd: &Command) -> bool {
-    matches!(
-        cmd,
-        Command::Issue { .. }
-            | Command::Project { .. }
-            | Command::Page { .. }
-            | Command::Export { .. }
-            | Command::Search { .. }
-            | Command::Comment { .. }
-            | Command::Module { .. }
-            | Command::Label { .. }
-            | Command::Folder { .. }
-            // LIF-450: `bind` reads and writes repo bindings, so it belongs on
-            // both backends. Routing it here also puts it under
-            // `needs_existing_database`, which is what stops the SQL path from
-            // conjuring an empty instance in whatever directory it ran from.
-            | Command::Bind { .. }
-            // LIF-5: `git-hook` closes issues, so it belongs on both backends
-            // — a local hook writes to the database directly, a CI step posts
-            // to `/api/git-hook`. Routing it here also puts it under
-            // `needs_existing_database`, so the SQL path refuses rather than
-            // conjuring an empty instance in whatever checkout it ran from.
-            | Command::GitHook { .. }
-    )
-}
-
-/// Whether `cmd` operates on a local database that must already exist.
-///
-/// Only `lific init` creates a database. Every other command that reaches
-/// `db::open` has to find one, because the alternative is the first-run
-/// failure this guard exists for: with no config file anywhere,
-/// `database.path` is the bare relative `lific.db`, so an unguarded command
-/// creates and migrates a fresh empty instance in whatever directory it
-/// happened to run from.
-///
-/// The exemption list is the interesting half, and it is deliberately
-/// exhaustive rather than a catch-all, so a command added later is guarded by
-/// default instead of by somebody remembering to:
-///
-/// - `Init` creates the database; `Restore` writes one into place.
-/// - `Doctor` must be able to *report* a missing database, not die on it.
-/// - `Login`/`Logout` are pure HTTP and never open a database.
-/// - `Connect` carries its own, more specific version of this guard.
-/// - `AgentsMd` only writes a markdown file.
-/// - `Completion` returns before config is even loaded.
-/// - `Mcp --remote` is a stdio proxy in front of a remote instance: it never
-///   opens a database, and the point of it is to run on a machine that has
-///   none. Plain `lific mcp` still serves from a local database and is guarded.
-/// - Of the service actions only `install` needs one, so that installing a
-///   unit whose `start` would immediately fail the guard is refused up front.
-///   `uninstall`/`stop`/`status`/`restart` must keep working on a host whose
-///   database is gone, which is exactly when you need to stop the service.
-/// - `start --init-if-missing` opts out on purpose (LIF-468): a container's
-///   first boot has no earlier moment to run `init` in. Plain `lific start`
-///   is guarded exactly as before, and the flag's own guards in
-///   [`first_boot::decide`] are stricter than this one.
-fn needs_existing_database(cmd: &Command) -> bool {
-    match cmd {
-        Command::Init { .. }
-        | Command::Restore { .. }
-        | Command::Doctor { .. }
-        | Command::Login { .. }
-        | Command::Logout { .. }
-        | Command::Connect { .. }
-        | Command::AgentsMd { .. }
-        | Command::Completion { .. } => false,
-        // `Mcp --instances` is the multi-instance stdio proxy. Like `--remote`
-        // every alias points at a server, so no local database is needed.
-        Command::Mcp {
-            remote, instances, ..
-        } => !remote && instances.is_none(),
-        Command::Start {
-            init_if_missing, ..
-        } => !init_if_missing,
-        Command::Service { action } => matches!(action, cli::ServiceAction::Install),
-        _ => true,
-    }
-}
-
 /// The three operations the in-place rewrite needs from an open config file.
 /// A trait rather than `File` directly so a test can fail the write and prove
 /// the rollback puts the original bytes back.
@@ -400,6 +320,7 @@ fn parse_cli() -> (Cli, clap::ArgMatches) {
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let (cli, matches) = parse_cli();
+    let plan = cli::runtime::plan(&cli.command);
 
     // Rust ignores SIGPIPE process-wide, which makes println!/stdout writes
     // PANIC when piped into a closed reader (`lific completion fish | head`,
@@ -409,7 +330,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // ignored — tokio socket writes rely on that to surface EPIPE as errors
     // instead of killing the process.
     #[cfg(unix)]
-    if !matches!(cli.command, Command::Start { .. } | Command::Mcp { .. }) {
+    if plan.restores_sigpipe() {
         // SAFETY: setting a signal disposition to SIG_DFL before any threads
         // depend on the ignored state; standard practice for CLI tools.
         unsafe {
@@ -419,7 +340,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Shell completions must work with no lific.toml present and touch no DB,
     // so handle them before loading config or opening the database.
-    if let Command::Completion { shell } = cli.command {
+    if plan.is_completion()
+        && let Command::Completion { shell } = cli.command
+    {
         clap_complete::generate(shell, &mut Cli::command(), "lific", &mut std::io::stdout());
         return Ok(());
     }
@@ -428,7 +351,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // error; doctor receives the same typed result and reports the failure
     // while continuing independent diagnostics.
     let resolution = Config::resolve(cli.config.as_deref());
-    if let Command::Doctor { key, repair } = &cli.command {
+    if plan.is_doctor()
+        && let Command::Doctor { key, repair } = &cli.command
+    {
         let json = cli::term::wants_json(cli.json);
         cli::doctor::run(resolution, cli.db.as_deref(), key.as_deref(), *repair, json)
             .await
@@ -463,7 +388,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if cli.backend == BackendKind::Http {
-        if !is_crud_command(&cli.command) {
+        if !plan.supports_http() {
             return Err(
                 "the HTTP backend currently supports data commands: issue, project, page, export, search, comment, module, label, folder, bind, and git-hook"
                     .into(),
@@ -486,12 +411,12 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Only `lific init` creates a database. Checked once, here, after the HTTP
     // backend has had its chance to return (an HTTP command talks to a server
     // and must never need a local database at all).
-    if needs_existing_database(&cli.command) {
+    if plan.requires_existing_database() {
         cfg.require_existing_database()?;
     }
 
     // Handle CRUD commands (direct database access, no server needed)
-    if is_crud_command(&cli.command) {
+    if plan.is_data() {
         // LIF-155: CLI mutations run outside any request task — audit
         // them via the process-default transport.
         actor::set_default_transport(actor::Transport::Cli);
@@ -847,11 +772,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Logs on stderr only: a stray stdout line corrupts the session.
-            tracing_subscriber::fmt()
-                .with_env_filter(crate::cli::term::logging_filter(&cfg.log.level)?)
-                .with_ansi(false)
-                .with_writer(crate::cli::term::sanitized_stderr())
-                .init();
+            cli::term::init_logging(&cfg.log.level)?;
 
             return cli::mcp_instances::run(&instances).await;
         }
@@ -866,11 +787,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             // so a remote deployment gets a local presence in an AI client.
             // Logs must stay on stderr: a stray stdout line corrupts the
             // stdio session.
-            tracing_subscriber::fmt()
-                .with_env_filter(crate::cli::term::logging_filter(&cfg.log.level)?)
-                .with_ansi(false)
-                .with_writer(crate::cli::term::sanitized_stderr())
-                .init();
+            cli::term::init_logging(&cfg.log.level)?;
 
             let url = mcp_url
                 .or(cli.url)
@@ -892,11 +809,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             url: _,
             instances: None,
         } => {
-            tracing_subscriber::fmt()
-                .with_env_filter(crate::cli::term::logging_filter(&cfg.log.level)?)
-                .with_ansi(false)
-                .with_writer(crate::cli::term::sanitized_stderr())
-                .init();
+            cli::term::init_logging(&cfg.log.level)?;
 
             let pool = db::open(&cfg.database.path)?;
             info!(path = %cfg.database.path.display(), "database ready");

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,15 +332,30 @@ use tracing::info;
 #[tokio::main]
 async fn main() {
     if let Err(error) = run().await {
-        eprintln!("{}", error.to_string().terminal_line());
+        let _ = std::io::stderr().write_all(error_report(error.as_ref()).as_bytes());
         std::process::exit(1);
     }
+}
+
+fn error_report(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut report = String::new();
+    let mut current = Some(error);
+    for index in 0..8 {
+        let Some(error) = current else { break };
+        if index != 0 {
+            report.push_str("\ncaused by: ");
+        }
+        report.push_str(&error.to_string().terminal_line().to_string());
+        current = error.source();
+    }
+    report.push('\n');
+    report
 }
 
 fn cli_error_message(error: &clap::Error) -> String {
     match error.kind() {
         clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
-            error.to_string().terminal_block().to_string()
+            safe_clap_help(error)
         }
         _ => format!(
             "{}\n{}\n",
@@ -348,6 +363,19 @@ fn cli_error_message(error: &clap::Error) -> String {
             Cli::command().render_usage().terminal_block()
         ),
     }
+}
+
+/// Keep Clap's intentional help layout while removing controls from the
+/// process-derived program name. Clap renders that name directly into help,
+/// including for successful `--help`/`--version` requests.
+fn safe_clap_help(error: &clap::Error) -> String {
+    let mut rendered = error.to_string();
+    if let Some(program) = std::env::args_os().next() {
+        let program = program.to_string_lossy().into_owned();
+        let safe_program = program.clone().terminal_line().to_string();
+        rendered = rendered.replace(&program, &safe_program);
+    }
+    rendered.terminal_block().to_string()
 }
 
 fn exit_cli_error(error: clap::Error) -> ! {
@@ -820,10 +848,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
             // Logs on stderr only: a stray stdout line corrupts the session.
             tracing_subscriber::fmt()
-                .with_env_filter(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
-                )
+                .with_env_filter(crate::cli::term::logging_filter(&cfg.log.level)?)
                 .with_ansi(false)
                 .with_writer(crate::cli::term::sanitized_stderr())
                 .init();
@@ -842,10 +867,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             // Logs must stay on stderr: a stray stdout line corrupts the
             // stdio session.
             tracing_subscriber::fmt()
-                .with_env_filter(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
-                )
+                .with_env_filter(crate::cli::term::logging_filter(&cfg.log.level)?)
                 .with_ansi(false)
                 .with_writer(crate::cli::term::sanitized_stderr())
                 .init();
@@ -871,10 +893,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             instances: None,
         } => {
             tracing_subscriber::fmt()
-                .with_env_filter(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
-                )
+                .with_env_filter(crate::cli::term::logging_filter(&cfg.log.level)?)
                 .with_ansi(false)
                 .with_writer(crate::cli::term::sanitized_stderr())
                 .init();
@@ -2330,6 +2349,42 @@ mod write_private_config_tests {
 mod cli_error_tests {
     use super::{Cli, cli_error_message};
     use clap::Parser;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct InnerError;
+
+    impl fmt::Display for InnerError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(formatter, "root cause\nFORGED\x1b[2J\u{202e}")
+        }
+    }
+
+    impl std::error::Error for InnerError {}
+
+    #[derive(Debug)]
+    struct OuterError(InnerError);
+
+    impl fmt::Display for OuterError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("outer context")
+        }
+    }
+
+    impl std::error::Error for OuterError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    #[test]
+    fn error_report_preserves_safe_context_and_root_cause() {
+        let rendered = super::error_report(&OuterError(InnerError));
+        assert!(rendered.contains("outer context"));
+        assert!(rendered.contains("caused by: root cause FORGED^[[2J"));
+        assert!(!rendered.contains('\u{202e}'));
+        assert!(rendered.chars().all(|ch| !ch.is_control() || ch == '\n'));
+    }
 
     #[test]
     fn parse_errors_sanitize_untrusted_argument_text() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,6 +326,7 @@ fn create_private_config(path: &std::path::Path, contents: &str) -> std::io::Res
 }
 
 use rmcp::ServiceExt;
+use std::io::Write;
 use tracing::info;
 
 #[tokio::main]
@@ -337,16 +338,26 @@ async fn main() {
 }
 
 fn cli_error_message(error: &clap::Error) -> String {
-    error.to_string().terminal_block().to_string()
+    match error.kind() {
+        clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
+            error.to_string().terminal_block().to_string()
+        }
+        _ => format!(
+            "{}\n{}\n",
+            error.to_string().terminal_line(),
+            Cli::command().render_usage().terminal_block()
+        ),
+    }
 }
 
 fn exit_cli_error(error: clap::Error) -> ! {
     let message = cli_error_message(&error);
-    if error.use_stderr() {
-        eprint!("{message}");
+    let result = if error.use_stderr() {
+        std::io::stderr().write_all(message.as_bytes())
     } else {
-        print!("{message}");
-    }
+        std::io::stdout().write_all(message.as_bytes())
+    };
+    let _ = result;
     std::process::exit(error.exit_code());
 }
 
@@ -354,15 +365,7 @@ fn parse_cli() -> (Cli, clap::ArgMatches) {
     let args = std::env::args_os().collect::<Vec<_>>();
     let matches = Cli::command()
         .try_get_matches_from(&args)
-        .unwrap_or_else(|error| {
-            let rendered = Cli::command()
-                .try_get_matches_from(args.iter().map(|arg| {
-                    std::ffi::OsString::from(arg.to_string_lossy().terminal_line().to_string())
-                }))
-                .err()
-                .unwrap_or(error);
-            exit_cli_error(rendered)
-        });
+        .unwrap_or_else(|error| exit_cli_error(error));
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|error| exit_cli_error(error));
     (cli, matches)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,12 +337,7 @@ async fn main() {
 }
 
 fn cli_error_message(error: &clap::Error) -> String {
-    match error.kind() {
-        clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
-            error.to_string()
-        }
-        _ => cli::ui::sanitize_terminal_line(&error.to_string()),
-    }
+    error.to_string().terminal_block().to_string()
 }
 
 fn exit_cli_error(error: clap::Error) -> ! {
@@ -356,9 +351,18 @@ fn exit_cli_error(error: clap::Error) -> ! {
 }
 
 fn parse_cli() -> (Cli, clap::ArgMatches) {
+    let args = std::env::args_os().collect::<Vec<_>>();
     let matches = Cli::command()
-        .try_get_matches()
-        .unwrap_or_else(|error| exit_cli_error(error));
+        .try_get_matches_from(&args)
+        .unwrap_or_else(|error| {
+            let rendered = Cli::command()
+                .try_get_matches_from(args.iter().map(|arg| {
+                    std::ffi::OsString::from(arg.to_string_lossy().terminal_line().to_string())
+                }))
+                .err()
+                .unwrap_or(error);
+            exit_cli_error(rendered)
+        });
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|error| exit_cli_error(error));
     (cli, matches)
 }
@@ -2333,6 +2337,13 @@ mod cli_error_tests {
         let rendered = cli_error_message(&error);
 
         assert!(!rendered.contains('\u{202e}'));
-        assert!(!rendered.chars().any(char::is_control));
+        assert!(
+            rendered.chars().all(|ch| !ch.is_control() || ch == '\n'),
+            "only line breaks remain as controls: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("\nUsage:"),
+            "usage remains multiline: {rendered:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod storage;
 mod test_env;
 
 use clap::{CommandFactory, FromArgMatches};
+use cli::ui::TerminalDisplay;
 use cli::{BackendKind, Cli, Command, ServiceAction};
 use config::Config;
 
@@ -328,15 +329,40 @@ use rmcp::ServiceExt;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Via `ArgMatches` rather than `Cli::parse()` so a value's source stays
-    // answerable: `lific mcp --instances` rejects a typed `--url` but ignores
-    // an exported `LIFIC_URL`. Behaviour is otherwise identical.
-    let matches = Cli::command().get_matches();
-    let cli = match Cli::from_arg_matches(&matches) {
-        Ok(cli) => cli,
-        Err(error) => error.exit(),
-    };
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("{}", error.to_string().terminal_line());
+        std::process::exit(1);
+    }
+}
+
+fn cli_error_message(error: &clap::Error) -> String {
+    match error.kind() {
+        clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
+            error.to_string()
+        }
+        _ => cli::ui::sanitize_terminal_line(&error.to_string()),
+    }
+}
+
+fn exit_cli_error(error: clap::Error) -> ! {
+    let message = cli_error_message(&error);
+    if error.use_stderr() {
+        eprint!("{message}");
+    } else {
+        print!("{message}");
+    }
+    std::process::exit(error.exit_code());
+}
+
+fn parse_cli() -> Cli {
+    let matches = Cli::command()
+        .try_get_matches()
+        .unwrap_or_else(exit_cli_error);
+    Cli::from_arg_matches(&matches).unwrap_or_else(exit_cli_error)
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Rust ignores SIGPIPE process-wide, which makes println!/stdout writes
     // PANIC when piped into a closed reader (`lific completion fish | head`,
@@ -507,7 +533,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "attachment_count": m.attachment_count,
                     "attachment_bytes": m.attachment_bytes,
                 });
-                println!("{}", serde_json::to_string_pretty(&out_json)?);
+                println!("{}", cli::term::json_string(&out_json)?);
             } else {
                 use cli::ui;
                 ui::step(format!(
@@ -534,11 +560,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let json = cli::term::wants_json(cli.json);
             // Best-effort warning: a hot WAL suggests the server is still up.
             if dump::server_maybe_running(&cfg.database.path) {
-                eprintln!(
+                cli::ui::stderr_line(format_args!(
                     "warning: a hot -wal file is present next to {} — is the server still \
                      running? Stop it before restoring.",
                     cfg.database.path.display()
-                );
+                ));
             }
             let options = dump::RestoreOptions::new(force, allow_large);
             let result = dump::run_restore_with(&archive, &cfg.database.path, &options)
@@ -556,7 +582,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .as_ref()
                         .map(|p| p.display().to_string()),
                 });
-                println!("{}", serde_json::to_string_pretty(&out_json)?);
+                println!("{}", cli::term::json_string(&out_json)?);
             } else {
                 use cli::ui;
                 ui::intro("lific restore");
@@ -739,9 +765,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "path": target.display().to_string(),
                     "action": action.as_str(),
                 });
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                println!("{}", cli::term::json_string(&out)?);
             } else {
-                println!("AGENTS.md {}: {}", action.as_str(), target.display());
+                cli::ui::line(format!(
+                    "AGENTS.md {}: {}",
+                    action.as_str(),
+                    target.display()
+                ));
             }
             return Ok(());
         }
@@ -834,7 +864,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     tracing_subscriber::EnvFilter::try_from_default_env()
                         .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
                 )
-                .with_writer(std::io::stderr)
+                .with_writer(crate::cli::term::sanitized_stderr())
                 .init();
 
             let pool = db::open(&cfg.database.path)?;
@@ -1429,7 +1459,7 @@ async fn cmd_init(
                 "error": service_error,
             },
         });
-        println!("{}", serde_json::to_string_pretty(&out)?);
+        println!("{}", cli::term::json_string(&out)?);
         return Ok(());
     }
 
@@ -1551,7 +1581,7 @@ fn cmd_service(
             let plan = cli::service::ServicePlan::for_config_file(config_path)?;
             let report = cli::service::install(mgr, &plan)?;
             if json {
-                println!("{}", serde_json::to_string_pretty(&report)?);
+                println!("{}", cli::term::json_string(&report)?);
             } else {
                 ui::intro("lific service install");
                 ui::step(format!(
@@ -1576,7 +1606,10 @@ fn cmd_service(
             if json {
                 println!(
                     "{}",
-                    serde_json::json!({ "uninstalled": true, "definition": removed })
+                    cli::term::json_string(&serde_json::json!({
+                        "uninstalled": true,
+                        "definition": removed,
+                    }))?
                 );
             } else {
                 ui::intro("lific service uninstall");
@@ -1593,7 +1626,7 @@ fn cmd_service(
         ServiceAction::Status => {
             let s = cli::service::status(mgr)?;
             if json {
-                println!("{}", serde_json::to_string_pretty(&s)?);
+                println!("{}", cli::term::json_string(&s)?);
             } else if s.active {
                 ui::step(format!(
                     "Service is running ({}) — {}",
@@ -1619,7 +1652,10 @@ fn cmd_service(
         ServiceAction::Stop => {
             cli::service::stop(mgr)?;
             if json {
-                println!("{}", serde_json::json!({ "stopped": true }));
+                println!(
+                    "{}",
+                    cli::term::json_string(&serde_json::json!({ "stopped": true }))?
+                );
             } else {
                 ui::step(format!(
                     "Service stopped {}",
@@ -1630,7 +1666,10 @@ fn cmd_service(
         ServiceAction::Restart => {
             cli::service::restart(mgr)?;
             if json {
-                println!("{}", serde_json::json!({ "restarted": true }));
+                println!(
+                    "{}",
+                    cli::term::json_string(&serde_json::json!({ "restarted": true }))?
+                );
             } else {
                 ui::step(format!(
                     "Service restarted — {}",
@@ -2272,5 +2311,23 @@ mod write_private_config_tests {
             fs::metadata(&config).expect("stat").permissions().mode() & 0o777,
             0o600
         );
+    }
+}
+
+#[cfg(test)]
+mod cli_error_tests {
+    use super::{Cli, cli_error_message};
+    use clap::Parser;
+
+    #[test]
+    fn parse_errors_sanitize_untrusted_argument_text() {
+        let error = match Cli::try_parse_from(["lific", "\u{202e}"]) {
+            Ok(_) => panic!("invalid subcommand unexpectedly parsed"),
+            Err(error) => error,
+        };
+        let rendered = cli_error_message(&error);
+
+        assert!(!rendered.contains('\u{202e}'));
+        assert!(!rendered.chars().any(char::is_control));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,14 +355,16 @@ fn exit_cli_error(error: clap::Error) -> ! {
     std::process::exit(error.exit_code());
 }
 
-fn parse_cli() -> Cli {
+fn parse_cli() -> (Cli, clap::ArgMatches) {
     let matches = Cli::command()
         .try_get_matches()
-        .unwrap_or_else(exit_cli_error);
-    Cli::from_arg_matches(&matches).unwrap_or_else(exit_cli_error)
+        .unwrap_or_else(|error| exit_cli_error(error));
+    let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|error| exit_cli_error(error));
+    (cli, matches)
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let (cli, matches) = parse_cli();
 
     // Rust ignores SIGPIPE process-wide, which makes println!/stdout writes
     // PANIC when piped into a closed reader (`lific completion fish | head`,
@@ -488,7 +490,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     project_archive::import(&pool, &store, &archive, &user)?
                 }
             };
-            println!("{}", serde_json::to_string_pretty(&result)?);
+            println!("{}", cli::term::json_string(&result)?);
             return Ok(());
         }
         Command::Init {
@@ -815,7 +817,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     tracing_subscriber::EnvFilter::try_from_default_env()
                         .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
                 )
-                .with_writer(std::io::stderr)
+                .with_ansi(false)
+                .with_writer(crate::cli::term::sanitized_stderr())
                 .init();
 
             return cli::mcp_instances::run(&instances).await;
@@ -836,7 +839,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     tracing_subscriber::EnvFilter::try_from_default_env()
                         .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
                 )
-                .with_writer(std::io::stderr)
+                .with_ansi(false)
+                .with_writer(crate::cli::term::sanitized_stderr())
                 .init();
 
             let url = mcp_url
@@ -864,6 +868,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     tracing_subscriber::EnvFilter::try_from_default_env()
                         .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
                 )
+                .with_ansi(false)
                 .with_writer(crate::cli::term::sanitized_stderr())
                 .init();
 
@@ -1288,7 +1293,7 @@ async fn cmd_init(
             resolved.config.database.path.display()
         );
         if json {
-            eprintln!("warning: {msg}");
+            ui::stderr_line(format_args!("warning: {msg}"));
         } else {
             ui::warn(msg);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,29 +273,45 @@ fn error_report(error: &(dyn std::error::Error + 'static)) -> String {
 }
 
 fn cli_error_message(error: &clap::Error) -> String {
-    match error.kind() {
-        clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
-            safe_clap_help(error)
+    let mut rendered = error.to_string();
+    for (_, value) in error.context() {
+        sanitize_clap_context(&mut rendered, value);
+    }
+    rendered.terminal_block().to_string()
+}
+
+fn sanitize_clap_context(rendered: &mut String, value: &clap::error::ContextValue) {
+    match value {
+        clap::error::ContextValue::String(value) => replace_clap_context(rendered, value),
+        clap::error::ContextValue::Strings(values) => {
+            for value in values {
+                replace_clap_context(rendered, value);
+            }
         }
-        _ => format!(
-            "{}\n{}\n",
-            error.to_string().terminal_line(),
-            Cli::command().render_usage().terminal_block()
-        ),
+        clap::error::ContextValue::None
+        | clap::error::ContextValue::Bool(_)
+        | clap::error::ContextValue::StyledStr(_)
+        | clap::error::ContextValue::StyledStrs(_)
+        | clap::error::ContextValue::Number(_) => {}
+        _ => {}
     }
 }
 
-/// Keep Clap's intentional help layout while removing controls from the
-/// process-derived program name. Clap renders that name directly into help,
-/// including for successful `--help`/`--version` requests.
-fn safe_clap_help(error: &clap::Error) -> String {
-    let mut rendered = error.to_string();
-    if let Some(program) = std::env::args_os().next() {
-        let program = program.to_string_lossy().into_owned();
-        let safe_program = program.clone().terminal_line().to_string();
-        rendered = rendered.replace(&program, &safe_program);
+fn replace_clap_context(rendered: &mut String, value: &str) {
+    if value.is_empty() {
+        return;
     }
-    rendered.terminal_block().to_string()
+    let safe = value.terminal_line().to_string();
+    if safe != value {
+        *rendered = rendered.replace(value, &safe);
+    }
+}
+
+/// Keep Clap's displayed program name independent from the process-provided
+/// `argv[0]`. The real argument remains untouched, while all generated help
+/// and diagnostics use this trusted name.
+fn cli_command() -> clap::Command {
+    Cli::command().name("lific").bin_name("lific")
 }
 
 fn exit_cli_error(error: clap::Error) -> ! {
@@ -311,7 +327,7 @@ fn exit_cli_error(error: clap::Error) -> ! {
 
 fn parse_cli() -> (Cli, clap::ArgMatches) {
     let args = std::env::args_os().collect::<Vec<_>>();
-    let matches = Cli::command()
+    let matches = cli_command()
         .try_get_matches_from(&args)
         .unwrap_or_else(|error| exit_cli_error(error));
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|error| exit_cli_error(error));
@@ -343,7 +359,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     if plan.is_completion()
         && let Command::Completion { shell } = cli.command
     {
-        clap_complete::generate(shell, &mut Cli::command(), "lific", &mut std::io::stdout());
+        clap_complete::generate(shell, &mut cli_command(), "lific", &mut std::io::stdout());
         return Ok(());
     }
 

--- a/src/project_archive/tests.rs
+++ b/src/project_archive/tests.rs
@@ -440,8 +440,9 @@ fn project_archive_cli_uses_local_operator_dispatch_and_requires_an_existing_dat
         ],
     ] {
         let parsed = Cli::try_parse_from(args).unwrap();
-        assert!(!crate::is_crud_command(&parsed.command));
-        assert!(crate::needs_existing_database(&parsed.command));
+        let plan = crate::cli::runtime::plan(&parsed.command);
+        assert!(!plan.is_data());
+        assert!(plan.requires_existing_database());
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -478,6 +478,7 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
         )
+        .with_ansi(false)
         .with_writer(crate::cli::term::sanitized_stderr())
         .init();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -478,6 +478,7 @@ pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
         )
+        .with_writer(crate::cli::term::sanitized_stderr())
         .init();
 
     // Parse trusted proxy CIDRs once at startup. Invalid entries must

--- a/src/server.rs
+++ b/src/server.rs
@@ -473,11 +473,7 @@ pub(crate) fn build_app_with_store(
 /// `lific start`: bring up the HTTP server for `cfg` and serve until a
 /// shutdown signal arrives.
 pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(crate::cli::term::logging_filter(&cfg.log.level)?)
-        .with_ansi(false)
-        .with_writer(crate::cli::term::sanitized_stderr())
-        .init();
+    crate::cli::term::init_logging(&cfg.log.level)?;
 
     // Parse trusted proxy CIDRs once at startup. Invalid entries must
     // stop the server rather than quietly disabling the trust boundary

--- a/src/server.rs
+++ b/src/server.rs
@@ -474,10 +474,7 @@ pub(crate) fn build_app_with_store(
 /// shutdown signal arrives.
 pub async fn run(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("lific={}", cfg.log.level).into()),
-        )
+        .with_env_filter(crate::cli::term::logging_filter(&cfg.log.level)?)
         .with_ansi(false)
         .with_writer(crate::cli::term::sanitized_stderr())
         .init();

--- a/tests/terminal_output.rs
+++ b/tests/terminal_output.rs
@@ -1,0 +1,84 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn cli(directory: &Path, config: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_lific"));
+    command
+        .current_dir(directory)
+        .env_remove("LIFIC_URL")
+        .env_remove("LIFIC_TOKEN")
+        .env_remove("LIFIC_API_KEY")
+        .stdin(Stdio::null())
+        .arg("--config")
+        .arg(config);
+    command
+}
+
+#[test]
+fn init_database_warning_is_safe_in_explicit_and_automatic_json_modes() {
+    for explicit_json in [false, true] {
+        let scratch = tempfile::tempdir().unwrap();
+        let config = scratch.path().join("selected.toml");
+        let database = scratch.path().join("override\u{009b}2J\u{202e}.db");
+        std::fs::write(&config, "[database]\npath = \"configured.db\"\n").unwrap();
+
+        let mut command = cli(scratch.path(), &config);
+        command.arg("--db").arg(&database).args([
+            "init",
+            "--no-service",
+            "--name",
+            "operator",
+            "--auth-mode",
+            "login-free",
+        ]);
+        if explicit_json {
+            command.arg("--json");
+        }
+        let output = command.output().unwrap();
+        assert!(output.status.success(), "{output:?}");
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains("warning: --db points at"), "{stderr:?}");
+        assert!(
+            stderr
+                .chars()
+                .all(|ch| (!ch.is_control() || ch == '\n') && ch != '\u{202e}'),
+            "{stderr:?}"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(json.is_object());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(!stdout.contains(['\u{009b}', '\u{202e}']), "{stdout:?}");
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn service_status_does_not_leak_subprocess_streams_into_json_or_stderr() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let scratch = tempfile::tempdir().unwrap();
+    let config = scratch.path().join("selected.toml");
+    std::fs::write(&config, "").unwrap();
+    let systemctl = scratch.path().join("systemctl");
+    std::fs::write(
+        &systemctl,
+        "#!/bin/sh\nprintf '\\033]52;c;YQ==\\007'\nprintf '\\033[2J' >&2\nexit 0\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    for explicit_json in [false, true] {
+        let mut command = cli(scratch.path(), &config);
+        command
+            .env("PATH", scratch.path())
+            .args(["service", "status"]);
+        if explicit_json {
+            command.arg("--json");
+        }
+        let output = command.output().unwrap();
+        assert_eq!(output.status.code(), Some(1), "{output:?}");
+        assert!(output.stderr.is_empty(), "{output:?}");
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(json["active"], true);
+    }
+}

--- a/tests/terminal_output.rs
+++ b/tests/terminal_output.rs
@@ -51,6 +51,43 @@ fn init_database_warning_is_safe_in_explicit_and_automatic_json_modes() {
     }
 }
 
+#[test]
+fn clap_output_cannot_render_terminal_controls_from_arguments_or_environment() {
+    let binary = env!("CARGO_BIN_EXE_lific");
+    let output = Command::new(binary)
+        .arg("bad\nSUCCESS: forged\u{202e}")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!stderr.contains("\nSUCCESS: forged"), "{stderr:?}");
+    assert!(!stderr.contains('\u{202e}'), "{stderr:?}");
+
+    let output = Command::new(binary)
+        .env("LIFIC_URL", "https://host/\u{202e}forged")
+        .arg("--help")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.contains('\u{202e}'), "{stdout:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn clap_help_cannot_render_a_terminal_control_in_the_program_name() {
+    use std::os::unix::process::CommandExt;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_lific"))
+        .arg0("lific\u{202e}forged")
+        .arg("--help")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.contains('\u{202e}'), "{stdout:?}");
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn service_status_does_not_leak_subprocess_streams_into_json_or_stderr() {
@@ -71,6 +108,7 @@ fn service_status_does_not_leak_subprocess_streams_into_json_or_stderr() {
         let mut command = cli(scratch.path(), &config);
         command
             .env("PATH", scratch.path())
+            .env("HOME", scratch.path())
             .args(["service", "status"]);
         if explicit_json {
             command.arg("--json");

--- a/tests/terminal_output.rs
+++ b/tests/terminal_output.rs
@@ -71,6 +71,105 @@ fn clap_output_cannot_render_terminal_controls_from_arguments_or_environment() {
     assert!(output.status.success(), "{output:?}");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(!stdout.contains('\u{202e}'), "{stdout:?}");
+
+    let output = Command::new(binary).arg("--version").output().unwrap();
+    assert!(output.status.success(), "{output:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn clap_parse_failure_uses_original_arguments_without_forged_lines() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+    use std::os::unix::process::CommandExt;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_lific"))
+        .arg0("lific\nFORGED STATUS")
+        .args([
+            OsString::from("--url"),
+            OsString::from_vec(vec![0xff]),
+            OsString::from("project"),
+            OsString::from("list"),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("\nFORGED STATUS"), "{stderr:?}");
+    assert!(!stderr.contains("FORGED STATUS\n"), "{stderr:?}");
+}
+
+#[test]
+fn import_help_hides_environment_values() {
+    let binary = env!("CARGO_BIN_EXE_lific");
+    let cases = vec![
+        (
+            "github",
+            vec![("GITHUB_TOKEN", "github-secret\u{1b}[2J")],
+            vec!["github-secret\u{1b}[2J", "FORGED JIRA STATUS"],
+        ),
+        (
+            "linear",
+            vec![("LINEAR_API_KEY", "linear-secret\u{202e}")],
+            vec!["linear-secret\u{202e}", "FORGED JIRA STATUS"],
+        ),
+        (
+            "jira",
+            vec![
+                ("JIRA_EMAIL", "jira@example.test\nFORGED JIRA STATUS"),
+                ("JIRA_API_TOKEN", "jira-token-secret"),
+            ],
+            vec![
+                "jira@example.test\nFORGED JIRA STATUS",
+                "jira-token-secret",
+                "FORGED JIRA STATUS",
+            ],
+        ),
+    ];
+
+    for (provider, variables, secrets) in cases {
+        let mut command = Command::new(binary);
+        for (variable, value) in variables {
+            command.env(variable, value);
+        }
+        let output = command
+            .args(["import", provider, "--help"])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{provider}: {output:?}");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for secret in secrets {
+            assert!(!stdout.contains(secret), "{provider}: {stdout:?}");
+        }
+        assert!(stdout.contains("Usage:"), "{provider}: {stdout:?}");
+        assert!(stdout.contains("--"), "{provider}: {stdout:?}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn clap_early_output_ignores_closed_pipes() {
+    use std::fs::File;
+    use std::os::fd::{FromRawFd, RawFd};
+
+    unsafe fn closed_reader_pipe() -> File {
+        let mut fds = [0 as RawFd; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        assert_eq!(unsafe { libc::close(fds[0]) }, 0);
+        unsafe { File::from_raw_fd(fds[1]) }
+    }
+
+    for (args, expected_code) in [(["--help"], 0), (["not-a-command"], 2)] {
+        let output_fd = unsafe { closed_reader_pipe() };
+        let output = Command::new(env!("CARGO_BIN_EXE_lific"))
+            .args(args)
+            .stdout(Stdio::from(output_fd.try_clone().unwrap()))
+            .stderr(Stdio::from(output_fd))
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(expected_code), "{output:?}");
+    }
 }
 
 #[cfg(unix)]

--- a/tests/terminal_output.rs
+++ b/tests/terminal_output.rs
@@ -72,6 +72,19 @@ fn clap_output_cannot_render_terminal_controls_from_arguments_or_environment() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(!stdout.contains('\u{202e}'), "{stdout:?}");
 
+    let output = Command::new(binary)
+        .env("LIFIC_URL", "https://host/secret\nFORGED URL")
+        .env("LIFIC_API_KEY", "api-secret\t\u{009b}2J\u{202e}")
+        .arg("--help")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("https://host/secret"), "{stdout:?}");
+    assert!(!stdout.contains("FORGED URL"), "{stdout:?}");
+    assert!(!stdout.contains("api-secret"), "{stdout:?}");
+    assert!(stdout.contains("Usage:"), "{stdout:?}");
+
     let output = Command::new(binary).arg("--version").output().unwrap();
     assert!(output.status.success(), "{output:?}");
 }
@@ -147,6 +160,37 @@ fn import_help_hides_environment_values() {
     }
 }
 
+#[test]
+fn invalid_log_filter_is_reported_safely_before_tracing_starts() {
+    let scratch = tempfile::tempdir().unwrap();
+    let config = scratch.path().join("lific.toml");
+    std::fs::write(
+        &config,
+        "[log]\nlevel = \"not-a-level\\u001B[2J\\nFORGED LOG STATUS\"\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_lific"))
+        .env_remove("RUST_LOG")
+        .args([
+            "--config",
+            config.to_str().unwrap(),
+            "mcp",
+            "--remote",
+            "--url",
+            "http://127.0.0.1:1",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains('\u{001b}'), "{stderr:?}");
+    assert!(!stderr.contains('\u{009b}'), "{stderr:?}");
+    assert!(!stderr.contains("\nFORGED LOG STATUS"), "{stderr:?}");
+    assert!(stderr.contains("not-a-level"), "{stderr:?}");
+}
+
 #[cfg(unix)]
 #[test]
 fn clap_early_output_ignores_closed_pipes() {
@@ -185,6 +229,22 @@ fn clap_help_cannot_render_a_terminal_control_in_the_program_name() {
     assert!(output.status.success(), "{output:?}");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(!stdout.contains('\u{202e}'), "{stdout:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn clap_help_preserves_layout_without_forged_program_name_lines() {
+    use std::os::unix::process::CommandExt;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_lific"))
+        .arg0("lific\nFORGED_DIAGNOSTIC")
+        .arg("--help")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.contains("\nFORGED_DIAGNOSTIC"), "{stdout:?}");
+    assert!(stdout.contains("\nUsage:"), "{stdout:?}");
 }
 
 #[cfg(target_os = "linux")]

--- a/tests/terminal_output.rs
+++ b/tests/terminal_output.rs
@@ -191,6 +191,44 @@ fn invalid_log_filter_is_reported_safely_before_tracing_starts() {
     assert!(stderr.contains("not-a-level"), "{stderr:?}");
 }
 
+#[test]
+fn valid_log_levels_and_rust_log_precedence_are_preserved() {
+    let scratch = tempfile::tempdir().unwrap();
+    let config = scratch.path().join("lific.toml");
+    let run = |level: &str, rust_log: Option<&str>| {
+        std::fs::write(&config, format!("[log]\nlevel = \"{level}\"\n")).unwrap();
+        let mut command = Command::new(env!("CARGO_BIN_EXE_lific"));
+        command.env_remove("RUST_LOG");
+        if let Some(rust_log) = rust_log {
+            command.env("RUST_LOG", rust_log);
+        }
+        command
+            .args([
+                "--config",
+                config.to_str().unwrap(),
+                "mcp",
+                "--remote",
+                "--url",
+                "http://127.0.0.1:1",
+            ])
+            .output()
+            .unwrap()
+    };
+
+    for level in ["OFF", "InFo"] {
+        let output = run(level, None);
+        assert!(
+            matches!(output.status.code(), Some(0 | 1)),
+            "{level}: {output:?}"
+        );
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("invalid configured log level"));
+    }
+
+    let output = run("not-a-level", Some("off"));
+    assert!(matches!(output.status.code(), Some(0 | 1)), "{output:?}");
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("invalid configured log level"));
+}
+
 #[cfg(unix)]
 #[test]
 fn clap_early_output_ignores_closed_pipes() {
@@ -221,14 +259,56 @@ fn clap_early_output_ignores_closed_pipes() {
 fn clap_help_cannot_render_a_terminal_control_in_the_program_name() {
     use std::os::unix::process::CommandExt;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_lific"))
-        .arg0("lific\u{202e}forged")
-        .arg("--help")
+    for argv0 in [
+        "lific\nFORGED_BARE",
+        "./lific\tFORGED_RELATIVE",
+        "/tmp/lific\u{1b}[2J\u{202e}FORGED_ABSOLUTE",
+    ] {
+        for args in [&["--help"][..], &["project", "--help"][..]] {
+            let output = Command::new(env!("CARGO_BIN_EXE_lific"))
+                .arg0(argv0)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "{argv0:?} {args:?}: {output:?}");
+            assert!(output.stderr.is_empty(), "{argv0:?} {args:?}: {output:?}");
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            assert!(stdout.contains("Usage: lific"), "{argv0:?}: {stdout:?}");
+            assert!(!stdout.contains("FORGED_"), "{argv0:?}: {stdout:?}");
+            assert!(!stdout.contains('\u{1b}'), "{argv0:?}: {stdout:?}");
+            assert!(!stdout.contains('\u{202e}'), "{argv0:?}: {stdout:?}");
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn clap_diagnostics_preserve_their_original_scope_and_layout() {
+    let nested = Command::new(env!("CARGO_BIN_EXE_lific"))
+        .arg("project")
         .output()
         .unwrap();
-    assert!(output.status.success(), "{output:?}");
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(!stdout.contains('\u{202e}'), "{stdout:?}");
+    assert_eq!(nested.status.code(), Some(2), "{nested:?}");
+    let nested_stderr = String::from_utf8(nested.stderr).unwrap();
+    assert!(
+        nested_stderr.contains("\n\nUsage: lific project [OPTIONS] <COMMAND>"),
+        "{nested_stderr:?}"
+    );
+    assert!(nested_stderr.contains("\n\nCommands:"), "{nested_stderr:?}");
+    assert!(!nested_stderr.contains("Usage: lific [OPTIONS] <COMMAND>"));
+
+    let implicit_help = Command::new(env!("CARGO_BIN_EXE_lific")).output().unwrap();
+    assert_eq!(implicit_help.status.code(), Some(2), "{implicit_help:?}");
+    assert!(implicit_help.stdout.is_empty(), "{implicit_help:?}");
+    let implicit_stderr = String::from_utf8(implicit_help.stderr).unwrap();
+    assert!(
+        implicit_stderr.contains("\n\nUsage: lific [OPTIONS] <COMMAND>"),
+        "{implicit_stderr:?}"
+    );
+    assert!(
+        implicit_stderr.contains("\n\nCommands:"),
+        "{implicit_stderr:?}"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Untrusted values from tracker records, configuration, subprocesses, remote responses, and parser diagnostics could alter terminal output. This change establishes one terminal-safe presentation boundary while preserving stored, HTTP, and MCP data semantics.

## Changes

- Sanitize human CLI lines and blocks, prompts, direct warnings, process errors, and `start`/`mcp` tracing.
- Serialize terminal-visible JSON with lossless escapes for C1 and Unicode formatting controls.
- Keep connect configuration files as ordinary JSON; only the manual snippet displayed to the operator uses the terminal encoder.
- Re-render rejected Clap invocations with terminal-safe arguments, hide dynamic `LIFIC_URL` help values, and retain help/error layout.
- Reject unsafe service paths before generating service configuration.

## Branch-added tests

- Property tests prove arbitrary Unicode line/block output contains no terminal-active characters and terminal JSON round-trips without literal controls in strings.
- Renderer, prompt, tracing, HTTP, and service tests exercise hostile persisted data, controls split across writes, subprocess output, and explicit/automatic JSON output.
- Process tests prove malformed arguments cannot forge a diagnostic line and hostile executable names or `LIFIC_URL` values cannot alter help output.